### PR TITLE
fix(APIChannel): position is optional

### DIFF
--- a/v6/payloads/channel.ts
+++ b/v6/payloads/channel.ts
@@ -20,7 +20,7 @@ export interface APIPartialChannel {
  */
 export interface APIChannel extends APIPartialChannel {
 	guild_id?: string;
-	position: number;
+	position?: number;
 	permission_overwrites?: APIOverwrite[];
 	name?: string;
 	topic?: string | null;


### PR DESCRIPTION
docs ref: https://discord.com/developers/docs/resources/channel#channel-object

position is only present on guild channels