### PR TITLE
fix(deno): replace `const enum` exports in deno with normal `enum`s

### DIFF
--- a/deno/common/mod.ts
+++ b/deno/common/mod.ts
@@ -1,7 +1,7 @@
 /**
  * https://discord.com/developers/docs/topics/opcodes-and-status-codes#json-json-error-codes
  */
-export const enum RESTJSONErrorCodes {
+export enum RESTJSONErrorCodes {
 	GeneralError,
 
 	UnknownAccount = 10001,
@@ -114,7 +114,7 @@ export const enum RESTJSONErrorCodes {
 /**
  * https://discord.com/developers/docs/topics/opcodes-and-status-codes#rpc-rpc-error-codes
  */
-export const enum RPCErrorCodes {
+export enum RPCErrorCodes {
 	UnknownError = 1000,
 	InvalidPayload = 4000,
 	InvalidCommand = 4002,
@@ -136,7 +136,7 @@ export const enum RPCErrorCodes {
 /**
  * https://discord.com/developers/docs/topics/opcodes-and-status-codes#rpc-rpc-close-event-codes
  */
-export const enum RPCCloseEventCodes {
+export enum RPCCloseEventCodes {
 	InvalidClientID = 4000,
 	InvalidOrigin,
 	RateLimited,

--- a/deno/v8/gateway/mod.ts
+++ b/deno/v8/gateway/mod.ts
@@ -27,7 +27,7 @@ export const GatewayVersion = '8';
 /**
  * https://discord.com/developers/docs/topics/opcodes-and-status-codes#gateway-gateway-opcodes
  */
-export const enum GatewayOPCodes {
+export enum GatewayOPCodes {
 	/**
 	 * An event was dispatched
 	 */
@@ -78,7 +78,7 @@ export const enum GatewayOPCodes {
 /**
  * https://discord.com/developers/docs/topics/opcodes-and-status-codes#gateway-gateway-close-event-codes
  */
-export const enum GatewayCloseCodes {
+export enum GatewayCloseCodes {
 	/**
 	 * We're not sure what went wrong. Try reconnecting?
 	 */
@@ -161,7 +161,7 @@ export const enum GatewayCloseCodes {
 /**
  * https://discord.com/developers/docs/topics/opcodes-and-status-codes#voice-voice-opcodes
  */
-export const enum VoiceOPCodes {
+export enum VoiceOPCodes {
 	/**
 	 * Begin a voice websocket connection
 	 */
@@ -215,7 +215,7 @@ export const enum VoiceOPCodes {
 /**
  * https://discord.com/developers/docs/topics/opcodes-and-status-codes#voice-voice-close-event-codes
  */
-export const enum VoiceCloseCodes {
+export enum VoiceCloseCodes {
 	/**
 	 * You sent an invalid opcode
 	 */
@@ -269,7 +269,7 @@ export const enum VoiceCloseCodes {
 /**
  * https://discord.com/developers/docs/topics/gateway#list-of-intents
  */
-export const enum GatewayIntentBits {
+export enum GatewayIntentBits {
 	GUILDS = 1 << 0,
 	GUILD_MEMBERS = 1 << 1,
 	GUILD_BANS = 1 << 2,
@@ -290,7 +290,7 @@ export const enum GatewayIntentBits {
 /**
  * https://discord.com/developers/docs/topics/gateway#commands-and-events-gateway-events
  */
-export const enum GatewayDispatchEvents {
+export enum GatewayDispatchEvents {
 	ApplicationCommandCreate = 'APPLICATION_COMMAND_CREATE',
 	ApplicationCommandUpdate = 'APPLICATION_COMMAND_UPDATE',
 	ApplicationCommandDelete = 'APPLICATION_COMMAND_DELETE',

--- a/deno/v8/payloads/auditLog.ts
+++ b/deno/v8/payloads/auditLog.ts
@@ -92,7 +92,7 @@ export interface APIAuditLogEntry {
 /**
  * https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events
  */
-export const enum AuditLogEvent {
+export enum AuditLogEvent {
 	GUILD_UPDATE = 1,
 
 	CHANNEL_CREATE = 10,
@@ -223,7 +223,7 @@ export interface APIAuditLogOptions {
 	role_name?: string;
 }
 
-export const enum AuditLogOptionsType {
+export enum AuditLogOptionsType {
 	Role = '0',
 	Member = '1',
 }

--- a/deno/v8/payloads/channel.ts
+++ b/deno/v8/payloads/channel.ts
@@ -103,7 +103,7 @@ export interface APIChannel extends APIPartialChannel {
 /**
  * https://discord.com/developers/docs/resources/channel#channel-object-channel-types
  */
-export const enum ChannelType {
+export enum ChannelType {
 	/**
 	 * A text channel within a guild
 	 */
@@ -312,7 +312,7 @@ export interface APIMessage {
 /**
  * https://discord.com/developers/docs/resources/channel#message-object-message-types
  */
-export const enum MessageType {
+export enum MessageType {
 	DEFAULT,
 	RECIPIENT_ADD,
 	RECIPIENT_REMOVE,
@@ -399,7 +399,7 @@ export interface APIMessageReference {
 /**
  * https://discord.com/developers/docs/resources/channel#message-object-message-activity-types
  */
-export const enum MessageActivityType {
+export enum MessageActivityType {
 	JOIN = 1,
 	SPECTATE,
 	LISTEN,
@@ -409,7 +409,7 @@ export const enum MessageActivityType {
 /**
  * https://discord.com/developers/docs/resources/channel#message-object-message-flags
  */
-export const enum MessageFlags {
+export enum MessageFlags {
 	/**
 	 * This message has been published to subscribed channels (via Channel Following)
 	 */
@@ -476,7 +476,7 @@ export interface APISticker {
 /**
  * https://discord.com/developers/docs/resources/channel#message-object-message-sticker-format-types
  */
-export const enum StickerFormatType {
+export enum StickerFormatType {
 	PNG = 1,
 	APNG,
 	LOTTIE,
@@ -548,7 +548,7 @@ export interface APIOverwrite {
 	deny: Permissions;
 }
 
-export const enum OverwriteType {
+export enum OverwriteType {
 	Role,
 	Member,
 }
@@ -641,7 +641,7 @@ export interface APIEmbed {
  * https://discord.com/developers/docs/resources/channel#embed-object-embed-types
  * @deprecated *Embed types should be considered deprecated and might be removed in a future API version*
  */
-export const enum EmbedType {
+export enum EmbedType {
 	/**
 	 * Generic embed rendered from embed attributes
 	 */
@@ -871,7 +871,7 @@ export interface APIChannelMention {
 /**
  * https://discord.com/developers/docs/resources/channel#allowed-mentions-object-allowed-mention-types
  */
-export const enum AllowedMentionsTypes {
+export enum AllowedMentionsTypes {
 	/**
 	 * Controls @everyone and @here mentions
 	 */

--- a/deno/v8/payloads/gateway.ts
+++ b/deno/v8/payloads/gateway.ts
@@ -91,7 +91,7 @@ export interface GatewayPresenceUpdate {
 	client_status?: GatewayPresenceClientStatus;
 }
 
-export const enum PresenceUpdateStatus {
+export enum PresenceUpdateStatus {
 	Online = 'online',
 	DoNotDisturb = 'dnd',
 	Idle = 'idle',
@@ -213,7 +213,7 @@ export enum ActivityPlatform {
 /**
  * https://discord.com/developers/docs/topics/gateway#activity-object-activity-types
  */
-export const enum ActivityType {
+export enum ActivityType {
 	/**
 	 * Playing {game}
 	 */
@@ -288,7 +288,7 @@ export type GatewayActivitySecrets = Partial<Record<'join' | 'spectate' | 'match
 /**
  * https://discord.com/developers/docs/topics/gateway#activity-object-activity-flags
  */
-export const enum ActivityFlags {
+export enum ActivityFlags {
 	INSTANCE = 1 << 0,
 	JOIN = 1 << 1,
 	SPECTATE = 1 << 2,

--- a/deno/v8/payloads/guild.ts
+++ b/deno/v8/payloads/guild.ts
@@ -302,7 +302,7 @@ export interface APIGuild extends APIPartialGuild {
 /**
  * https://discord.com/developers/docs/resources/guild#guild-object-default-message-notification-level
  */
-export const enum GuildDefaultMessageNotifications {
+export enum GuildDefaultMessageNotifications {
 	ALL_MESSAGES,
 	ONLY_MENTIONS,
 }
@@ -310,7 +310,7 @@ export const enum GuildDefaultMessageNotifications {
 /**
  * https://discord.com/developers/docs/resources/guild#guild-object-explicit-content-filter-level
  */
-export const enum GuildExplicitContentFilter {
+export enum GuildExplicitContentFilter {
 	DISABLED,
 	MEMBERS_WITHOUT_ROLES,
 	ALL_MEMBERS,
@@ -319,7 +319,7 @@ export const enum GuildExplicitContentFilter {
 /**
  * https://discord.com/developers/docs/resources/guild#guild-object-mfa-level
  */
-export const enum GuildMFALevel {
+export enum GuildMFALevel {
 	NONE,
 	ELEVATED,
 }
@@ -327,7 +327,7 @@ export const enum GuildMFALevel {
 /**
  * https://discord.com/developers/docs/resources/guild#guild-object-verification-level
  */
-export const enum GuildVerificationLevel {
+export enum GuildVerificationLevel {
 	/**
 	 * Unrestricted
 	 */
@@ -353,7 +353,7 @@ export const enum GuildVerificationLevel {
 /**
  * https://discord.com/developers/docs/resources/guild#guild-object-premium-tier
  */
-export const enum GuildPremiumTier {
+export enum GuildPremiumTier {
 	NONE,
 	TIER_1,
 	TIER_2,
@@ -363,7 +363,7 @@ export const enum GuildPremiumTier {
 /**
  * https://discord.com/developers/docs/resources/guild#guild-object-system-channel-flags
  */
-export const enum GuildSystemChannelFlags {
+export enum GuildSystemChannelFlags {
 	/**
 	 * Suppress member join notifications
 	 */
@@ -377,7 +377,7 @@ export const enum GuildSystemChannelFlags {
 /**
  * https://discord.com/developers/docs/resources/guild#guild-object-guild-features
  */
-export const enum GuildFeature {
+export enum GuildFeature {
 	/**
 	 * Guild has access to set an animated guild icon
 	 */
@@ -658,7 +658,7 @@ export type APIGuildInteractionType = 'twitch' | 'youtube' | 'discord';
 /**
  * https://discord.com/developers/docs/resources/guild#integration-object-integration-expire-behaviors
  */
-export const enum IntegrationExpireBehavior {
+export enum IntegrationExpireBehavior {
 	RemoveRole,
 	Kick,
 }
@@ -762,7 +762,7 @@ export interface APIGuildWidgetMember {
 /**
  * https://discord.com/developers/docs/resources/guild#get-guild-widget-image-widget-style-options
  */
-export const enum GuildWidgetStyle {
+export enum GuildWidgetStyle {
 	/**
 	 * Shield style widget with Discord icon and guild members online count
 	 */
@@ -848,7 +848,7 @@ export interface APIGuildMembershipScreeningField {
 	required: boolean;
 }
 
-export const enum MembershipScreeningFieldType {
+export enum MembershipScreeningFieldType {
 	/**
 	 * Server Rules
 	 */

--- a/deno/v8/payloads/interactions.ts
+++ b/deno/v8/payloads/interactions.ts
@@ -213,6 +213,9 @@ export type APIInteractionResponseDeferredChannelMessageWithSource = Interaction
  * https://discord.com/developers/docs/interactions/slash-commands#interaction-response-interactionresponsetype
  */
 export enum APIInteractionResponseType {
+	/**
+	 * ACK a `Ping`
+	 */
 	Pong = 1,
 	/**
 	 * ACK a command without sending a message, eating the user's input

--- a/deno/v8/payloads/interactions.ts
+++ b/deno/v8/payloads/interactions.ts
@@ -57,7 +57,7 @@ export interface APIApplicationCommandArgumentOptions extends Omit<APIApplicatio
 /**
  * https://discord.com/developers/docs/interactions/slash-commands#applicationcommandoptiontype
  */
-export const enum ApplicationCommandOptionType {
+export enum ApplicationCommandOptionType {
 	SUB_COMMAND = 1,
 	SUB_COMMAND_GROUP,
 	STRING,
@@ -98,7 +98,7 @@ export type APIApplicationCommandInteraction = Required<APIInteraction>;
 /**
  * https://discord.com/developers/docs/interactions/slash-commands#interaction-interactiontype
  */
-export const enum InteractionType {
+export enum InteractionType {
 	Ping = 1,
 	ApplicationCommand,
 }
@@ -156,7 +156,7 @@ export type APIInteractionResponseChannelMessageWithSource = InteractionResponse
 /**
  * https://discord.com/developers/docs/interactions/slash-commands#interaction-interactionresponsetype
  */
-export const enum APIInteractionResponseType {
+export enum APIInteractionResponseType {
 	Pong = 1,
 	Acknowledge,
 	ChannelMessage,

--- a/deno/v8/payloads/invite.ts
+++ b/deno/v8/payloads/invite.ts
@@ -57,7 +57,7 @@ export interface APIInvite {
 /**
  * https://discord.com/developers/docs/resources/invite#invite-object-target-user-types
  */
-export const enum InviteTargetUserType {
+export enum InviteTargetUserType {
 	STREAM = 1,
 }
 

--- a/deno/v8/payloads/oauth2.ts
+++ b/deno/v8/payloads/oauth2.ts
@@ -83,7 +83,7 @@ export interface APIApplication {
 	flags: number;
 }
 
-export const enum OAuth2Scopes {
+export enum OAuth2Scopes {
 	/**
 	 * For oauth2 bots, this puts the bot in the user's selected guild by default
 	 */

--- a/deno/v8/payloads/teams.ts
+++ b/deno/v8/payloads/teams.ts
@@ -56,7 +56,7 @@ export interface APITeamMember {
 /**
  * https://discord.com/developers/docs/topics/teams#data-models-membership-state-enum
  */
-export const enum TeamMemberMembershipState {
+export enum TeamMemberMembershipState {
 	INVITED = 1,
 	ACCEPTED,
 }

--- a/deno/v8/payloads/user.ts
+++ b/deno/v8/payloads/user.ts
@@ -74,7 +74,7 @@ export interface APIUser {
 /**
  * https://discord.com/developers/docs/resources/user#user-object-user-flags
  */
-export const enum UserFlags {
+export enum UserFlags {
 	None = 0,
 	DiscordEmployee = 1 << 0,
 	PartneredServerOwner = 1 << 1,
@@ -94,7 +94,7 @@ export const enum UserFlags {
 /**
  * https://discord.com/developers/docs/resources/user#user-object-premium-types
  */
-export const enum UserPremiumType {
+export enum UserPremiumType {
 	None,
 	NitroClassic,
 	Nitro,
@@ -146,7 +146,7 @@ export interface APIConnection {
 	visibility: ConnectionVisibility;
 }
 
-export const enum ConnectionVisibility {
+export enum ConnectionVisibility {
 	/**
 	 * Invisible to everyone except the user themselves
 	 */

--- a/deno/v8/payloads/webhook.ts
+++ b/deno/v8/payloads/webhook.ts
@@ -53,7 +53,7 @@ export interface APIWebhook {
 	source_channel?: APIPartialChannel;
 }
 
-export const enum WebhookType {
+export enum WebhookType {
 	/**
 	 * Incoming Webhooks can post messages to channels with a generated token
 	 */

--- a/deno/v8/rest/guild.ts
+++ b/deno/v8/rest/guild.ts
@@ -31,7 +31,7 @@ export type APIGuildCreatePartialChannel = Partial<
 > & {
 	name: string;
 	id?: number | string;
-	parent_id?: number | string;
+	parent_id?: number | string | null;
 	permission_overwrites?: APIGuildCreateOverwrite[];
 };
 
@@ -106,7 +106,7 @@ export interface RESTPostAPIGuildsJSONBody {
 	/**
 	 * ID for afk channel
 	 */
-	afk_channel_id?: number | Snowflake;
+	afk_channel_id?: number | Snowflake | null;
 	/**
 	 * AFK timeout in seconds
 	 */
@@ -114,7 +114,7 @@ export interface RESTPostAPIGuildsJSONBody {
 	/**
 	 * The id of the channel where guild notices such as welcome messages and boost events are posted
 	 */
-	system_channel_id?: number | Snowflake;
+	system_channel_id?: number | Snowflake | null;
 	/**
 	 * System channel flags
 	 *

--- a/scripts/deno.mjs
+++ b/scripts/deno.mjs
@@ -31,6 +31,15 @@ function convertImports(source) {
 }
 
 /**
+ * @param {string} source The raw source
+ */
+function convertConstEnums(source) {
+	return source.replace(/const enum/gi, 'enum');
+}
+
+const transformers = [convertImports, convertConstEnums];
+
+/**
  * @param {string} folderName The folder name
  * @param {URL} node The node path
  * @param {URL} deno The deno path
@@ -54,7 +63,9 @@ async function adaptFolderToDeno(folderName, node = baseDirectory, deno = denoPa
 
 		const originalFile = await readFile(fullFilePath, { encoding: 'utf8' });
 
-		await writeFile(finalDenoPath, convertImports(originalFile));
+		const finalFile = transformers.reduce((code, transformer) => transformer(code), originalFile);
+
+		await writeFile(finalDenoPath, finalFile);
 	}
 }
 


### PR DESCRIPTION
AFAIA, Deno does not support `const enum` due to `--isolatedModules` being enabled https://github.com/denoland/deno/discussions/9082#discussioncomment-273198 (possible TypeScript bug)

I have added fixes although I want to be sure that this works. Any Deno reviewers would be extra appreciated.