### PR TITLE
fix(APIGuildMember): drop nullability of `pending` prop

### DIFF
--- a/v8/payloads/guild.ts
+++ b/v8/payloads/guild.ts
@@ -227,7 +227,7 @@ export interface APIGuildMember {
 	premium_since?: string | null;
 	deaf: boolean;
 	mute: boolean;
-	pending?: boolean | null;
+	pending?: boolean;
 }
 
 /**


### PR DESCRIPTION
ref: https://github.com/discord/discord-api-docs/commit/2fe4e62a86f1d6b79bb57e3b46f0016b03391261