### PR TITLE
fix(APIChannel): `rtc_region` is optional

### DIFF
--- a/deno/payloads/v8/channel.ts
+++ b/deno/payloads/v8/channel.ts
@@ -105,7 +105,7 @@ export interface APIChannel extends APIPartialChannel {
 	 *
 	 * See https://discord.com/developers/docs/resources/voice#voice-region-object
 	 */
-	rtc_region: string | null;
+	rtc_region?: string | null;
 	/**
 	 * The camera video quality mode of the voice channel, `1` when not present
 	 *

--- a/payloads/v8/channel.ts
+++ b/payloads/v8/channel.ts
@@ -105,7 +105,7 @@ export interface APIChannel extends APIPartialChannel {
 	 *
 	 * See https://discord.com/developers/docs/resources/voice#voice-region-object
 	 */
-	rtc_region: string | null;
+	rtc_region?: string | null;
 	/**
 	 * The camera video quality mode of the voice channel, `1` when not present
 	 *


### PR DESCRIPTION
**Reference Discord API Docs PRs or commits:**

https://discord.com/developers/docs/resources/guild#guild-object