### PR TITLE
fix(APIInvite): `channel` is not optional

### DIFF
--- a/deno/payloads/v8/invite.ts
+++ b/deno/payloads/v8/invite.ts
@@ -26,7 +26,7 @@ export interface APIInvite {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#channel-object
 	 */
-	channel?: Required<APIPartialChannel>;
+	channel: Required<APIPartialChannel>;
 	/**
 	 * The user who created the invite
 	 *

--- a/payloads/v8/invite.ts
+++ b/payloads/v8/invite.ts
@@ -26,7 +26,7 @@ export interface APIInvite {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#channel-object
 	 */
-	channel?: Required<APIPartialChannel>;
+	channel: Required<APIPartialChannel>;
 	/**
 	 * The user who created the invite
 	 *


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`APIInvite#channel` was marked as optional for some reason but it is not

**Reference Discord API Docs PRs or commits:**
https://discord.com/developers/docs/resources/invite