### PR TITLE
fix(RESTOAuth2): correct casing of `OAuth`

### DIFF
--- a/deno/rest/v8/oauth2.ts
+++ b/deno/rest/v8/oauth2.ts
@@ -4,12 +4,12 @@ import type { APIApplication, APIGuild, APIUser, APIWebhook, OAuth2Scopes } from
 /**
  * https://discord.com/developers/docs/topics/oauth2#get-current-application-information
  */
-export type RESTGetAPIOauth2CurrentApplicationResult = Omit<APIApplication, 'flags'>;
+export type RESTGetAPIOAuth2CurrentApplicationResult = Omit<APIApplication, 'flags'>;
 
 /**
  * https://discord.com/developers/docs/topics/oauth2#get-current-authorization-information
  */
-export interface RESTGetAPIOauth2CurrentAuthorizationResult {
+export interface RESTGetAPIOAuth2CurrentAuthorizationResult {
 	/**
 	 * the current application
 	 */

--- a/rest/v8/oauth2.ts
+++ b/rest/v8/oauth2.ts
@@ -4,12 +4,12 @@ import type { APIApplication, APIGuild, APIUser, APIWebhook, OAuth2Scopes } from
 /**
  * https://discord.com/developers/docs/topics/oauth2#get-current-application-information
  */
-export type RESTGetAPIOauth2CurrentApplicationResult = Omit<APIApplication, 'flags'>;
+export type RESTGetAPIOAuth2CurrentApplicationResult = Omit<APIApplication, 'flags'>;
 
 /**
  * https://discord.com/developers/docs/topics/oauth2#get-current-authorization-information
  */
-export interface RESTGetAPIOauth2CurrentAuthorizationResult {
+export interface RESTGetAPIOAuth2CurrentAuthorizationResult {
 	/**
 	 * the current application
 	 */


### PR DESCRIPTION
BREAKING CHANGE: `RESTGetAPIOauth2CurrentApplicationResult` and `RESTGetAPIOauth2CurrentAuthorizationResult` have been renamed to `RESTGetAPIOAuth2CurrentApplicationResult ` and `RESTGetAPIOAuth2CurrentAuthorizationResult`, to correct the casing of `OAuth`

**Please describe the changes this PR makes and why it should be merged:**

**Reference Discord API Docs PRs or commits:**
