### PR TITLE
fix(GatewayIdentify): use correct presence interface

### DIFF
--- a/v8/gateway/index.ts
+++ b/v8/gateway/index.ts
@@ -605,7 +605,7 @@ export interface GatewayIdentify {
 		large_threshold?: number;
 		// eslint-disable-next-line prettier/prettier
 		shard?: [shard_id: number, shard_count: number];
-		presence?: RawGatewayPresenceUpdate;
+		presence?: GatewayPresenceUpdateData;
 		guild_subscriptions?: boolean;
 		intents: number;
 	};


### PR DESCRIPTION
Currently, `GatewayIdentify` uses the `GatewayPresenceUpdate` interface, however that is used for presences that the client receives from Discord and `GatewayPresenceUpdateData` should be used.