### PR TITLE
fix(APIMessage): Correct APIMessage#mentions type

### DIFF
--- a/v6/payloads/channel.ts
+++ b/v6/payloads/channel.ts
@@ -64,7 +64,7 @@ export interface APIMessage {
 	edited_timestamp: string | null;
 	tts: boolean;
 	mention_everyone: boolean;
-	mentions: APIUser & { member?: Omit<APIGuildMember, 'user'> };
+	mentions: (APIUser & { member?: Omit<APIGuildMember, 'user'> })[];
 	mention_roles: string[];
 	mention_channels?: APIChannelMention[];
 	attachments: APIAttachment[];


### PR DESCRIPTION
APIMessage#mentions is an array of users, not just the user by itself - this PR reflects updates the typings to reflect such state.