### PR TITLE
fix(RESTPatchAPIGuildJSONBody): multiple properties are actually nullable

### DIFF
--- a/v8/rest/guild.ts
+++ b/v8/rest/guild.ts
@@ -75,9 +75,9 @@ export type RESTGetAPIGuildPreviewResult = APIGuildPreview;
 export interface RESTPatchAPIGuildJSONBody {
 	name?: string;
 	region?: string | null;
-	verification_level?: GuildVerificationLevel;
-	default_message_notifications?: GuildDefaultMessageNotifications;
-	explicit_content_filter?: GuildExplicitContentFilter;
+	verification_level?: GuildVerificationLevel | null;
+	default_message_notifications?: GuildDefaultMessageNotifications | null;
+	explicit_content_filter?: GuildExplicitContentFilter | null;
 	afk_channel_id?: string | null;
 	afk_timeout?: number;
 	icon?: string | null;
@@ -88,7 +88,7 @@ export interface RESTPatchAPIGuildJSONBody {
 	system_channel_id?: string | null;
 	rules_channel_id?: string | null;
 	public_updates_channel_id?: string | null;
-	preferred_locale?: string;
+	preferred_locale?: string | null;
 	features?: GuildFeature[];
 	description?: string | null;
 }

--- a/v8/rest/guild.ts
+++ b/v8/rest/guild.ts
@@ -74,7 +74,7 @@ export type RESTGetAPIGuildPreviewResult = APIGuildPreview;
  */
 export interface RESTPatchAPIGuildJSONBody {
 	name?: string;
-	region?: string;
+	region?: string | null;
 	verification_level?: GuildVerificationLevel;
 	default_message_notifications?: GuildDefaultMessageNotifications;
 	explicit_content_filter?: GuildExplicitContentFilter;


### PR DESCRIPTION
As per [documentation](https://discord.com/developers/docs/resources/guild#modify-guild-json-params).

After testing them, it seems `null` casuses Discord to flip each of the said fields to their original defaults.