### PR TITLE
chore(APIGuildMember): make `premium_since` not optional

### DIFF
--- a/v8/payloads/guild.ts
+++ b/v8/payloads/guild.ts
@@ -542,7 +542,7 @@ export interface APIGuildMember {
 	 *
 	 * See https://support.discord.com/hc/en-us/articles/360028038352-Server-Boosting-
 	 */
-	premium_since?: string | null;
+	premium_since: string | null;
 	/**
 	 * Whether the user is deafened in voice channels
 	 */


### PR DESCRIPTION
Syncs up with https://github.com/discord/discord-api-docs/commit/364e7fb3fbf4b304778afcd503fc8a4100a7987d
