### PR TITLE
fix(GatewayIdentifyProperties): rename `device` to `$device`

### DIFF
--- a/v6/gateway/index.ts
+++ b/v6/gateway/index.ts
@@ -590,7 +590,7 @@ export interface GatewayHeartbeat {
 export interface GatewayIdentifyProperties {
 	$os: string;
 	$browser: string;
-	device: string;
+	$device: string;
 }
 
 /**


### PR DESCRIPTION
ref: https://discord.com/developers/docs/topics/gateway#identify-identify-connection-properties

the `device` in `GatewayIdentifyProperties` should be `$device` not `device`