### PR TITLE
chore: release 0.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-api-types",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-api-types",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Discord API typings that are kept up to date for use in bot library creation.",
   "main": "default/index.js",
   "scripts": {


### PR DESCRIPTION
Because 0.6.1 had a very sort lifespan