### PR TITLE
fix(APIAuditLogChangeKeyID): make `new_value` optional

### DIFF
--- a/v8/payloads/auditLog.ts
+++ b/v8/payloads/auditLog.ts
@@ -431,11 +431,7 @@ export type APIAuditLogChangeKeyAvatarHash = AuditLogChangeData<'avatar_hash', s
 /**
  * The ID of the changed entity - sometimes used in conjunction with other keys
  */
-export interface APIAuditLogChangeKeyID {
-	key: 'id';
-	new_value: string;
-	old_value?: string;
-}
+export type APIAuditLogChangeKeyID = AuditLogChangeData<'id', string>;
 
 /**
  * The type of entity created


### PR DESCRIPTION
An audit log change with the key `id` doesn't have the `new_value` property when a channel override is removed:

```jsonc
{
  // ...
  "action_type": 15, // CHANNEL_OVERWRITE_DELETE,
  "changes": [
    {"key": "id", "old_value": "<member/role id>"},
    // ...
  ],
  // ...
}
```

Can this get into #62?