### PR TITLE
fix(RESTPostAPIGuildsJSONBody): make some fields nullable

### DIFF
--- a/v8/rest/guild.ts
+++ b/v8/rest/guild.ts
@@ -31,7 +31,7 @@ export type APIGuildCreatePartialChannel = Partial<
 > & {
 	name: string;
 	id?: number | string;
-	parent_id?: number | string;
+	parent_id?: number | string | null;
 	permission_overwrites?: APIGuildCreateOverwrite[];
 };
 
@@ -106,7 +106,7 @@ export interface RESTPostAPIGuildsJSONBody {
 	/**
 	 * ID for afk channel
 	 */
-	afk_channel_id?: number | Snowflake;
+	afk_channel_id?: number | Snowflake | null;
 	/**
 	 * AFK timeout in seconds
 	 */
@@ -114,7 +114,7 @@ export interface RESTPostAPIGuildsJSONBody {
 	/**
 	 * The id of the channel where guild notices such as welcome messages and boost events are posted
 	 */
-	system_channel_id?: number | Snowflake;
+	system_channel_id?: number | Snowflake | null;
 	/**
 	 * System channel flags
 	 *


### PR DESCRIPTION
This PR makes `afk_channel_id` and `system_channel_id` in `RESTPostAPIGuildsJSONBody` and `parent_id` in `APIGuildCreatePartialChannel` nullable.

These types are used in the following:

- `RESTPostAPIGuildsJSONBody`: I tested creating a guild using `POST /guilds` with a `null` `afk_channel_id` and `system_channel_id`, and a channel with a null `parent_id`, and it worked.
- `APITemplate` (via `APITemplateSerializedSourceGuild`): The [example template object in the docs](https://discord.com/developers/docs/resources/template#template-object-example-template-object) includes a `null` `afk_channel_id` and a null `parent_id` for a channel. I also tested creating a template from a guild without a system channel and the `system_channel_id` in the returned template object was `null`.
- `RESTPostAPIGuildChannelJSONBody`: I tested creating a channel using `POST /guilds/:id/channels` with a null `parent_id` in the JSON body, and it worked.