### PR TITLE
src(GameSDK): document gamesdk routes

### DIFF
--- a/v8/payloads/gamesdk.ts
+++ b/v8/payloads/gamesdk.ts
@@ -1,5 +1,5 @@
 /**
- * Types extracted from https://discord.com/developers/docs/game-sdk/achievements#the-api-way
+ * Types extracted from https://discord.com/developers/docs/game-sdk
  */
 import type { Snowflake } from '../../common/index';
 

--- a/v8/payloads/gamesdk.ts
+++ b/v8/payloads/gamesdk.ts
@@ -1,0 +1,326 @@
+/**
+ * Types extracted from https://discord.com/developers/docs/game-sdk/achievements#the-api-way
+ */
+import type { Snowflake } from '../../common/index';
+
+/**
+ * https://discord.com/developers/docs/game-sdk/achievements#data-models-achievement-struct
+ */
+export interface APIAchievement {
+	/**
+	 * the unique id of the application
+	 */
+	application_id: Snowflake;
+
+	/**
+	 * the name of the achievement as an achievement locale object
+	 */
+	name: APIAchievementLocale;
+	/**
+	 * the user-facing achievement description as an achievement locale object
+	 */
+	description: APIAchievementLocale;
+	/**
+	 * if the achievement is secret
+	 */
+	secret: boolean;
+	/**
+	 * if the achievement is secure
+	 */
+	secure: boolean;
+	/**
+	 * the unique id of the achievement
+	 */
+	id: number;
+	/**
+	 * 	the hash of the icon
+	 */
+	icon_hash: string;
+}
+
+/**
+ * https://discord.com/developers/docs/game-sdk/achievements#data-models-achievement-locale-object
+ */
+export interface APIAchievementLocale {
+	/**
+	 * the default locale for the achievement
+	 */
+	default: string;
+	/**
+	 * object of accepted locales as the key and achievement translations as the value
+	 */
+	localizations?: Record<AcceptedLocales, string>;
+}
+
+/**
+ * https://discord.com/developers/docs/dispatch/field-values#predefined-field-values-accepted-locales
+ */
+export const enum AcceptedLocales {
+	'en-US' = 'English (United States)',
+	'en-GB' = 'English (Great Britain)',
+	'zh-CN' = 'Chinese (China)',
+	'zh-TW' = ' CHinese (Taiwan)',
+	cs = 'Czech',
+	da = 'Danish',
+	nl = 'Dutch',
+	fr = 'French',
+	de = 'German',
+	el = 'Greek',
+	hu = 'Hungarian',
+	it = 'Italian',
+	ja = 'Japanese',
+	ko = 'Korean',
+	no = 'Norwegian',
+	pl = 'Polish',
+	'pt-BR' = 'Portuguese (Brazil)',
+	ru = 'Russian',
+	'es-ES' = 'Spanish (Spain)',
+	'sv-SE' = 'Swedish',
+	tr = 'Turkish',
+	bg = 'Bulgarian',
+	uk = 'Ukrainian',
+	fi = 'Finnish',
+	hr = 'Croatian',
+	ro = 'Romanian',
+	lt = 'Lithuanian',
+}
+
+/**
+ * https://discord.com/developers/docs/game-sdk/lobbies#data-models-lobbytype-enum
+ */
+export const enum LobbyType {
+	Private = 1,
+	Public,
+}
+
+/**
+ * https://discord.com/developers/docs/game-sdk/lobbies#data-models-lobby-struct
+ */
+export interface APILobby {
+	/**
+	 * the max capacity of the lobby
+	 *
+	 * @default 16
+	 */
+	capacity: number;
+	/**
+	 * the region in which to make the lobby - defaults to the region of the requesting server's IP address
+	 */
+	region: string;
+	/**
+	 * the password to the lobby
+	 */
+	secret: string;
+	/**
+	 * your application id
+	 */
+	application_id: Snowflake;
+	/**
+	 * metadata for the lobby - key/value pairs with types `string`
+	 */
+	metadata: Record<string, string>;
+	/**
+	 * if the lobby is public or private
+	 */
+	type: LobbyType;
+	/**
+	 * the unique id of the lobby
+	 */
+	id: Snowflake;
+	/**
+	 * the id of the lobby owner
+	 */
+	owner_id: Snowflake;
+}
+
+/**
+ * https://discord.com/developers/docs/game-sdk/store#data-models-entitlementtype-enum
+ */
+export const enum EntitlementType {
+	/**
+	 * entitlement was purchased
+	 */
+	Purchase = 1,
+	/**
+	 * entitlement for a Discord Nitro subscription
+	 */
+	PremiumSubscription,
+	/**
+	 * entitlement was gifted by a developer
+	 */
+	DeveloperGift,
+	/**
+	 * entitlement was purchased by a dev in application test mode
+	 */
+	TestModePurchase,
+	/**
+	 * entitlement was granted when the SKU was free
+	 */
+	FreePurchase,
+	/**
+	 * entitlement was gifted by another user
+	 */
+	UserGift,
+	/**
+	 * entitlement was claimed by user for free as a Nitro Subscriber
+	 */
+	PremiumPurchase,
+}
+
+export interface APIEntitlement {
+	/**
+	 * the ID of the user this entitlement belongs to
+	 */
+	user_id: Snowflake;
+	/**
+	 * the ID of the SKU to which the user is entitled
+	 */
+	sku_id: Snowflake;
+	/**
+	 * the ID of the application this entitlement belongs to
+	 */
+	application_id: Snowflake;
+	/**
+	 * the unique ID of this entitlement
+	 */
+	id: Snowflake;
+	/**
+	 * the kind of entitlement it is
+	 */
+	type: EntitlementType;
+	/**
+	 * payment data for this entitled -- to recieve this data you must specifiy `with_patments` in respective query bodies
+	 */
+	payment?: APIPaymentData;
+}
+
+/**
+ * https://discord.com/developers/docs/game-sdk/store#httpspecific-data-models-limited-payment-data-object
+ */
+export interface APIPaymentData {
+	/**
+	 * unique ID of the payment
+	 */
+	id: Snowflake;
+	/**
+	 * the currency the payment was made in
+	 */
+	currency: number;
+	/**
+	 * the amount paid
+	 */
+	amount: number;
+	/**
+	 * the amount of tax
+	 */
+	tax: number;
+	/**
+	 * whether the amount is tax-inclusive
+	 */
+	tax_inclusive: boolean;
+}
+
+/**
+ * https://discord.com/developers/docs/game-sdk/store#data-models-skutype-enum
+ */
+export const enum APISKUType {
+	/**
+	 * SKU is a game
+	 */
+	Application = 1,
+	/**
+	 * SKU is a DLC
+	 */
+	DLC,
+	/**
+	 * SKU is a consumable (in-app purchase)
+	 */
+	Consumable,
+	/**
+	 * SKU is a bundle (comprising the other 3 types)
+	 */
+	Bundle,
+}
+
+/**
+ * https://discord.com/developers/docs/game-sdk/store#data-models-skuprice-struct
+ */
+export interface APISKUPrice {
+	/**
+	 * the amount of money the SKU costs
+	 */
+	amount: number;
+	/**
+	 * the currency the amount is in
+	 */
+	currency: string;
+}
+
+export interface APISKU {
+	/**
+	 * The unique ID of this SKU
+	 */
+	id: Snowflake;
+	/**
+	 * The type of this SKU
+	 */
+	type: APISKUType;
+	/**
+	 * This field is lacking documentation
+	 * @unstable
+	 */
+	dependent_sku_id: Snowflake | null;
+	/**
+	 * The ID of the application this SKU belongs to
+	 */
+	application_id: Snowflake;
+	/**
+	 * This field is lacking documentation
+	 * @unstable
+	 */
+	manifest_labels: Snowflake[];
+	name: string;
+	/**
+	 * The field is lacking documentation
+	 * @unstable
+	 */
+	access_type: number;
+	/**
+	 * The field is lacking documentation
+	 * @unstable
+	 */
+	features: number[];
+	/**
+	 * The field is lacking documentation
+	 * @unstable
+	 */
+	system_requirements: {}; // eslint-disable-line @typescript-eslint/ban-types
+	/**
+	 * The field is lacking documentation
+	 * @unstable
+	 */
+	content_ratings: {}; // eslint-disable-line @typescript-eslint/ban-types
+	release_date: string;
+	/**
+	 * The field is lacking documentation
+	 * @unstable
+	 */
+	legal_notice: {}; // eslint-disable-line @typescript-eslint/ban-types
+	/**
+	 * The field is lacking documentation
+	 * @unstable
+	 */
+	price_tier: number;
+	price: APISKUPrice;
+	premium: boolean;
+	/**
+	 * The field is lacking documentation
+	 * @unstable
+	 */
+	locales: keyof AcceptedLocales[];
+	/**
+	 * The field is lacking documentation
+	 * @unstable
+	 */
+	bundled_skus: string | null;
+}

--- a/v8/payloads/gamesdk.ts
+++ b/v8/payloads/gamesdk.ts
@@ -8,30 +8,30 @@ import type { Snowflake } from '../../common/index';
  */
 export interface APIAchievement {
 	/**
-	 * the unique id of the application
+	 * Achievement id
+	 */
+	id: number;
+	/**
+	 * The id of the application this achievement belongs to
 	 */
 	application_id: Snowflake;
 
 	/**
-	 * the name of the achievement as an achievement locale object
+	 * Achievement name
 	 */
 	name: APIAchievementLocale;
 	/**
-	 * the user-facing achievement description as an achievement locale object
+	 * Achievement description
 	 */
 	description: APIAchievementLocale;
 	/**
-	 * if the achievement is secret
+	 * If the achievement is secret
 	 */
 	secret: boolean;
 	/**
-	 * if the achievement is secure
+	 * If the achievement is secure
 	 */
 	secure: boolean;
-	/**
-	 * the unique id of the achievement
-	 */
-	id: number;
 	/**
 	 * 	the hash of the icon
 	 */
@@ -98,37 +98,37 @@ export const enum LobbyType {
  */
 export interface APILobby {
 	/**
-	 * the max capacity of the lobby
+	 * Lobby id
+	 */
+	id: Snowflake;
+	/**
+	 * The max capacity of the lobby
 	 *
 	 * @default 16
 	 */
 	capacity: number;
 	/**
-	 * the region in which to make the lobby - defaults to the region of the requesting server's IP address
+	 * The region in which to make the lobby - defaults to the region of the requesting server's IP address
 	 */
 	region: string;
 	/**
-	 * the password to the lobby
+	 * The password to the lobby
 	 */
 	secret: string;
 	/**
-	 * your application id
+	 * The id of the application this achievement belongs to
 	 */
 	application_id: Snowflake;
 	/**
-	 * metadata for the lobby - key/value pairs with types `string`
+	 * Metadata for the lobby
 	 */
 	metadata: Record<string, string>;
 	/**
-	 * if the lobby is public or private
+	 * If the lobby is public or private
 	 */
 	type: LobbyType;
 	/**
-	 * the unique id of the lobby
-	 */
-	id: Snowflake;
-	/**
-	 * the id of the lobby owner
+	 * The id of the lobby owner
 	 */
 	owner_id: Snowflake;
 }
@@ -138,58 +138,60 @@ export interface APILobby {
  */
 export const enum EntitlementType {
 	/**
-	 * entitlement was purchased
+	 * Entitlement was purchased
 	 */
 	Purchase = 1,
 	/**
-	 * entitlement for a Discord Nitro subscription
+	 * Entitlement for a Discord Nitro subscription
 	 */
 	PremiumSubscription,
 	/**
-	 * entitlement was gifted by a developer
+	 * Entitlement was gifted by a developer
 	 */
 	DeveloperGift,
 	/**
-	 * entitlement was purchased by a dev in application test mode
+	 * Entitlement was purchased by a dev in application test mode
 	 */
 	TestModePurchase,
 	/**
-	 * entitlement was granted when the SKU was free
+	 * Entitlement was granted when the SKU was free
 	 */
 	FreePurchase,
 	/**
-	 * entitlement was gifted by another user
+	 * Entitlement was gifted by another user
 	 */
 	UserGift,
 	/**
-	 * entitlement was claimed by user for free as a Nitro Subscriber
+	 * Entitlement was claimed by user for free as a Nitro Subscriber
 	 */
 	PremiumPurchase,
 }
 
 export interface APIEntitlement {
 	/**
-	 * the ID of the user this entitlement belongs to
-	 */
-	user_id: Snowflake;
-	/**
-	 * the ID of the SKU to which the user is entitled
-	 */
-	sku_id: Snowflake;
-	/**
-	 * the ID of the application this entitlement belongs to
-	 */
-	application_id: Snowflake;
-	/**
-	 * the unique ID of this entitlement
+	 * Entitlement id
 	 */
 	id: Snowflake;
 	/**
-	 * the kind of entitlement it is
+	 * The id of the user this entitlement belongs to
+	 */
+	user_id: Snowflake;
+	/**
+	 * The id of the SKU to which the user is entitled
+	 */
+	sku_id: Snowflake;
+	/**
+	 * The id of the application this entitlement belongs to
+	 */
+	application_id: Snowflake;
+	/**
+	 * The type of the entitlement
 	 */
 	type: EntitlementType;
 	/**
-	 * payment data for this entitled -- to recieve this data you must specifiy `with_patments` in respective query bodies
+	 * Payment data for this entitlement
+	 *
+	 * To recieve this data you must specifiy `with_patments` in respective query bodies
 	 */
 	payment?: APIPaymentData;
 }
@@ -199,23 +201,23 @@ export interface APIEntitlement {
  */
 export interface APIPaymentData {
 	/**
-	 * unique ID of the payment
+	 * Payment id
 	 */
 	id: Snowflake;
 	/**
-	 * the currency the payment was made in
+	 * The currency the payment was made in
 	 */
 	currency: number;
 	/**
-	 * the amount paid
+	 * The amount paid
 	 */
 	amount: number;
 	/**
-	 * the amount of tax
+	 * The amount of tax paid
 	 */
 	tax: number;
 	/**
-	 * whether the amount is tax-inclusive
+	 * Whether the amount is tax-inclusive
 	 */
 	tax_inclusive: boolean;
 }
@@ -247,18 +249,18 @@ export const enum APISKUType {
  */
 export interface APISKUPrice {
 	/**
-	 * the amount of money the SKU costs
+	 * The amount of money the SKU costs
 	 */
 	amount: number;
 	/**
-	 * the currency the amount is in
+	 * The currency the amount is in
 	 */
 	currency: string;
 }
 
 export interface APISKU {
 	/**
-	 * The unique ID of this SKU
+	 * SKU id
 	 */
 	id: Snowflake;
 	/**
@@ -271,7 +273,7 @@ export interface APISKU {
 	 */
 	dependent_sku_id: Snowflake | null;
 	/**
-	 * The ID of the application this SKU belongs to
+	 * The id of the application this SKU belongs to
 	 */
 	application_id: Snowflake;
 	/**
@@ -279,6 +281,9 @@ export interface APISKU {
 	 * @unstable
 	 */
 	manifest_labels: Snowflake[];
+	/**
+	 * The name of this SKU
+	 */
 	name: string;
 	/**
 	 * The field is lacking documentation
@@ -300,6 +305,9 @@ export interface APISKU {
 	 * @unstable
 	 */
 	content_ratings: {}; // eslint-disable-line @typescript-eslint/ban-types
+	/**
+	 * The date this SKU was released
+	 */
 	release_date: string;
 	/**
 	 * The field is lacking documentation
@@ -311,7 +319,13 @@ export interface APISKU {
 	 * @unstable
 	 */
 	price_tier: number;
+	/**
+	 * The price of this SKU
+	 */
 	price: APISKUPrice;
+	/**
+	 * Whether or not this SKU is premium
+	 */
 	premium: boolean;
 	/**
 	 * The field is lacking documentation

--- a/v8/rest/gamesdk.ts
+++ b/v8/rest/gamesdk.ts
@@ -1,0 +1,306 @@
+import type { Snowflake } from '../../common/index';
+import type { APIAchievement, APIEntitlement, APILobby, APISKU } from '../payloads/gamesdk';
+
+/**
+ * https://discord.com/developers/docs/game-sdk/achievements#get-achievements
+ */
+export type RESTGetAPIAchievementsResult = APIAchievement[];
+
+/**
+ * https://discord.com/developers/docs/game-sdk/achievements#get-achievement
+ */
+export type RESTGETAPIAchievementResult = APIAchievement;
+
+/**
+ * https://discord.com/developers/docs/game-sdk/achievements#create-achievement-parameters
+ */
+export interface RESTPostAPIAchievementJSONBody {
+	/**
+	 * The name of the achievement
+	 */
+	name: string;
+	/**
+	 * The user-facing achievement description
+	 */
+	description: string;
+	/**
+	 * If the achievement is secret
+	 */
+	secret: boolean;
+	/**
+	 * If the achievement is secure
+	 */
+	secure: boolean;
+	/**
+	 * base64 png/jpeg image for the achievement icon
+	 *
+	 * See https://discord.com/developers/docs/reference#image-data
+	 */
+	icon: string;
+}
+
+/**
+ * https://discord.com/developers/docs/game-sdk/achievements#create-achievement
+ */
+export type RESTPostAPIAchievementResult = APIAchievement;
+
+/**
+ * https://discord.com/developers/docs/game-sdk/achievements#update-achievement-parameters
+ */
+export type RESTPatchAPIAchievementJSONBody = Partial<RESTPostAPIAchievementJSONBody>;
+
+/**
+ * https://discord.com/developers/docs/game-sdk/achievements#update-achievement
+ */
+export type RESTPatchAPIAchievementResult = APIAchievement;
+
+/**
+ * https://discord.com/developers/docs/game-sdk/achievements#delete-achievement
+ */
+export type RESTDeleteAPIAchievementResult = never;
+
+/**
+ * https://discord.com/developers/docs/game-sdk/achievements#update-user-achievement-parameters
+ */
+export interface RESTPutAPIUpdateUserAchievementJSONBody {
+	/**
+	 * the user's progress towards completing the achievement
+	 */
+	percent_complete: number;
+}
+
+/**
+ * https://discord.com/developers/docs/game-sdk/achievements#update-user-achievement
+ */
+export interface RESTPutAPIUpdateUserAchievementResult {}
+
+/**
+ * https://discord.com/developers/docs/game-sdk/lobbies#create-lobby-parameters
+ */
+export type RESTPostAPICreateLobbyJSONBody = Omit<APILobby, 'secret' | 'id' | 'owner_id'> & { capacity?: number };
+
+/**
+ * https://discord.com/developers/docs/game-sdk/lobbies#create-lobby
+ */
+export type RESTPostAPICreateLobbyResult = APILobby;
+
+/**
+ * https://discord.com/developers/docs/game-sdk/lobbies#create-update-parameters
+ */
+export type RESTPatchAPICUpdateLobbyJSONBody = Partial<
+	Omit<APILobby, 'secret' | 'id' | 'owner_id' | 'region' | 'application_id'>
+>;
+
+/**
+ * https://discord.com/developers/docs/game-sdk/lobbies#update-lobby
+ */
+export type RESTPatchAPIUpdateLobbyResult = APILobby;
+
+/**
+ * https://discord.com/developers/docs/game-sdk/lobbies#delete-lobby
+ */
+export type RESTDeleteAPIDeleteLobbyResult = never;
+
+/**
+ * https://discord.com/developers/docs/game-sdk/lobbies#update-lobby-member-parameters
+ */
+export interface RESTPatchAPILobbyMemberJSONBody {
+	/**
+	 * Metadata for the lobby member - key/value pairs with types string
+	 */
+	metadata: Record<string, string>;
+}
+
+/**
+ * https://discord.com/developers/docs/game-sdk/lobbies#update-lobby-member
+ */
+export interface RESTPatchAPILobbyMemberResult {}
+
+/**
+ * https://discord.com/developers/docs/game-sdk/lobbies#create-lobby-search-searchfilter-object
+ */
+export interface SearchFilterObject {
+	/**
+	 * the metadata key to search
+	 */
+	key: string;
+	/**
+	 * the value of the metadata key to validate against
+	 */
+	value: string;
+	/**
+	 * the type to cast `value` as
+	 */
+	cast: RESTPostAPICreateLobbySearchSearchCast;
+	/**
+	 * how to compare the metadata values
+	 */
+	comparison: RESTPostAPICreateLobbySearchSearchComparison;
+}
+
+/**
+ * https://discord.com/developers/docs/game-sdk/lobbies#create-lobby-search-searchcomparison-types
+ */
+export const enum RESTPostAPICreateLobbySearchSearchComparison {
+	EQUAL_TO_OR_LESS_THAN = -2,
+	LESS_THAN,
+	EQUAL,
+	EQUAL_TO_OR_GREATER_THAN,
+	GREATER_THAN,
+	NOT_EQUAL,
+}
+
+/**
+ * https://discord.com/developers/docs/game-sdk/lobbies#create-lobby-search-searchsort-object
+ */
+export interface RESTPostAPICreateLobbySearchSearchSort {
+	/**
+	 * the metadata key on which to sort lobbies that meet the search criteria
+	 */
+	key: string;
+	/**
+	 * the type to cast `value` as
+	 */
+	cast: RESTPostAPICreateLobbySearchSearchCast;
+	/**
+	 * the value around which to sort the key
+	 */
+	near_value: string;
+}
+
+/**
+ * https://discord.com/developers/docs/game-sdk/lobbies#create-lobby-search-searchcast-types
+ */
+export const enum RESTPostAPICreateLobbySearchSearchCast {
+	STRING = 1,
+	NUMBER,
+}
+
+/**
+ * https://discord.com/developers/docs/game-sdk/lobbies#create-lobby-search-parameters
+ */
+export interface RESTPostAPICreateLobbySearchJSONBody {
+	/**
+	 * your application id
+	 */
+	application_id: Snowflake;
+	/**
+	 * the filter to check against
+	 */
+	filter: SearchFilterObject;
+	/**
+	 * how to sort the results
+	 */
+	sort: RESTPostAPICreateLobbySearchSearchSort;
+	/**
+	 * limit of lobbies returned
+	 *
+	 * @default 25
+	 */
+	limit: number;
+}
+
+/**
+ * https://discord.com/developers/docs/game-sdk/lobbies#send-lobby-data
+ */
+export interface RESTPostAPISendLobyDataJSONBody {
+	/**
+	 * a message to be sent to other lobby members
+	 */
+	data: string;
+}
+
+/**
+ * https://discord.com/developers/docs/game-sdk/lobbies#send-lobby-data
+ */
+export type RESTPostAPISendLobyDataResult = never;
+
+/**
+ * https://discord.com/developers/docs/game-sdk/store#get-entitlement-query-parameters
+ */
+export interface RESTGetAPIEntitlementQuery {
+	/**
+	 * Whether or not to payment data for each entitlement
+	 */
+	with_payments?: boolean;
+}
+
+/**
+ * https://discord.com/developers/docs/game-sdk/store#get-entitlement
+ */
+export type RESTGetAPIEntitlementResponse = APIEntitlement;
+
+/**
+ * https://discord.com/developers/docs/game-sdk/store#get-entitlements-query-parameters
+ */
+export interface RESTGetAPIGetEntitlementsQuery extends RESTGetAPIEntitlementQuery {
+	/**
+	 * the user id to look up entitlements for
+	 */
+	user_id?: Snowflake;
+	/**
+	 * The list SKU ids to check entitlements for
+	 */
+	sku_ids?: string;
+
+	/**
+	 * retrieve entitlements before this time
+	 */
+	before?: Snowflake;
+	/**
+	 * retrieve entitlements after this time
+	 */
+	after?: Snowflake;
+	/**
+	 * number of entitlements to return, 1-100
+	 *
+	 * @default 100
+	 */
+	limit?: number;
+}
+
+/**
+ * https://discord.com/developers/docs/game-sdk/store#get-entitlements
+ */
+export type RESTGetAPIEntitlements = APIEntitlement[];
+
+/**
+ * https://discord.com/developers/docs/game-sdk/store#get-skus
+ */
+export type RESTGetAPISKUSResult = APISKU[];
+
+/**
+ * https://discord.com/developers/docs/game-sdk/store#consume-sku
+ */
+export type RESTPostAPISKUConsume = never;
+
+/**
+ * https://discord.com/developers/docs/game-sdk/store#delete-test-entitlement
+ */
+export type RESTDeleteAPIDeleteTestEntitlement = never;
+
+/**
+ * https://discord.com/developers/docs/game-sdk/store#create-purchase-discount-parameters
+ */
+export interface RESTPutAPICreatePurchaseDiscountJSONBody {
+	/**
+	 * the percentage to discount (1-100)
+	 */
+	percent_off: number;
+	/**
+	 * the time to live for the discount, in seconds (60-3600)
+	 *
+	 * @default 600
+	 */
+	ttl?: number;
+}
+
+/**
+ * https://discord.com/developers/docs/game-sdk/store#create-purchase-discount
+ */
+export type RESTPutAPICreatePurchaseDiscountResponse = never;
+
+/**
+ * https://discord.com/developers/docs/game-sdk/store#delete-purchase-discount
+ */
+export type RESTDeletePurchaseDiscountResult = never;

--- a/v8/rest/gamesdk.ts
+++ b/v8/rest/gamesdk.ts
@@ -64,7 +64,7 @@ export type RESTDeleteAPIAchievementResult = never;
  */
 export interface RESTPutAPIUpdateUserAchievementJSONBody {
 	/**
-	 * the user's progress towards completing the achievement
+	 * The user's progress towards completing the achievement
 	 */
 	percent_complete: number;
 }
@@ -106,7 +106,7 @@ export type RESTDeleteAPIDeleteLobbyResult = never;
  */
 export interface RESTPatchAPILobbyMemberJSONBody {
 	/**
-	 * Metadata for the lobby member - key/value pairs with types string
+	 * Metadata for the lobby member
 	 */
 	metadata: Record<string, string>;
 }
@@ -119,29 +119,29 @@ export interface RESTPatchAPILobbyMemberResult {}
 /**
  * https://discord.com/developers/docs/game-sdk/lobbies#create-lobby-search-searchfilter-object
  */
-export interface SearchFilterObject {
+export interface CreateLobbySearchFilterObject {
 	/**
-	 * the metadata key to search
+	 * The metadata key to search
 	 */
 	key: string;
 	/**
-	 * the value of the metadata key to validate against
+	 * The value of the metadata key to validate against
 	 */
 	value: string;
 	/**
-	 * the type to cast `value` as
+	 * The type to cast `value` as
 	 */
-	cast: RESTPostAPICreateLobbySearchSearchCast;
+	cast: CreateLobbySearchFilterObject;
 	/**
-	 * how to compare the metadata values
+	 * How to compare the metadata values
 	 */
-	comparison: RESTPostAPICreateLobbySearchSearchComparison;
+	comparison: CreateLobbySearchSearchComparison;
 }
 
 /**
  * https://discord.com/developers/docs/game-sdk/lobbies#create-lobby-search-searchcomparison-types
  */
-export const enum RESTPostAPICreateLobbySearchSearchComparison {
+export const enum CreateLobbySearchSearchComparison {
 	EQUAL_TO_OR_LESS_THAN = -2,
 	LESS_THAN,
 	EQUAL,
@@ -153,17 +153,17 @@ export const enum RESTPostAPICreateLobbySearchSearchComparison {
 /**
  * https://discord.com/developers/docs/game-sdk/lobbies#create-lobby-search-searchsort-object
  */
-export interface RESTPostAPICreateLobbySearchSearchSort {
+export interface CreateLobbySearchSearchSort {
 	/**
-	 * the metadata key on which to sort lobbies that meet the search criteria
+	 * The metadata key on which to sort lobbies that meet the search criteria
 	 */
 	key: string;
 	/**
-	 * the type to cast `value` as
+	 * The type to cast `value` as
 	 */
-	cast: RESTPostAPICreateLobbySearchSearchCast;
+	cast: CreateLobbySearchCast;
 	/**
-	 * the value around which to sort the key
+	 * The value around which to sort the key
 	 */
 	near_value: string;
 }
@@ -171,7 +171,7 @@ export interface RESTPostAPICreateLobbySearchSearchSort {
 /**
  * https://discord.com/developers/docs/game-sdk/lobbies#create-lobby-search-searchcast-types
  */
-export const enum RESTPostAPICreateLobbySearchSearchCast {
+export const enum CreateLobbySearchCast {
 	STRING = 1,
 	NUMBER,
 }
@@ -181,19 +181,19 @@ export const enum RESTPostAPICreateLobbySearchSearchCast {
  */
 export interface RESTPostAPICreateLobbySearchJSONBody {
 	/**
-	 * your application id
+	 * The id of the application the lobby is under
 	 */
 	application_id: Snowflake;
 	/**
-	 * the filter to check against
+	 * The filter to check against
 	 */
-	filter: SearchFilterObject;
+	filter: CreateLobbySearchFilterObject;
 	/**
-	 * how to sort the results
+	 * How to sort the results
 	 */
-	sort: RESTPostAPICreateLobbySearchSearchSort;
+	sort: CreateLobbySearchSearchSort;
 	/**
-	 * limit of lobbies returned
+	 * Limit of lobbies returned
 	 *
 	 * @default 25
 	 */
@@ -205,7 +205,7 @@ export interface RESTPostAPICreateLobbySearchJSONBody {
  */
 export interface RESTPostAPISendLobyDataJSONBody {
 	/**
-	 * a message to be sent to other lobby members
+	 * A message to be sent to other lobby members
 	 */
 	data: string;
 }
@@ -220,7 +220,7 @@ export type RESTPostAPISendLobyDataResult = never;
  */
 export interface RESTGetAPIEntitlementQuery {
 	/**
-	 * Whether or not to payment data for each entitlement
+	 * Whether or not to include payment data for each entitlement
 	 */
 	with_payments?: boolean;
 }
@@ -235,7 +235,7 @@ export type RESTGetAPIEntitlementResponse = APIEntitlement;
  */
 export interface RESTGetAPIGetEntitlementsQuery extends RESTGetAPIEntitlementQuery {
 	/**
-	 * the user id to look up entitlements for
+	 * The user id to look up entitlements for
 	 */
 	user_id?: Snowflake;
 	/**
@@ -244,15 +244,15 @@ export interface RESTGetAPIGetEntitlementsQuery extends RESTGetAPIEntitlementQue
 	sku_ids?: string;
 
 	/**
-	 * retrieve entitlements before this time
+	 * Retrieve entitlements before this time
 	 */
 	before?: Snowflake;
 	/**
-	 * retrieve entitlements after this time
+	 * Retrieve entitlements after this time
 	 */
 	after?: Snowflake;
 	/**
-	 * number of entitlements to return, 1-100
+	 * Number of entitlements to return (1-100)
 	 *
 	 * @default 100
 	 */
@@ -284,11 +284,11 @@ export type RESTDeleteAPIDeleteTestEntitlement = never;
  */
 export interface RESTPutAPICreatePurchaseDiscountJSONBody {
 	/**
-	 * the percentage to discount (1-100)
+	 * The percentage to discount (1-100)
 	 */
 	percent_off: number;
 	/**
-	 * the time to live for the discount, in seconds (60-3600)
+	 * The time to live for the discount, in seconds (60-3600)
 	 *
 	 * @default 600
 	 */


### PR DESCRIPTION
This PR documents all (public) Game SDK routes.
I ran into many problems writing these types, such as the lack of documentation for [APISKU](https://github.com/Fyko/discord-api-types/blob/feat/gamesdk/v8/payloads/gamesdk.ts#L261-L340), which is why I've marked this as a draft for deliberation.
