### PR TITLE
chore(Gateway): clarify Heartbeat OP as bidirectional

### DIFF
--- a/deno/v8/gateway/mod.ts
+++ b/deno/v8/gateway/mod.ts
@@ -32,7 +32,8 @@ export const enum GatewayOPCodes {
 	 */
 	Dispatch,
 	/**
-	 * Fired periodically by the client to keep the connection alive
+	 * A bidirectional opcode to maintain an active gateway connection.
+	 * Fired periodically by the client, or fired by the gateway to request an immediate heartbeat from the client.
 	 */
 	Heartbeat,
 	/**

--- a/v8/gateway/index.ts
+++ b/v8/gateway/index.ts
@@ -33,7 +33,8 @@ export const enum GatewayOPCodes {
 	 */
 	Dispatch,
 	/**
-	 * Fired periodically by the client to keep the connection alive
+	 * A bidirectional opcode to maintain an active gateway connection.
+	 * Fired periodically by the client, or fired by the gateway to request an immediate heartbeat from the client.
 	 */
 	Heartbeat,
 	/**


### PR DESCRIPTION
https://discord.com/developers/docs/topics/gateway#heartbeat
> This OP code is also bidirectional. The gateway may request a heartbeat from you in some situations, and you should send a heartbeat back to the gateway as you normally would.
