### PR TITLE
feat: add new interfaces for interaction-related structures

### DIFF
--- a/deno/payloads/v8/interactions.ts
+++ b/deno/payloads/v8/interactions.ts
@@ -100,21 +100,6 @@ export interface APIApplicationCommandOptionChoice {
 }
 
 /**
- * https://discord.com/developers/docs/resources/channel#channel-object
- */
-export interface APIInteractionChannel extends Required<APIPartialChannel> {
-	permissions: Permissions;
-}
-
-/**
- * https://discord.com/developers/docs/resources/guild#guild-member-object
- */
-export interface APIInteractionGuildMember extends APIGuildMember {
-	permissions: Permissions;
-	user: APIUser;
-}
-
-/**
  * https://discord.com/developers/docs/interactions/slash-commands#interaction
  */
 export interface APIBaseInteraction {
@@ -146,6 +131,14 @@ export interface APIBaseInteraction {
 	 * Read-only property, always `1`
 	 */
 	version: 1;
+}
+
+/**
+ * https://discord.com/developers/docs/resources/guild#guild-member-object
+ */
+export interface APIInteractionGuildMember extends APIGuildMember {
+	permissions: Permissions;
+	user: APIUser;
 }
 
 /**
@@ -261,6 +254,20 @@ export enum ApplicationCommandPermissionType {
 }
 
 /**
+ * https://discord.com/developers/docs/resources/channel#channel-object
+ */
+export interface APIInteractionDataResolvedChannel extends Required<APIPartialChannel> {
+	permissions: Permissions;
+}
+
+/**
+ * https://discord.com/developers/docs/resources/guild#guild-member-object
+ */
+export interface APIInteractionDataResolvedGuildMember extends Omit<APIGuildMember, 'user' | 'deaf' | 'mute'> {
+	permissions: Permissions;
+}
+
+/**
  * https://discord.com/developers/docs/interactions/slash-commands#interaction-applicationcommandinteractiondata
  */
 export interface APIApplicationCommandInteractionData {
@@ -270,8 +277,8 @@ export interface APIApplicationCommandInteractionData {
 	resolved?: {
 		users?: Record<string, APIUser>;
 		roles?: Record<string, APIRole>;
-		members?: Record<string, Omit<APIInteractionGuildMember, 'user' | 'deaf' | 'mute'>>;
-		channels?: Record<string, APIInteractionChannel>;
+		members?: Record<string, APIInteractionDataResolvedGuildMember>;
+		channels?: Record<string, APIInteractionDataResolvedChannel>;
 	};
 }
 

--- a/deno/payloads/v8/interactions.ts
+++ b/deno/payloads/v8/interactions.ts
@@ -100,6 +100,21 @@ export interface APIApplicationCommandOptionChoice {
 }
 
 /**
+ * https://discord.com/developers/docs/resources/channel#channel-object
+ */
+export interface APIInteractionChannel extends Required<APIPartialChannel> {
+	permissions: Permissions;
+}
+
+/**
+ * https://discord.com/developers/docs/resources/guild#guild-member-object
+ */
+export interface APIInteractionGuildMember extends APIGuildMember {
+	permissions: Permissions;
+	user: APIUser;
+}
+
+/**
  * https://discord.com/developers/docs/interactions/slash-commands#interaction
  */
 export interface APIBaseInteraction {
@@ -146,7 +161,7 @@ export interface APIGuildInteraction extends APIBaseInteraction {
 	/**
 	 * Guild member data for the invoking user, including permissions
 	 */
-	member: APIGuildMember & { permissions: Permissions; user: APIUser };
+	member: APIInteractionGuildMember;
 	channel_id: Snowflake;
 }
 
@@ -255,8 +270,8 @@ export interface APIApplicationCommandInteractionData {
 	resolved?: {
 		users?: Record<string, APIUser>;
 		roles?: Record<string, APIRole>;
-		members?: Record<string, Omit<APIGuildMember, 'user' | 'deaf' | 'mute'> & { permissions: Permissions }>;
-		channels?: Record<string, Required<APIPartialChannel> & { permissions: Permissions }>;
+		members?: Record<string, Omit<APIInteractionGuildMember, 'user' | 'deaf' | 'mute'>>;
+		channels?: Record<string, APIInteractionChannel>;
 	};
 }
 

--- a/payloads/v8/interactions.ts
+++ b/payloads/v8/interactions.ts
@@ -100,6 +100,21 @@ export interface APIApplicationCommandOptionChoice {
 }
 
 /**
+ * https://discord.com/developers/docs/resources/channel#channel-object
+ */
+export interface APIInteractionChannel extends Required<APIPartialChannel> {
+	permissions: Permissions;
+}
+
+/**
+ * https://discord.com/developers/docs/resources/guild#guild-member-object
+ */
+export interface APIInteractionGuildMember extends APIGuildMember {
+	permissions: Permissions;
+	user: APIUser;
+}
+
+/**
  * https://discord.com/developers/docs/interactions/slash-commands#interaction
  */
 export interface APIBaseInteraction {
@@ -146,7 +161,7 @@ export interface APIGuildInteraction extends APIBaseInteraction {
 	/**
 	 * Guild member data for the invoking user, including permissions
 	 */
-	member: APIGuildMember & { permissions: Permissions; user: APIUser };
+	member: APIInteractionGuildMember;
 	channel_id: Snowflake;
 }
 
@@ -255,8 +270,8 @@ export interface APIApplicationCommandInteractionData {
 	resolved?: {
 		users?: Record<string, APIUser>;
 		roles?: Record<string, APIRole>;
-		members?: Record<string, Omit<APIGuildMember, 'user' | 'deaf' | 'mute'> & { permissions: Permissions }>;
-		channels?: Record<string, Required<APIPartialChannel> & { permissions: Permissions }>;
+		members?: Record<string, Omit<APIInteractionGuildMember, 'user' | 'deaf' | 'mute'>>;
+		channels?: Record<string, APIInteractionChannel>;
 	};
 }
 

--- a/payloads/v8/interactions.ts
+++ b/payloads/v8/interactions.ts
@@ -100,21 +100,6 @@ export interface APIApplicationCommandOptionChoice {
 }
 
 /**
- * https://discord.com/developers/docs/resources/channel#channel-object
- */
-export interface APIInteractionChannel extends Required<APIPartialChannel> {
-	permissions: Permissions;
-}
-
-/**
- * https://discord.com/developers/docs/resources/guild#guild-member-object
- */
-export interface APIInteractionGuildMember extends APIGuildMember {
-	permissions: Permissions;
-	user: APIUser;
-}
-
-/**
  * https://discord.com/developers/docs/interactions/slash-commands#interaction
  */
 export interface APIBaseInteraction {
@@ -146,6 +131,14 @@ export interface APIBaseInteraction {
 	 * Read-only property, always `1`
 	 */
 	version: 1;
+}
+
+/**
+ * https://discord.com/developers/docs/resources/guild#guild-member-object
+ */
+export interface APIInteractionGuildMember extends APIGuildMember {
+	permissions: Permissions;
+	user: APIUser;
 }
 
 /**
@@ -261,6 +254,20 @@ export const enum ApplicationCommandPermissionType {
 }
 
 /**
+ * https://discord.com/developers/docs/resources/channel#channel-object
+ */
+export interface APIInteractionDataResolvedChannel extends Required<APIPartialChannel> {
+	permissions: Permissions;
+}
+
+/**
+ * https://discord.com/developers/docs/resources/guild#guild-member-object
+ */
+export interface APIInteractionDataResolvedGuildMember extends Omit<APIGuildMember, 'user' | 'deaf' | 'mute'> {
+	permissions: Permissions;
+}
+
+/**
  * https://discord.com/developers/docs/interactions/slash-commands#interaction-applicationcommandinteractiondata
  */
 export interface APIApplicationCommandInteractionData {
@@ -270,8 +277,8 @@ export interface APIApplicationCommandInteractionData {
 	resolved?: {
 		users?: Record<string, APIUser>;
 		roles?: Record<string, APIRole>;
-		members?: Record<string, Omit<APIInteractionGuildMember, 'user' | 'deaf' | 'mute'>>;
-		channels?: Record<string, APIInteractionChannel>;
+		members?: Record<string, APIInteractionDataResolvedGuildMember>;
+		channels?: Record<string, APIInteractionDataResolvedChannel>;
 	};
 }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This adds new interfaces for the guild members and channels returned when dealing with interactions. Previously, the extra properties were just added to the base interface, but that way it's harder to import and use them. (This will also be useful for discordjs/discord.js#5448)