### PR TITLE
fix(APIAuditLogOptions): make `type` optional

### DIFF
--- a/v8/payloads/auditLog.ts
+++ b/v8/payloads/auditLog.ts
@@ -141,7 +141,7 @@ export interface APIAuditLogOptions {
 	 * - CHANNEL_OVERWRITE_UPDATE
 	 * - CHANNEL_OVERWRITE_DELETE
 	 */
-	type: AuditLogOptionsType;
+	type?: AuditLogOptionsType;
 
 	/**
 	 * Present from:


### PR DESCRIPTION
The `type` property is only present in the channel overwrite changes and is therefore not always present.

Can this get into #62?