### PR TITLE
chore: RESTPatchAPIGuildJSONBody `system_channel_flags` is optional; release 0.11.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-api-types",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-api-types",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Discord API typings that are kept up to date for use in bot library creation.",
   "main": "default/index.js",
   "scripts": {

--- a/v8/rest/guild.ts
+++ b/v8/rest/guild.ts
@@ -88,7 +88,7 @@ export interface RESTPatchAPIGuildJSONBody {
 	discovery_splash?: string | null;
 	banner?: string | null;
 	system_channel_id?: string | null;
-	system_channel_flags: GuildSystemChannelFlags;
+	system_channel_flags?: GuildSystemChannelFlags;
 	rules_channel_id?: string | null;
 	public_updates_channel_id?: string | null;
 	preferred_locale?: string | null;


### PR DESCRIPTION
<sup>i swear i literally didn't notice this was also broken with my last pr, please don't hurt me</sup>

All jokes aside, totally sorry you put out a version that didn't have this fixed as well, will try to pay more attention from here on out with those PRs, lol