### PR TITLE
fix(GatewayPresence): correct type for sent activity objects

### DIFF
--- a/v8/gateway/index.ts
+++ b/v8/gateway/index.ts
@@ -672,7 +672,7 @@ export interface GatewayPresenceUpdateData {
 /**
  * https://discord.com/developers/docs/topics/gateway#activity-object-activity-structure
  */
-export type GatewayActivityUpdateData = Pick<GatewayActivity, 'name' | 'type' | 'url'>
+export type GatewayActivityUpdateData = Pick<GatewayActivity, 'name' | 'type' | 'url'>;
 
 // #endregion Sendable Payloads
 

--- a/v8/gateway/index.ts
+++ b/v8/gateway/index.ts
@@ -664,10 +664,15 @@ export interface GatewayUpdatePresence {
  */
 export interface GatewayPresenceUpdateData {
 	since: number | null;
-	activities: GatewayActivity[] | null;
+	activities: GatewayActivityUpdateData[] | null;
 	status: PresenceUpdateStatus;
 	afk: boolean;
 }
+
+/**
+ * https://discord.com/developers/docs/topics/gateway#activity-object-activity-structure
+ */
+export type GatewayActivityUpdateData = Pick<GatewayActivity, 'name' | 'type' | 'url'>
 
 // #endregion Sendable Payloads
 

--- a/v8/payloads/gateway.ts
+++ b/v8/payloads/gateway.ts
@@ -56,7 +56,7 @@ export enum PresenceUpdateStatus {
 export type GatewayPresenceClientStatus = Partial<Record<'desktop' | 'mobile' | 'web', PresenceUpdateStatus>>;
 
 /**
- * https://discord.com/developers/docs/topics/gateway#activity-object
+ * https://discord.com/developers/docs/topics/gateway#activity-object-activity-structure
  */
 export interface GatewayActivity {
 	name: string;


### PR DESCRIPTION
[API Docs](https://discord.com/developers/docs/topics/gateway#activity-object-activity-structure): Bots are only able to send `name`, `type`, and optionally `url`.

There is no separation between activity objects received from Discord and ones sent from the client. That causes problems like this, even though `created_at` should not be sent / will be ignored anyway.

![image](https://user-images.githubusercontent.com/66554238/96385073-c18b6400-1191-11eb-83fb-2f2fc824eb1a.png)

I'm not fully familiar with the file structure yet, so if I placed it where it doesn't belong just let me know.