### PR TITLE
fix(APIUser): premium_type is optional

### DIFF
--- a/v6/payloads/user.ts
+++ b/v6/payloads/user.ts
@@ -19,7 +19,7 @@ export interface APIUser {
 	verified?: boolean;
 	email?: string | null;
 	flags?: UserFlags;
-	premium_type: UserPremiumType;
+	premium_type?: UserPremiumType;
 	public_flags?: UserFlags;
 }
 


### PR DESCRIPTION
ref: https://discord.com/developers/docs/resources/user#user-object

premium_type is optional