### PR TITLE
fix(TypeScript): imports not working in TypeScript

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+	"plugins": ["@babel/plugin-syntax-top-level-await"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,11 @@ globals.*map
 globals.d.ts
 globals.mjs
 
+v*.js
+v*.*map
+v*.d.ts
+v*.mjs
+
 gateway/**/*.js
 gateway/**/*.map
 gateway/**/*.d.ts

--- a/.npmrc
+++ b/.npmrc
@@ -2,4 +2,4 @@ audit=false
 fund=false
 legacy-peer-deps=true
 tag-version-prefix=""
-message="chore(release): %s :tada:"
+message="chore(release): %s 🎉"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,8 @@
-## [0.15.1](https://github.com/discordjs/discord-api-types/compare/0.14.0...0.15.1) (2021-04-12)
+## [0.15.1](https://github.com/discordjs/discord-api-types/compare/0.15.0...0.15.1) (2021-04-12)
 
 ### Bug Fixes
 
-- **APIApplicationCommand:** default_permission ([#111](https://github.com/discordjs/discord-api-types/issues/111)) ([9420c3e](https://github.com/discordjs/discord-api-types/commit/9420c3e0af7b2486f0e49bb680ed98e0d9f5c625))
 - **TypeScript:** imports not working in TypeScript ([4738c33](https://github.com/discordjs/discord-api-types/commit/4738c33b062d359a1c2fbb35cdd2daf128ab6e5b))
-
-### BREAKING CHANGES
-
-- **APIApplicationCommand:** This renames the `default_permissions` property to `default_permission`, the correct spelling.
 
 # [0.15.0](https://github.com/discordjs/discord-api-types/compare/0.14.0...0.15.0) (2021-04-11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [0.15.1](https://github.com/discordjs/discord-api-types/compare/0.14.0...0.15.1) (2021-04-12)
+
+### Bug Fixes
+
+- **APIApplicationCommand:** default_permission ([#111](https://github.com/discordjs/discord-api-types/issues/111)) ([9420c3e](https://github.com/discordjs/discord-api-types/commit/9420c3e0af7b2486f0e49bb680ed98e0d9f5c625))
+- **TypeScript:** imports not working in TypeScript ([4738c33](https://github.com/discordjs/discord-api-types/commit/4738c33b062d359a1c2fbb35cdd2daf128ab6e5b))
+
+### BREAKING CHANGES
+
+- **APIApplicationCommand:** This renames the `default_permissions` property to `default_permission`, the correct spelling.
+
 # [0.15.0](https://github.com/discordjs/discord-api-types/compare/0.14.0...0.15.0) (2021-04-11)
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -53,21 +53,21 @@ We also provide typings compatible with the [deno](https://deno.land/) runtime. 
 
 ```ts
 // Importing a specific API version
-import { APIUser } from 'https://raw.githubusercontent.com/discordjs/discord-api-types/main/deno/shortcuts/v8/mod.ts';
+import { APIUser } from 'https://raw.githubusercontent.com/discordjs/discord-api-types/main/deno/v8.ts';
 ```
 
 2. From [deno.land/x](https://deno.land/x)
 
 ```ts
 // Importing a specific API version
-import { APIUser } from 'https://deno.land/x/discord_api_types/shortcuts/v8.ts';
+import { APIUser } from 'https://deno.land/x/discord_api_types/v8.ts';
 ```
 
 3. From [skypack.dev](https://www.skypack.dev/)
 
 ```ts
 // Importing a specific API version
-import { APIUser } from 'https://cdn.skypack.dev/discord-api-types/shortcuts/v8?dts';
+import { APIUser } from 'https://cdn.skypack.dev/discord-api-types/v8?dts';
 ```
 
 ## Project Structure

--- a/deno/README.md
+++ b/deno/README.md
@@ -53,21 +53,21 @@ We also provide typings compatible with the [deno](https://deno.land/) runtime. 
 
 ```ts
 // Importing a specific API version
-import { APIUser } from 'https://raw.githubusercontent.com/discordjs/discord-api-types/main/deno/shortcuts/v8/mod.ts';
+import { APIUser } from 'https://raw.githubusercontent.com/discordjs/discord-api-types/main/deno/v8.ts';
 ```
 
 2. From [deno.land/x](https://deno.land/x)
 
 ```ts
 // Importing a specific API version
-import { APIUser } from 'https://deno.land/x/discord_api_types/shortcuts/v8.ts';
+import { APIUser } from 'https://deno.land/x/discord_api_types/v8.ts';
 ```
 
 3. From [skypack.dev](https://www.skypack.dev/)
 
 ```ts
 // Importing a specific API version
-import { APIUser } from 'https://cdn.skypack.dev/discord-api-types/shortcuts/v8?dts';
+import { APIUser } from 'https://cdn.skypack.dev/discord-api-types/v8?dts';
 ```
 
 ## Project Structure

--- a/deno/shortcuts/v6.ts
+++ b/deno/shortcuts/v6.ts
@@ -1,4 +1,0 @@
-export * from '../globals.ts';
-export * from '../gateway/v6.ts';
-export * from '../payloads/v6/mod.ts';
-export * from '../rest/v6/mod.ts';

--- a/deno/shortcuts/v8.ts
+++ b/deno/shortcuts/v8.ts
@@ -1,6 +1,0 @@
-export * from '../globals.ts';
-export * from '../gateway/v8.ts';
-export * from '../payloads/v8/mod.ts';
-export * from '../rest/v8/mod.ts';
-export * from '../rpc/v8.ts';
-export * as Utils from '../utils/v8.ts';

--- a/deno/v6.ts
+++ b/deno/v6.ts
@@ -1,0 +1,4 @@
+export * from './globals.ts';
+export * from './gateway/v6.ts';
+export * from './payloads/v6/mod.ts';
+export * from './rest/v6/mod.ts';

--- a/deno/v8.ts
+++ b/deno/v8.ts
@@ -1,0 +1,6 @@
+export * from './globals.ts';
+export * from './gateway/v8.ts';
+export * from './payloads/v8/mod.ts';
+export * from './rest/v8/mod.ts';
+export * from './rpc/v8.ts';
+export * as Utils from './utils/v8.ts';

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
 			"version": "0.15.0",
 			"license": "MIT",
 			"devDependencies": {
+				"@babel/core": "^7.13.15",
+				"@babel/eslint-parser": "^7.13.14",
+				"@babel/plugin-syntax-top-level-await": "^7.12.13",
 				"@commitlint/cli": "^12.1.1",
 				"@commitlint/config-angular": "^12.1.1",
 				"@types/node": "^14.14.37",
@@ -40,11 +43,270 @@
 				"@babel/highlight": "^7.10.4"
 			}
 		},
+		"node_modules/@babel/compat-data": {
+			"version": "7.13.15",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.15.tgz",
+			"integrity": "sha512-ltnibHKR1VnrU4ymHyQ/CXtNXI6yZC0oJThyW78Hft8XndANwi+9H+UIklBDraIjFEJzw8wmcM427oDd9KS5wA==",
+			"dev": true
+		},
+		"node_modules/@babel/core": {
+			"version": "7.13.15",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.15.tgz",
+			"integrity": "sha512-6GXmNYeNjS2Uz+uls5jalOemgIhnTMeaXo+yBUA72kC2uX/8VW6XyhVIo2L8/q0goKQA3EVKx0KOQpVKSeWadQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/code-frame": "^7.12.13",
+				"@babel/generator": "^7.13.9",
+				"@babel/helper-compilation-targets": "^7.13.13",
+				"@babel/helper-module-transforms": "^7.13.14",
+				"@babel/helpers": "^7.13.10",
+				"@babel/parser": "^7.13.15",
+				"@babel/template": "^7.12.13",
+				"@babel/traverse": "^7.13.15",
+				"@babel/types": "^7.13.14",
+				"convert-source-map": "^1.7.0",
+				"debug": "^4.1.0",
+				"gensync": "^1.0.0-beta.2",
+				"json5": "^2.1.2",
+				"semver": "^6.3.0",
+				"source-map": "^0.5.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/babel"
+			}
+		},
+		"node_modules/@babel/core/node_modules/@babel/code-frame": {
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+			"integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+			"dev": true,
+			"dependencies": {
+				"@babel/highlight": "^7.12.13"
+			}
+		},
+		"node_modules/@babel/core/node_modules/semver": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/@babel/core/node_modules/source-map": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@babel/eslint-parser": {
+			"version": "7.13.14",
+			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.13.14.tgz",
+			"integrity": "sha512-I0HweR36D73Ibn/FfrRDMKlMqJHFwidIUgYdMpH+aXYuQC+waq59YaJ6t9e9N36axJ82v1jR041wwqDrDXEwRA==",
+			"dev": true,
+			"dependencies": {
+				"eslint-scope": "^5.1.0",
+				"eslint-visitor-keys": "^1.3.0",
+				"semver": "^6.3.0"
+			},
+			"engines": {
+				"node": "^10.13.0 || ^12.13.0 || >=14.0.0"
+			},
+			"peerDependencies": {
+				"@babel/core": ">=7.11.0",
+				"eslint": ">=7.5.0"
+			}
+		},
+		"node_modules/@babel/eslint-parser/node_modules/eslint-visitor-keys": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+			"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@babel/eslint-parser/node_modules/semver": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/@babel/generator": {
+			"version": "7.13.9",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
+			"integrity": "sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/types": "^7.13.0",
+				"jsesc": "^2.5.1",
+				"source-map": "^0.5.0"
+			}
+		},
+		"node_modules/@babel/generator/node_modules/source-map": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@babel/helper-compilation-targets": {
+			"version": "7.13.13",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.13.tgz",
+			"integrity": "sha512-q1kcdHNZehBwD9jYPh3WyXcsFERi39X4I59I3NadciWtNDyZ6x+GboOxncFK0kXlKIv6BJm5acncehXWUjWQMQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/compat-data": "^7.13.12",
+				"@babel/helper-validator-option": "^7.12.17",
+				"browserslist": "^4.14.5",
+				"semver": "^6.3.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0"
+			}
+		},
+		"node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/@babel/helper-function-name": {
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
+			"integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-get-function-arity": "^7.12.13",
+				"@babel/template": "^7.12.13",
+				"@babel/types": "^7.12.13"
+			}
+		},
+		"node_modules/@babel/helper-get-function-arity": {
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
+			"integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/types": "^7.12.13"
+			}
+		},
+		"node_modules/@babel/helper-member-expression-to-functions": {
+			"version": "7.13.12",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz",
+			"integrity": "sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/types": "^7.13.12"
+			}
+		},
+		"node_modules/@babel/helper-module-imports": {
+			"version": "7.13.12",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz",
+			"integrity": "sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/types": "^7.13.12"
+			}
+		},
+		"node_modules/@babel/helper-module-transforms": {
+			"version": "7.13.14",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.13.14.tgz",
+			"integrity": "sha512-QuU/OJ0iAOSIatyVZmfqB0lbkVP0kDRiKj34xy+QNsnVZi/PA6BoSoreeqnxxa9EHFAIL0R9XOaAR/G9WlIy5g==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-module-imports": "^7.13.12",
+				"@babel/helper-replace-supers": "^7.13.12",
+				"@babel/helper-simple-access": "^7.13.12",
+				"@babel/helper-split-export-declaration": "^7.12.13",
+				"@babel/helper-validator-identifier": "^7.12.11",
+				"@babel/template": "^7.12.13",
+				"@babel/traverse": "^7.13.13",
+				"@babel/types": "^7.13.14"
+			}
+		},
+		"node_modules/@babel/helper-optimise-call-expression": {
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
+			"integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/types": "^7.12.13"
+			}
+		},
+		"node_modules/@babel/helper-plugin-utils": {
+			"version": "7.13.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz",
+			"integrity": "sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==",
+			"dev": true
+		},
+		"node_modules/@babel/helper-replace-supers": {
+			"version": "7.13.12",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.12.tgz",
+			"integrity": "sha512-Gz1eiX+4yDO8mT+heB94aLVNCL+rbuT2xy4YfyNqu8F+OI6vMvJK891qGBTqL9Uc8wxEvRW92Id6G7sDen3fFw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-member-expression-to-functions": "^7.13.12",
+				"@babel/helper-optimise-call-expression": "^7.12.13",
+				"@babel/traverse": "^7.13.0",
+				"@babel/types": "^7.13.12"
+			}
+		},
+		"node_modules/@babel/helper-simple-access": {
+			"version": "7.13.12",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.13.12.tgz",
+			"integrity": "sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/types": "^7.13.12"
+			}
+		},
+		"node_modules/@babel/helper-split-export-declaration": {
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
+			"integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/types": "^7.12.13"
+			}
+		},
 		"node_modules/@babel/helper-validator-identifier": {
 			"version": "7.12.11",
 			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
 			"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
 			"dev": true
+		},
+		"node_modules/@babel/helper-validator-option": {
+			"version": "7.12.17",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz",
+			"integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw==",
+			"dev": true
+		},
+		"node_modules/@babel/helpers": {
+			"version": "7.13.10",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.10.tgz",
+			"integrity": "sha512-4VO883+MWPDUVRF3PhiLBUFHoX/bsLTGFpFK/HqvvfBZz2D57u9XzPVNFVBTc0PW/CWR9BXTOKt8NF4DInUHcQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/template": "^7.12.13",
+				"@babel/traverse": "^7.13.0",
+				"@babel/types": "^7.13.0"
+			}
 		},
 		"node_modules/@babel/highlight": {
 			"version": "7.13.10",
@@ -117,6 +379,95 @@
 			},
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"node_modules/@babel/parser": {
+			"version": "7.13.15",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.15.tgz",
+			"integrity": "sha512-b9COtcAlVEQljy/9fbcMHpG+UIW9ReF+gpaxDHTlZd0c6/UU9ng8zdySAW9sRTzpvcdCHn6bUcbuYUgGzLAWVQ==",
+			"dev": true,
+			"bin": {
+				"parser": "bin/babel-parser.js"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-top-level-await": {
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.12.13.tgz",
+			"integrity": "sha512-A81F9pDwyS7yM//KwbCSDqy3Uj4NMIurtplxphWxoYtNPov7cJsDkAFNNyVlIZ3jwGycVsurZ+LtOA8gZ376iQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.12.13"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/template": {
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
+			"integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/code-frame": "^7.12.13",
+				"@babel/parser": "^7.12.13",
+				"@babel/types": "^7.12.13"
+			}
+		},
+		"node_modules/@babel/template/node_modules/@babel/code-frame": {
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+			"integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+			"dev": true,
+			"dependencies": {
+				"@babel/highlight": "^7.12.13"
+			}
+		},
+		"node_modules/@babel/traverse": {
+			"version": "7.13.15",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.15.tgz",
+			"integrity": "sha512-/mpZMNvj6bce59Qzl09fHEs8Bt8NnpEDQYleHUPZQ3wXUMvXi+HJPLars68oAbmp839fGoOkv2pSL2z9ajCIaQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/code-frame": "^7.12.13",
+				"@babel/generator": "^7.13.9",
+				"@babel/helper-function-name": "^7.12.13",
+				"@babel/helper-split-export-declaration": "^7.12.13",
+				"@babel/parser": "^7.13.15",
+				"@babel/types": "^7.13.14",
+				"debug": "^4.1.0",
+				"globals": "^11.1.0"
+			}
+		},
+		"node_modules/@babel/traverse/node_modules/@babel/code-frame": {
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+			"integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+			"dev": true,
+			"dependencies": {
+				"@babel/highlight": "^7.12.13"
+			}
+		},
+		"node_modules/@babel/traverse/node_modules/globals": {
+			"version": "11.12.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@babel/types": {
+			"version": "7.13.14",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.14.tgz",
+			"integrity": "sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-validator-identifier": "^7.12.11",
+				"lodash": "^4.17.19",
+				"to-fast-properties": "^2.0.0"
 			}
 		},
 		"node_modules/@commitlint/cli": {
@@ -841,6 +1192,29 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/browserslist": {
+			"version": "4.16.3",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.3.tgz",
+			"integrity": "sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==",
+			"dev": true,
+			"dependencies": {
+				"caniuse-lite": "^1.0.30001181",
+				"colorette": "^1.2.1",
+				"electron-to-chromium": "^1.3.649",
+				"escalade": "^3.1.1",
+				"node-releases": "^1.1.70"
+			},
+			"bin": {
+				"browserslist": "cli.js"
+			},
+			"engines": {
+				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/browserslist"
+			}
+		},
 		"node_modules/call-bind": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -888,6 +1262,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/caniuse-lite": {
+			"version": "1.0.30001208",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001208.tgz",
+			"integrity": "sha512-OE5UE4+nBOro8Dyvv0lfx+SRtfVIOM9uhKqFmJeUbGriqhhStgp1A0OyBpgy3OUF8AhYCT+PVwPC1gMl2ZcQMA==",
+			"dev": true
 		},
 		"node_modules/chalk": {
 			"version": "4.1.0",
@@ -975,6 +1355,12 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
+		},
+		"node_modules/colorette": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+			"integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
 			"dev": true
 		},
 		"node_modules/commander": {
@@ -1343,6 +1729,21 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/convert-source-map": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+			"integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+			"dev": true,
+			"dependencies": {
+				"safe-buffer": "~5.1.1"
+			}
+		},
+		"node_modules/convert-source-map/node_modules/safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true
+		},
 		"node_modules/core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -1516,6 +1917,12 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/electron-to-chromium": {
+			"version": "1.3.712",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.712.tgz",
+			"integrity": "sha512-3kRVibBeCM4vsgoHHGKHmPocLqtFAGTrebXxxtgKs87hNUzXrX2NuS3jnBys7IozCnw7viQlozxKkmty2KNfrw==",
+			"dev": true
 		},
 		"node_modules/emoji-regex": {
 			"version": "8.0.0",
@@ -2070,6 +2477,15 @@
 			},
 			"bin": {
 				"gen-esm-wrapper": "gen-esm-wrapper.js"
+			}
+		},
+		"node_modules/gensync": {
+			"version": "1.0.0-beta.2",
+			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+			"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/get-caller-file": {
@@ -3089,6 +3505,18 @@
 				"js-yaml": "bin/js-yaml.js"
 			}
 		},
+		"node_modules/jsesc": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+			"dev": true,
+			"bin": {
+				"jsesc": "bin/jsesc"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/json-parse-better-errors": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -3118,6 +3546,21 @@
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
 			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
 			"dev": true
+		},
+		"node_modules/json5": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+			"integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+			"dev": true,
+			"dependencies": {
+				"minimist": "^1.2.5"
+			},
+			"bin": {
+				"json5": "lib/cli.js"
+			},
+			"engines": {
+				"node": ">=6"
+			}
 		},
 		"node_modules/jsonfile": {
 			"version": "6.1.0",
@@ -3578,6 +4021,12 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+			"dev": true
+		},
+		"node_modules/node-releases": {
+			"version": "1.1.71",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.71.tgz",
+			"integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==",
 			"dev": true
 		},
 		"node_modules/normalize-package-data": {
@@ -5109,6 +5558,15 @@
 				"readable-stream": "3"
 			}
 		},
+		"node_modules/to-fast-properties": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -5444,11 +5902,243 @@
 				"@babel/highlight": "^7.10.4"
 			}
 		},
+		"@babel/compat-data": {
+			"version": "7.13.15",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.15.tgz",
+			"integrity": "sha512-ltnibHKR1VnrU4ymHyQ/CXtNXI6yZC0oJThyW78Hft8XndANwi+9H+UIklBDraIjFEJzw8wmcM427oDd9KS5wA==",
+			"dev": true
+		},
+		"@babel/core": {
+			"version": "7.13.15",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.15.tgz",
+			"integrity": "sha512-6GXmNYeNjS2Uz+uls5jalOemgIhnTMeaXo+yBUA72kC2uX/8VW6XyhVIo2L8/q0goKQA3EVKx0KOQpVKSeWadQ==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.12.13",
+				"@babel/generator": "^7.13.9",
+				"@babel/helper-compilation-targets": "^7.13.13",
+				"@babel/helper-module-transforms": "^7.13.14",
+				"@babel/helpers": "^7.13.10",
+				"@babel/parser": "^7.13.15",
+				"@babel/template": "^7.12.13",
+				"@babel/traverse": "^7.13.15",
+				"@babel/types": "^7.13.14",
+				"convert-source-map": "^1.7.0",
+				"debug": "^4.1.0",
+				"gensync": "^1.0.0-beta.2",
+				"json5": "^2.1.2",
+				"semver": "^6.3.0",
+				"source-map": "^0.5.0"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+					"integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.12.13"
+					}
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
+			}
+		},
+		"@babel/eslint-parser": {
+			"version": "7.13.14",
+			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.13.14.tgz",
+			"integrity": "sha512-I0HweR36D73Ibn/FfrRDMKlMqJHFwidIUgYdMpH+aXYuQC+waq59YaJ6t9e9N36axJ82v1jR041wwqDrDXEwRA==",
+			"dev": true,
+			"requires": {
+				"eslint-scope": "^5.1.0",
+				"eslint-visitor-keys": "^1.3.0",
+				"semver": "^6.3.0"
+			},
+			"dependencies": {
+				"eslint-visitor-keys": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+					"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+					"dev": true
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/generator": {
+			"version": "7.13.9",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
+			"integrity": "sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.13.0",
+				"jsesc": "^2.5.1",
+				"source-map": "^0.5.0"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
+			}
+		},
+		"@babel/helper-compilation-targets": {
+			"version": "7.13.13",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.13.tgz",
+			"integrity": "sha512-q1kcdHNZehBwD9jYPh3WyXcsFERi39X4I59I3NadciWtNDyZ6x+GboOxncFK0kXlKIv6BJm5acncehXWUjWQMQ==",
+			"dev": true,
+			"requires": {
+				"@babel/compat-data": "^7.13.12",
+				"@babel/helper-validator-option": "^7.12.17",
+				"browserslist": "^4.14.5",
+				"semver": "^6.3.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/helper-function-name": {
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
+			"integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-get-function-arity": "^7.12.13",
+				"@babel/template": "^7.12.13",
+				"@babel/types": "^7.12.13"
+			}
+		},
+		"@babel/helper-get-function-arity": {
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
+			"integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.12.13"
+			}
+		},
+		"@babel/helper-member-expression-to-functions": {
+			"version": "7.13.12",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz",
+			"integrity": "sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.13.12"
+			}
+		},
+		"@babel/helper-module-imports": {
+			"version": "7.13.12",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz",
+			"integrity": "sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.13.12"
+			}
+		},
+		"@babel/helper-module-transforms": {
+			"version": "7.13.14",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.13.14.tgz",
+			"integrity": "sha512-QuU/OJ0iAOSIatyVZmfqB0lbkVP0kDRiKj34xy+QNsnVZi/PA6BoSoreeqnxxa9EHFAIL0R9XOaAR/G9WlIy5g==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-module-imports": "^7.13.12",
+				"@babel/helper-replace-supers": "^7.13.12",
+				"@babel/helper-simple-access": "^7.13.12",
+				"@babel/helper-split-export-declaration": "^7.12.13",
+				"@babel/helper-validator-identifier": "^7.12.11",
+				"@babel/template": "^7.12.13",
+				"@babel/traverse": "^7.13.13",
+				"@babel/types": "^7.13.14"
+			}
+		},
+		"@babel/helper-optimise-call-expression": {
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
+			"integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.12.13"
+			}
+		},
+		"@babel/helper-plugin-utils": {
+			"version": "7.13.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz",
+			"integrity": "sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==",
+			"dev": true
+		},
+		"@babel/helper-replace-supers": {
+			"version": "7.13.12",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.12.tgz",
+			"integrity": "sha512-Gz1eiX+4yDO8mT+heB94aLVNCL+rbuT2xy4YfyNqu8F+OI6vMvJK891qGBTqL9Uc8wxEvRW92Id6G7sDen3fFw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-member-expression-to-functions": "^7.13.12",
+				"@babel/helper-optimise-call-expression": "^7.12.13",
+				"@babel/traverse": "^7.13.0",
+				"@babel/types": "^7.13.12"
+			}
+		},
+		"@babel/helper-simple-access": {
+			"version": "7.13.12",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.13.12.tgz",
+			"integrity": "sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.13.12"
+			}
+		},
+		"@babel/helper-split-export-declaration": {
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
+			"integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.12.13"
+			}
+		},
 		"@babel/helper-validator-identifier": {
 			"version": "7.12.11",
 			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
 			"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
 			"dev": true
+		},
+		"@babel/helper-validator-option": {
+			"version": "7.12.17",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz",
+			"integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw==",
+			"dev": true
+		},
+		"@babel/helpers": {
+			"version": "7.13.10",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.10.tgz",
+			"integrity": "sha512-4VO883+MWPDUVRF3PhiLBUFHoX/bsLTGFpFK/HqvvfBZz2D57u9XzPVNFVBTc0PW/CWR9BXTOKt8NF4DInUHcQ==",
+			"dev": true,
+			"requires": {
+				"@babel/template": "^7.12.13",
+				"@babel/traverse": "^7.13.0",
+				"@babel/types": "^7.13.0"
+			}
 		},
 		"@babel/highlight": {
 			"version": "7.13.10",
@@ -5511,6 +6201,87 @@
 						"has-flag": "^3.0.0"
 					}
 				}
+			}
+		},
+		"@babel/parser": {
+			"version": "7.13.15",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.15.tgz",
+			"integrity": "sha512-b9COtcAlVEQljy/9fbcMHpG+UIW9ReF+gpaxDHTlZd0c6/UU9ng8zdySAW9sRTzpvcdCHn6bUcbuYUgGzLAWVQ==",
+			"dev": true
+		},
+		"@babel/plugin-syntax-top-level-await": {
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.12.13.tgz",
+			"integrity": "sha512-A81F9pDwyS7yM//KwbCSDqy3Uj4NMIurtplxphWxoYtNPov7cJsDkAFNNyVlIZ3jwGycVsurZ+LtOA8gZ376iQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.12.13"
+			}
+		},
+		"@babel/template": {
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
+			"integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.12.13",
+				"@babel/parser": "^7.12.13",
+				"@babel/types": "^7.12.13"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+					"integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.12.13"
+					}
+				}
+			}
+		},
+		"@babel/traverse": {
+			"version": "7.13.15",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.15.tgz",
+			"integrity": "sha512-/mpZMNvj6bce59Qzl09fHEs8Bt8NnpEDQYleHUPZQ3wXUMvXi+HJPLars68oAbmp839fGoOkv2pSL2z9ajCIaQ==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.12.13",
+				"@babel/generator": "^7.13.9",
+				"@babel/helper-function-name": "^7.12.13",
+				"@babel/helper-split-export-declaration": "^7.12.13",
+				"@babel/parser": "^7.13.15",
+				"@babel/types": "^7.13.14",
+				"debug": "^4.1.0",
+				"globals": "^11.1.0"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+					"integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.12.13"
+					}
+				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/types": {
+			"version": "7.13.14",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.14.tgz",
+			"integrity": "sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-validator-identifier": "^7.12.11",
+				"lodash": "^4.17.19",
+				"to-fast-properties": "^2.0.0"
 			}
 		},
 		"@commitlint/cli": {
@@ -6029,6 +6800,19 @@
 				"fill-range": "^7.0.1"
 			}
 		},
+		"browserslist": {
+			"version": "4.16.3",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.3.tgz",
+			"integrity": "sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==",
+			"dev": true,
+			"requires": {
+				"caniuse-lite": "^1.0.30001181",
+				"colorette": "^1.2.1",
+				"electron-to-chromium": "^1.3.649",
+				"escalade": "^3.1.1",
+				"node-releases": "^1.1.70"
+			}
+		},
 		"call-bind": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -6061,6 +6845,12 @@
 				"map-obj": "^4.0.0",
 				"quick-lru": "^4.0.1"
 			}
+		},
+		"caniuse-lite": {
+			"version": "1.0.30001208",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001208.tgz",
+			"integrity": "sha512-OE5UE4+nBOro8Dyvv0lfx+SRtfVIOM9uhKqFmJeUbGriqhhStgp1A0OyBpgy3OUF8AhYCT+PVwPC1gMl2ZcQMA==",
+			"dev": true
 		},
 		"chalk": {
 			"version": "4.1.0",
@@ -6127,6 +6917,12 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
+		},
+		"colorette": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+			"integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
 			"dev": true
 		},
 		"commander": {
@@ -6415,6 +7211,23 @@
 				"trim-off-newlines": "^1.0.0"
 			}
 		},
+		"convert-source-map": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+			"integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "~5.1.1"
+			},
+			"dependencies": {
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+					"dev": true
+				}
+			}
+		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -6546,6 +7359,12 @@
 			"requires": {
 				"is-obj": "^2.0.0"
 			}
+		},
+		"electron-to-chromium": {
+			"version": "1.3.712",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.712.tgz",
+			"integrity": "sha512-3kRVibBeCM4vsgoHHGKHmPocLqtFAGTrebXxxtgKs87hNUzXrX2NuS3jnBys7IozCnw7viQlozxKkmty2KNfrw==",
+			"dev": true
 		},
 		"emoji-regex": {
 			"version": "8.0.0",
@@ -6970,6 +7789,12 @@
 			"requires": {
 				"is-valid-identifier": "^2.0.2"
 			}
+		},
+		"gensync": {
+			"version": "1.0.0-beta.2",
+			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+			"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+			"dev": true
 		},
 		"get-caller-file": {
 			"version": "2.0.5",
@@ -7714,6 +8539,12 @@
 				"esprima": "^4.0.0"
 			}
 		},
+		"jsesc": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+			"dev": true
+		},
 		"json-parse-better-errors": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -7743,6 +8574,15 @@
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
 			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
 			"dev": true
+		},
+		"json5": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+			"integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+			"dev": true,
+			"requires": {
+				"minimist": "^1.2.5"
+			}
 		},
 		"jsonfile": {
 			"version": "6.1.0",
@@ -8095,6 +8935,12 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+			"dev": true
+		},
+		"node-releases": {
+			"version": "1.1.71",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.71.tgz",
+			"integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==",
 			"dev": true
 		},
 		"normalize-package-data": {
@@ -9208,6 +10054,12 @@
 			"requires": {
 				"readable-stream": "3"
 			}
+		},
+		"to-fast-properties": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+			"dev": true
 		},
 		"to-regex-range": {
 			"version": "5.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
 	"name": "discord-api-types",
-	"version": "0.15.0",
+	"version": "0.15.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"version": "0.15.0",
+			"version": "0.15.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@babel/core": "^7.13.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "discord-api-types",
-	"version": "0.15.0",
+	"version": "0.15.1",
 	"description": "Discord API typings that are kept up to date for use in bot library creation.",
 	"main": "./v8.js",
 	"module": "./v8.mjs",

--- a/package.json
+++ b/package.json
@@ -2,21 +2,21 @@
 	"name": "discord-api-types",
 	"version": "0.15.0",
 	"description": "Discord API typings that are kept up to date for use in bot library creation.",
-	"main": "./shortcuts/v8.js",
-	"module": "./shortcuts/v8.mjs",
-	"types": "./shortcuts/v8.d.ts",
+	"main": "./v8.js",
+	"module": "./v8.mjs",
+	"types": "./v8.d.ts",
 	"exports": {
 		"./globals": {
 			"require": "./globals.js",
 			"import": "./globals.mjs"
 		},
 		"./v6": {
-			"require": "./shortcuts/v6.js",
-			"import": "./shortcuts/v6.mjs"
+			"require": "./v6.js",
+			"import": "./v6.mjs"
 		},
 		"./v8": {
-			"require": "./shortcuts/v8.js",
-			"import": "./shortcuts/v8.mjs"
+			"require": "./v8.js",
+			"import": "./v8.mjs"
 		},
 		"./gateway": {
 			"require": "./gateway/index.js",
@@ -72,7 +72,7 @@
 		"build:deno": "node ./scripts/deno.mjs",
 		"build:node": "tsc && run-p esm:*",
 		"clean:deno": "rimraf deno/",
-		"clean:node": "rimraf {gateway,payloads,rest,rpc,voice,shortcuts,utils}/**/*.{js,mjs,d.ts,map} globals.{js,mjs,d.ts,*map}",
+		"clean:node": "rimraf {gateway,payloads,rest,rpc,voice,utils}/**/*.{js,mjs,d.ts,map} {globals,v*}.{js,mjs,d.ts,*map}",
 		"clean": "run-p clean:*",
 		"esm:gateway": "gen-esm-wrapper ./gateway/index.js ./gateway/index.mjs",
 		"esm:payloads": "gen-esm-wrapper ./payloads/index.js ./payloads/index.mjs",
@@ -82,8 +82,8 @@
 		"esm:voice": "gen-esm-wrapper ./voice/index.js ./voice/index.mjs",
 		"esm:globals": "gen-esm-wrapper ./globals.js ./globals.mjs",
 		"esm:versions": "node ./scripts/versions.mjs",
-		"lint": "eslint --fix --ext mjs,ts {gateway,payloads,rest,rpc,voice,shortcuts,utils}/** globals.ts",
-		"test:lint": "eslint --ext mjs,ts {gateway,payloads,rest,rpc,voice,shortcuts,utils}/** globals.ts",
+		"lint": "eslint --fix --ext mjs,ts {gateway,payloads,rest,rpc,voice,utils}/** {globals,v*}.ts",
+		"test:lint": "eslint --ext mjs,ts {gateway,payloads,rest,rpc,voice,utils}/** {globals,v*}.ts",
 		"prepublishOnly": "run-s clean test:lint build:node",
 		"postpublish": "run-s clean:node build:deno",
 		"version": "conventional-changelog -p angular -i CHANGELOG.md -s && git add CHANGELOG.md"
@@ -97,13 +97,16 @@
 	"author": "Vlad Frangu <kingdgrizzle@gmail.com>",
 	"license": "MIT",
 	"files": [
-		"{gateway,payloads,rest,rpc,voice,shortcuts,utils}/**/*.{js,js.map,d.ts,d.ts.map,mjs}",
-		"globals.{js,js.map,d.ts,d.ts.map,mjs}"
+		"{gateway,payloads,rest,rpc,voice,utils}/**/*.{js,js.map,d.ts,d.ts.map,mjs}",
+		"{globals,v*}.{js,js.map,d.ts,d.ts.map,mjs}"
 	],
 	"engines": {
 		"node": ">=12"
 	},
 	"devDependencies": {
+		"@babel/core": "^7.13.15",
+		"@babel/eslint-parser": "^7.13.14",
+		"@babel/plugin-syntax-top-level-await": "^7.12.13",
 		"@commitlint/cli": "^12.1.1",
 		"@commitlint/config-angular": "^12.1.1",
 		"@types/node": "^14.14.37",
@@ -143,7 +146,9 @@
 				"files": [
 					"scripts/**/*.mjs"
 				],
+				"parser": "@babel/eslint-parser",
 				"parserOptions": {
+					"ecmaVersion": 2021,
 					"sourceType": "module"
 				}
 			}

--- a/scripts/versions.mjs
+++ b/scripts/versions.mjs
@@ -9,7 +9,7 @@ const rootDir = join(__dirname, '..');
 const execAsync = promisify(exec);
 
 const fileToESMWrapperCall = (path, version) =>
-	execAsync(`npx gen-esm-wrapper ${rootDir}${path}/${version}.js ${rootDir}${path}/${version}.mjs`);
+	execAsync(`npx gen-esm-wrapper "${join(rootDir, path, `${version}.js`)}" "${join(rootDir, path, `${version}.mjs`)}"`);
 
 await Promise.allSettled(
 	[
@@ -20,18 +20,18 @@ await Promise.allSettled(
 		'v4',
 	]
 		.map((version) => [
-			fileToESMWrapperCall('/gateway', version),
-			fileToESMWrapperCall(`/payloads/${version}`, 'index'),
-			fileToESMWrapperCall(`/rest/${version}`, 'index'),
+			fileToESMWrapperCall('gateway', version),
+			fileToESMWrapperCall(`payloads/${version}`, 'index'),
+			fileToESMWrapperCall(`rest/${version}`, 'index'),
 
 			// Voice
-			fileToESMWrapperCall('/voice', version),
+			fileToESMWrapperCall('voice', version),
 
 			// RPC
-			fileToESMWrapperCall('/rpc', version),
+			fileToESMWrapperCall('rpc', version),
 
 			// Utils
-			fileToESMWrapperCall('/utils', version),
+			fileToESMWrapperCall('utils', version),
 
 			// Shortcuts
 			fileToESMWrapperCall('', version),

--- a/scripts/versions.mjs
+++ b/scripts/versions.mjs
@@ -1,10 +1,15 @@
 import { exec } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
 
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const rootDir = join(__dirname, '..');
 const execAsync = promisify(exec);
 
 const fileToESMWrapperCall = (path, version) =>
-	execAsync(`npx gen-esm-wrapper ./${path}/${version}.js ./${path}/${version}.mjs`);
+	execAsync(`npx gen-esm-wrapper ${rootDir}${path}/${version}.js ${rootDir}${path}/${version}.mjs`);
 
 await Promise.allSettled(
 	[
@@ -15,21 +20,21 @@ await Promise.allSettled(
 		'v4',
 	]
 		.map((version) => [
-			fileToESMWrapperCall('gateway', version),
-			fileToESMWrapperCall(`payloads/${version}`, 'index'),
-			fileToESMWrapperCall(`rest/${version}`, 'index'),
+			fileToESMWrapperCall('/gateway', version),
+			fileToESMWrapperCall(`/payloads/${version}`, 'index'),
+			fileToESMWrapperCall(`/rest/${version}`, 'index'),
 
 			// Voice
-			fileToESMWrapperCall('voice', version),
+			fileToESMWrapperCall('/voice', version),
 
 			// RPC
-			fileToESMWrapperCall('rpc', version),
+			fileToESMWrapperCall('/rpc', version),
 
 			// Utils
-			fileToESMWrapperCall('utils', version),
+			fileToESMWrapperCall('/utils', version),
 
 			// Shortcuts
-			fileToESMWrapperCall('owo/..', version),
+			fileToESMWrapperCall('', version),
 		])
 		.flat(),
 );

--- a/scripts/versions.mjs
+++ b/scripts/versions.mjs
@@ -29,7 +29,7 @@ await Promise.allSettled(
 			fileToESMWrapperCall('utils', version),
 
 			// Shortcuts
-			fileToESMWrapperCall('shortcuts', version),
+			fileToESMWrapperCall('owo/..', version),
 		])
 		.flat(),
 );

--- a/shortcuts/v6.ts
+++ b/shortcuts/v6.ts
@@ -1,4 +1,0 @@
-export * from '../globals';
-export * from '../gateway/v6';
-export * from '../payloads/v6/index';
-export * from '../rest/v6/index';

--- a/shortcuts/v8.ts
+++ b/shortcuts/v8.ts
@@ -1,6 +1,0 @@
-export * from '../globals';
-export * from '../gateway/v8';
-export * from '../payloads/v8/index';
-export * from '../rest/v8/index';
-export * from '../rpc/v8';
-export * as Utils from '../utils/v8';

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -6,11 +6,12 @@
 	},
 	"include": [
 		"globals.ts",
+		"v6.ts",
+		"v8.ts",
 		"gateway/**/*.ts",
 		"payloads/**/*.ts",
 		"rest/**/*.ts",
 		"rpc/**/*.ts",
-		"shortcuts/**/*.ts",
 		"utils/**/*.ts",
 		"voice/**/*.ts",
 		"scripts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,11 +17,12 @@
 	},
 	"include": [
 		"globals.ts",
+		"v6.ts",
+		"v8.ts",
 		"gateway/**/*.ts",
 		"payloads/**/*.ts",
 		"rest/**/*.ts",
 		"rpc/**/*.ts",
-		"shortcuts/**/*.ts",
 		"utils/**/*.ts",
 		"voice/**/*.ts"
 	]

--- a/v6.ts
+++ b/v6.ts
@@ -1,0 +1,4 @@
+export * from './globals';
+export * from './gateway/v6';
+export * from './payloads/v6/index';
+export * from './rest/v6/index';

--- a/v8.ts
+++ b/v8.ts
@@ -1,0 +1,6 @@
+export * from './globals';
+export * from './gateway/v8';
+export * from './payloads/v8/index';
+export * from './rest/v8/index';
+export * from './rpc/v8';
+export * as Utils from './utils/v8';


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

While the node.js exports work perfectly fine, TypeScript doesn't parse those.
As such, TS users would get an error when importing the module.
Alongside that, this commit fixes eslint for mjs files,
which need @babel to process TLA

**Reference Discord API Docs PRs or commits:**

N/A