### PR TITLE
fix(RESTPostAPIChannelMessageJSONBody): mark `tts` as a full boolean

### DIFF
--- a/deno/v8/rest/channel.ts
+++ b/deno/v8/rest/channel.ts
@@ -162,7 +162,7 @@ export interface RESTPostAPIChannelMessageJSONBody {
 	/**
 	 * `true` if this is a TTS message
 	 */
-	tts?: true;
+	tts?: boolean;
 	/**
 	 * Embedded `rich` content
 	 *

--- a/v8/rest/channel.ts
+++ b/v8/rest/channel.ts
@@ -162,7 +162,7 @@ export interface RESTPostAPIChannelMessageJSONBody {
 	/**
 	 * `true` if this is a TTS message
 	 */
-	tts?: true;
+	tts?: boolean;
 	/**
 	 * Embedded `rich` content
 	 *


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Currently, `APIMessage` is not assignable to `RESTPostAPIChannelMessageJSONBody` due to the latter taking `tts?: true` as a property.

Also, just generally, setting `tts` to false *is* valid, but the typings don't allow for it.