### PR TITLE
feat: add oauth2 types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,0 @@
-# Changelog
-
-This will be a list of changes that happen between versions
-
-## 0.1.0
-
-Initial release

--- a/README.md
+++ b/README.md
@@ -50,21 +50,21 @@ You can `require` / `import` the module directly, which will give you the latest
 > We **strongly recommend** you use a version when importing this module! This will prevent breaking changes when updating the module.
 
 ```js
-const { APIUserData } = require('discord-api-types');
+const { APIUser } = require('discord-api-types');
 ```
 
 ```ts
 // TypeScript/ES Module support
-import { APIUserData } from 'discord-api-types';
+import { APIUser } from 'discord-api-types';
 ```
 
 You should instead consider adding the API version you want to target by appending `/v*`, where the `*` represents the API version.
 
 ```js
-const { APIUserData } = require('discord-api-types/v6');
+const { APIUser } = require('discord-api-types/v6');
 ```
 
 ```ts
 // TypeScript/ES Module support
-import { APIUserData } from 'discord-api-types/v6';
+import { APIUser } from 'discord-api-types/v6';
 ```

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ The exports of each API version is split into three main parts:
 
     - For example, `RESTPostAPIChannelMessageJSONBody` or `RESTGetAPIGatewayBotInfoResult`.
 
+    - Some exported types (specifically OAuth2 related ones) may not respect this entire structure due to the nature of the fields. They will start with either `RESTOAuth2` or with something similar to `REST<HTTP Method>OAuth2`
+
   - If a type ends with `Result`, then it represents the expected result by calling its accompanying route.
 
     - Types that are exported as `never` usually mean the result will be a `204 No Content`, so you can safely ignore it. This does **not** account for errors.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-api-types",
-  "version": "0.3.0",
+  "version": "0.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-api-types",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Discord API typings that are kept up to date for use in bot library creation.",
   "main": "default/index.js",
   "scripts": {

--- a/v6/rest/oauth2.ts
+++ b/v6/rest/oauth2.ts
@@ -134,7 +134,7 @@ export interface RESTOAuth2AdvancedBotAuthorizationURIQueryResult {
 /**
  * https://discord.com/developers/docs/topics/oauth2#advanced-bot-authorization-extended-bot-authorization-access-token-example
  */
-export interface RESTPostOAuth2AccessTokenWithGuildsScopeResult {
+export interface RESTPostOAuth2AccessTokenWithBotAndGuildsScopeResult {
 	access_token: string;
 	token_type: string;
 	expires_in: number;
@@ -146,7 +146,7 @@ export interface RESTPostOAuth2AccessTokenWithGuildsScopeResult {
 /**
  * https://discord.com/developers/docs/topics/oauth2#webhooks-webhook-token-response-example
  */
-export interface RESTPostOAuth2AccessTokenWithWebhookIncomingScopeResult {
+export interface RESTPostOAuth2AccessTokenWithBotAndWebhookIncomingScopeResult {
 	access_token: string;
 	token_type: string;
 	expires_in: number;
@@ -155,5 +155,5 @@ export interface RESTPostOAuth2AccessTokenWithWebhookIncomingScopeResult {
 	webhook: APIWebhook;
 }
 
-export type RESTPostOAuth2AccessTokenWithGuildsAndWebhookIncomingScopeResult = RESTPostOAuth2AccessTokenWithGuildsScopeResult &
-	RESTPostOAuth2AccessTokenWithWebhookIncomingScopeResult;
+export type RESTPostOAuth2AccessTokenWithBotAndGuildsAndWebhookIncomingScopeResult = RESTPostOAuth2AccessTokenWithBotAndGuildsScopeResult &
+	RESTPostOAuth2AccessTokenWithBotAndWebhookIncomingScopeResult;

--- a/v6/rest/oauth2.ts
+++ b/v6/rest/oauth2.ts
@@ -60,7 +60,7 @@ export interface RESTPostOAuth2RefreshTokenURIEncodedData {
 	scope: string;
 }
 
-export type RESTPostOAuth2RefreshTokenURIResult = RESTPostOAuth2AccessTokenResult;
+export type RESTPostOAuth2RefreshTokenResult = RESTPostOAuth2AccessTokenResult;
 
 /**
  * https://discord.com/developers/docs/topics/oauth2#implicit-grant

--- a/v6/rest/oauth2.ts
+++ b/v6/rest/oauth2.ts
@@ -20,7 +20,7 @@ export interface RESTOAuth2AuthorizationQuery {
 /**
  * https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-redirect-url-example
  */
-export interface RESTOAuth2AuthorizationResult {
+export interface RESTOAuth2AuthorizationQueryResult {
 	code: string;
 	state?: string;
 }
@@ -124,7 +124,7 @@ export interface RESTOAuth2AdvancedBotAuthorizationQuery {
 	redirect_uri?: string;
 }
 
-export interface RESTOAuth2AdvancedBotAuthorizationURIQueryResult {
+export interface RESTOAuth2AdvancedBotAuthorizationQueryResult {
 	code: string;
 	state?: string;
 	guild_id: string;

--- a/v6/rest/oauth2.ts
+++ b/v6/rest/oauth2.ts
@@ -8,7 +8,7 @@ export type RESTGetAPIOauth2CurrentApplicationResult = APIApplication;
 /**
  * https://discord.com/developers/docs/topics/oauth2#authorization-code-grant
  */
-export interface RESTOAuth2AuthorizationURIEncodedData {
+export interface RESTOAuth2AuthorizationQuery {
 	response_type: 'code';
 	client_id: string;
 	scope: string;
@@ -20,7 +20,7 @@ export interface RESTOAuth2AuthorizationURIEncodedData {
 /**
  * https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-redirect-url-example
  */
-export interface RESTOAuth2AuthorizationURIQueryResult {
+export interface RESTOAuth2AuthorizationResult {
 	code: string;
 	state?: string;
 }
@@ -65,7 +65,7 @@ export type RESTPostOAuth2RefreshTokenResult = RESTPostOAuth2AccessTokenResult;
 /**
  * https://discord.com/developers/docs/topics/oauth2#implicit-grant
  */
-export interface RESTOAuth2ImplicitAuthorizationURIEncodedData {
+export interface RESTOAuth2ImplicitAuthorizationQuery {
 	response_type: 'token';
 	client_id: string;
 	scope: string;
@@ -94,7 +94,7 @@ export type RESTPostOAuth2ClientCredentialsResult = RESTOAuth2ImplicitAuthorizat
 /**
  * https://discord.com/developers/docs/topics/oauth2#bot-authorization-flow-bot-auth-parameters
  */
-export interface RESTOAuth2BotAuthorizationURIEncodedData {
+export interface RESTOAuth2BotAuthorizationQuery {
 	client_id: string;
 	scope: string;
 	/**
@@ -108,8 +108,11 @@ export interface RESTOAuth2BotAuthorizationURIEncodedData {
 /**
  * https://discord.com/developers/docs/topics/oauth2#advanced-bot-authorization
  */
-export interface RESTOAuth2AdvancedBotAuthorizationURIEncodedData {
+export interface RESTOAuth2AdvancedBotAuthorizationQuery {
 	client_id: string;
+	/**
+	 * This assumes you include the `bot` scope alongside others (like `identify` for example)
+	 */
 	scope: string;
 	/**
 	 * The required permissions bitfield, stringified

--- a/v6/rest/oauth2.ts
+++ b/v6/rest/oauth2.ts
@@ -1,6 +1,156 @@
-import type { APIApplication } from '../payloads';
+import type { APIApplication, APIGuild, APIWebhook } from '../payloads';
 
 /**
  * https://discord.com/developers/docs/topics/oauth2#get-current-application-information
  */
 export type RESTGetAPIOauth2CurrentApplicationResult = APIApplication;
+
+/**
+ * https://discord.com/developers/docs/topics/oauth2#authorization-code-grant
+ */
+export interface RESTOAuth2AuthorizationURIEncodedData {
+	response_type: 'code';
+	client_id: string;
+	scope: string;
+	redirect_uri?: string;
+	state?: string;
+	prompt?: 'consent' | 'none';
+}
+
+/**
+ * https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-redirect-url-example
+ */
+export interface RESTOAuth2AuthorizationURIQueryResult {
+	code: string;
+	state?: string;
+}
+
+/**
+ * https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-redirect-url-example
+ */
+export interface RESTPostOAuth2AccessTokenURIEncodedData {
+	client_id: string;
+	client_secret: string;
+	grant_type: 'authorization_code';
+	code: string;
+	redirect_uri?: string;
+	scope: string;
+}
+
+/**
+ * https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-access-token-response
+ */
+export interface RESTPostOAuth2AccessTokenResult {
+	access_token: string;
+	token_type: string;
+	expires_in: number;
+	refresh_token: string;
+	scope: string;
+}
+
+/**
+ * https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-refresh-token-exchange-example
+ */
+export interface RESTPostOAuth2RefreshTokenURIEncodedData {
+	client_id: string;
+	client_secret: string;
+	grant_type: 'refresh_token';
+	refresh_token: string;
+	redirect_uri?: string;
+	scope: string;
+}
+
+export type RESTPostOAuth2RefreshTokenURIResult = RESTPostOAuth2AccessTokenResult;
+
+/**
+ * https://discord.com/developers/docs/topics/oauth2#implicit-grant
+ */
+export interface RESTOAuth2ImplicitAuthorizationURIEncodedData {
+	response_type: 'token';
+	client_id: string;
+	scope: string;
+	redirect_uri?: string;
+	state?: string;
+	prompt?: 'consent' | 'none';
+}
+
+/**
+ * https://discord.com/developers/docs/topics/oauth2#implicit-grant-redirect-url-example
+ */
+export type RESTOAuth2ImplicitAuthorizationURIFragmentResult = Omit<RESTPostOAuth2AccessTokenResult, 'refresh_token'>;
+
+/**
+ * https://discord.com/developers/docs/topics/oauth2#client-credentials-grant
+ */
+export interface RESTPostOAuth2ClientCredentialsURIEncodedData {
+	client_id: string;
+	client_secret: string;
+	grant_type: 'client_credentials';
+	scope: string;
+}
+
+export type RESTPostOAuth2ClientCredentialsResult = RESTOAuth2ImplicitAuthorizationURIFragmentResult;
+
+/**
+ * https://discord.com/developers/docs/topics/oauth2#bot-authorization-flow-bot-auth-parameters
+ */
+export interface RESTOAuth2BotAuthorizationURIEncodedData {
+	client_id: string;
+	scope: string;
+	/**
+	 * The required permissions bitfield, stringified
+	 */
+	permissions?: string;
+	guild_id?: string;
+	disable_guild_select?: boolean;
+}
+
+/**
+ * https://discord.com/developers/docs/topics/oauth2#advanced-bot-authorization
+ */
+export interface RESTOAuth2AdvancedBotAuthorizationURIEncodedData {
+	client_id: string;
+	scope: string;
+	/**
+	 * The required permissions bitfield, stringified
+	 */
+	permissions?: string;
+	guild_id?: string;
+	disable_guild_select?: boolean;
+	response_type: string;
+	redirect_uri?: string;
+}
+
+export interface RESTOAuth2AdvancedBotAuthorizationURIQueryResult {
+	code: string;
+	state?: string;
+	guild_id: string;
+	permissions: string;
+}
+
+/**
+ * https://discord.com/developers/docs/topics/oauth2#advanced-bot-authorization-extended-bot-authorization-access-token-example
+ */
+export interface RESTPostOAuth2AccessTokenWithGuildsScopeResult {
+	access_token: string;
+	token_type: string;
+	expires_in: number;
+	refresh_token: string;
+	scope: string;
+	guild: APIGuild;
+}
+
+/**
+ * https://discord.com/developers/docs/topics/oauth2#webhooks-webhook-token-response-example
+ */
+export interface RESTPostOAuth2AccessTokenWithWebhookIncomingScopeResult {
+	access_token: string;
+	token_type: string;
+	expires_in: number;
+	refresh_token: string;
+	scope: string;
+	webhook: APIWebhook;
+}
+
+export type RESTPostOAuth2AccessTokenWithGuildsAndWebhookIncomingScopeResult = RESTPostOAuth2AccessTokenWithGuildsScopeResult &
+	RESTPostOAuth2AccessTokenWithWebhookIncomingScopeResult;


### PR DESCRIPTION
You thought this module had long named exports? You didn't know what you signed up for! Introducing... `RESTPostOAuth2AccessTokenWithBotAndGuildsAndWebhookIncomingScopeResult`! And others, mind you...