### PR TITLE
fix(GatewayHeartbeat): d is nullable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-api-types",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/v8/gateway/index.ts
+++ b/v8/gateway/index.ts
@@ -581,7 +581,7 @@ export type GatewayWebhooksUpdateDispatch = DataPayload<
  */
 export interface GatewayHeartbeat {
 	op: GatewayOPCodes.Heartbeat;
-	d: number;
+	d: number | null;
 }
 
 /**


### PR DESCRIPTION
As per [documentation](https://discord.com/developers/docs/topics/gateway#heartbeat).
> The inner d key is the last sequence number—s—received by the client. If you have not yet received one, send null.