### PR TITLE
fix(RESTPostAPIGuildsJSONBody): use correct types

### DIFF
--- a/v6/rest/guild.ts
+++ b/v6/rest/guild.ts
@@ -7,6 +7,7 @@ import type {
 	APIGuildPreview,
 	APIGuildWidget,
 	APIInvite,
+	APIOverwrite,
 	APIRole,
 	APIVoiceRegion,
 	GuildDefaultMessageNotifications,
@@ -17,33 +18,22 @@ import type {
 	IntegrationExpireBehavior,
 } from '../payloads';
 
-export type APIGuildCreateOverwrite = Pick<
-	APIOverwrite,
-	'type'
-> & {
+export type APIGuildCreateOverwrite = Pick<APIOverwrite, 'type'> & {
 	id: string | number;
 	allow: number | string;
 	deny: number | string;
-}
+};
 
 export type APIGuildCreatePartialChannel = Partial<
-	Pick<
-		APIChannel,
-		'type' | 'topic' | 'nsfw' | 'bitrate' | 'user_limit' | 'rate_limit_per_user'
-	>
+	Pick<APIChannel, 'type' | 'topic' | 'nsfw' | 'bitrate' | 'user_limit' | 'rate_limit_per_user'>
 > & {
 	name: string;
 	id?: number;
 	parent_id?: number;
 	permission_overwrites?: APIGuildCreateOverwrite[];
-}
+};
 
-export type APIGuildCreateRole = Partial<
-	Pick<
-		APIRole,
-		'name' | 'color' | 'hoist' | 'position' | 'mentionable'
-	>
-> & {
+export interface APIGuildCreateRole extends RESTPostAPIGuildRoleJSONBody {
 	id?: number;
 	permissions?: number;
 }
@@ -120,7 +110,13 @@ export type RESTGetAPIGuildChannelsResult = APIChannel[];
 /**
  * https://discord.com/developers/docs/resources/guild#create-guild-channel
  */
-export type RESTPostAPIGuildChannelJSONBody = APIGuildCreatePartialChannel;
+export type RESTPostAPIGuildChannelJSONBody = Partial<
+	Pick<
+		APIChannel,
+		'type' | 'permission_overwrites' | 'topic' | 'nsfw' | 'bitrate' | 'user_limit' | 'rate_limit_per_user' | 'parent_id'
+	>
+> &
+	Required<Pick<APIChannel, 'name'>>;
 
 export type RESTPostAPIGuildChannelResult = APIChannel;
 

--- a/v6/rest/guild.ts
+++ b/v6/rest/guild.ts
@@ -17,13 +17,36 @@ import type {
 	IntegrationExpireBehavior,
 } from '../payloads';
 
+export type APIGuildCreateOverwrite = Pick<
+	APIOverwrite,
+	'type'
+> & {
+	id: string | number;
+	allow: number | string;
+	deny: number | string;
+}
+
 export type APIGuildCreatePartialChannel = Partial<
 	Pick<
 		APIChannel,
-		'type' | 'permission_overwrites' | 'topic' | 'nsfw' | 'bitrate' | 'user_limit' | 'rate_limit_per_user' | 'parent_id'
+		'type' | 'topic' | 'nsfw' | 'bitrate' | 'user_limit' | 'rate_limit_per_user'
 	>
-> &
-	Required<Pick<APIChannel, 'name'>>;
+> & {
+	name: string;
+	id?: number;
+	parent_id?: number;
+	permission_overwrites?: APIGuildCreateOverwrite[];
+}
+
+export type APIGuildCreateRole = Partial<
+	Pick<
+		APIRole,
+		'name' | 'color' | 'hoist' | 'position' | 'mentionable'
+	>
+> & {
+	id?: number;
+	permissions?: number;
+}
 
 /**
  * https://discord.com/developers/docs/resources/guild#create-guild
@@ -35,11 +58,11 @@ export interface RESTPostAPIGuildsJSONBody {
 	verification_level?: GuildVerificationLevel;
 	default_message_notifications?: GuildDefaultMessageNotifications;
 	explicit_content_filter?: GuildExplicitContentFilter;
-	roles?: APIRole[];
+	roles?: APIGuildCreateRole[];
 	channels?: APIGuildCreatePartialChannel[];
-	afk_channel_id?: string;
+	afk_channel_id?: number;
 	afk_timeout?: number;
-	system_channel_id?: string;
+	system_channel_id?: number;
 }
 
 export type RESTPostAPIGuildsResult = APIGuild;

--- a/v6/rest/guild.ts
+++ b/v6/rest/guild.ts
@@ -28,13 +28,13 @@ export type APIGuildCreatePartialChannel = Partial<
 	Pick<APIChannel, 'type' | 'topic' | 'nsfw' | 'bitrate' | 'user_limit' | 'rate_limit_per_user'>
 > & {
 	name: string;
-	id?: number;
+	id?: number | string;
 	parent_id?: number;
 	permission_overwrites?: APIGuildCreateOverwrite[];
 };
 
 export interface APIGuildCreateRole extends RESTPostAPIGuildRoleJSONBody {
-	id?: number;
+	id: number | string;
 	permissions?: number;
 }
 

--- a/v6/rest/guild.ts
+++ b/v6/rest/guild.ts
@@ -19,7 +19,7 @@ import type {
 } from '../payloads';
 
 export type APIGuildCreateOverwrite = Pick<APIOverwrite, 'type'> & {
-	id: string | number;
+	id: number | string;
 	allow: number | string;
 	deny: number | string;
 };
@@ -29,7 +29,7 @@ export type APIGuildCreatePartialChannel = Partial<
 > & {
 	name: string;
 	id?: number | string;
-	parent_id?: number;
+	parent_id?: number | string;
 	permission_overwrites?: APIGuildCreateOverwrite[];
 };
 
@@ -50,9 +50,9 @@ export interface RESTPostAPIGuildsJSONBody {
 	explicit_content_filter?: GuildExplicitContentFilter;
 	roles?: APIGuildCreateRole[];
 	channels?: APIGuildCreatePartialChannel[];
-	afk_channel_id?: number;
+	afk_channel_id?: number | string;
 	afk_timeout?: number;
-	system_channel_id?: number;
+	system_channel_id?: number | string;
 }
 
 export type RESTPostAPIGuildsResult = APIGuild;


### PR DESCRIPTION
on the API docs for [Create Guild (POST /guilds)](https://discord.com/developers/docs/resources/guild#create-guild) there are a couple of info boxes stating that roles and channels can have an integer ID as a placeholder, eg for creating channel overwrites, this PR corrects these types into numbers

This PR also corrects the type for `roles` in `RESTPostAPIGuildsJSONBody` as it was previously typed as `APIRole` which isn't technically correct; the API won't accept permissons_new here, 

`afk_channel_id` and `system_channel_id` are documented to be of type snowflake, but testing shows that the API accepts an integer, (there is an issue on the API about this https://github.com/discord/discord-api-docs/issues/2089)

also i think these types need better names perhaps? im really not good with names so if anyones got suggestions