### PR TITLE
types(GatewayChannelPinsUpdateDispatch): make last_pin_timestamp nullable

### DIFF
--- a/v8/gateway/index.ts
+++ b/v8/gateway/index.ts
@@ -298,7 +298,7 @@ export type GatewayChannelPinsUpdateDispatch = DataPayload<
 	{
 		guild_id?: string;
 		channel_id: string;
-		last_pin_timestamp?: string;
+		last_pin_timestamp?: string | null;
 	}
 >;
 


### PR DESCRIPTION
This PR syncs up with https://github.com/discord/discord-api-docs/commit/14460930d859237dc6cf8d464378b482d712fd6e (#2215 in the Discord API docs PRs), which was recently merged.
