### PR TITLE
fix(GatewayActivityEmoji): fix types for `name` and `id`

### DIFF
--- a/v8/payloads/gateway.ts
+++ b/v8/payloads/gateway.ts
@@ -109,7 +109,10 @@ export interface GatewayActivityTimestamps {
 /**
  * https://discord.com/developers/docs/topics/gateway#activity-object-activity-emoji
  */
-export type GatewayActivityEmoji = Partial<Pick<APIEmoji, 'name' | 'animated'>> & Pick<APIEmoji, 'id'>;
+export interface GatewayActivityEmoji extends Pick<APIEmoji, 'animated'> {
+	name: string;
+	id?: string;
+}
 
 /**
  * https://discord.com/developers/docs/topics/gateway#activity-object-activity-party


### PR DESCRIPTION
According to the [docs](https://discord.com/developers/docs/topics/gateway#activity-object-activity-emoji) `name` is required and `id` is optional. Both are also non-nullable.

Previously, the typings incorrectly had `name` as optional and `id` as required, with both being nullable.