### PR TITLE
chore(RESTErrorCodes): correct casing for OAuth

### DIFF
--- a/deno/rest/common.ts
+++ b/deno/rest/common.ts
@@ -77,9 +77,9 @@ export enum RESTJSONErrorCodes {
 	CannotSendMessagesToThisUser,
 	CannotSendMessagesInVoiceChannel,
 	ChannelVerificationLevelTooHighForYouToGainAccess,
-	Oauth2ApplicationDoesNotHaveBot,
-	Oauth2ApplicationLimitReached,
-	InvalidOauth2State,
+	OAuth2ApplicationDoesNotHaveBot,
+	OAuth2ApplicationLimitReached,
+	InvalidOAuth2State,
 	MissingPermissions,
 	InvalidToken,
 	NoteWasTooLong,
@@ -90,7 +90,7 @@ export enum RESTJSONErrorCodes {
 	CannotExecuteActionOnSystemMessage,
 
 	CannotExecuteActionOnThisChannelType = 50024,
-	InvalidOauth2AccessToken,
+	InvalidOAuth2AccessToken,
 
 	InvalidWebhookToken = 50027,
 

--- a/rest/common.ts
+++ b/rest/common.ts
@@ -77,9 +77,9 @@ export const enum RESTJSONErrorCodes {
 	CannotSendMessagesToThisUser,
 	CannotSendMessagesInVoiceChannel,
 	ChannelVerificationLevelTooHighForYouToGainAccess,
-	Oauth2ApplicationDoesNotHaveBot,
-	Oauth2ApplicationLimitReached,
-	InvalidOauth2State,
+	OAuth2ApplicationDoesNotHaveBot,
+	OAuth2ApplicationLimitReached,
+	InvalidOAuth2State,
 	MissingPermissions,
 	InvalidToken,
 	NoteWasTooLong,
@@ -90,7 +90,7 @@ export const enum RESTJSONErrorCodes {
 	CannotExecuteActionOnSystemMessage,
 
 	CannotExecuteActionOnThisChannelType = 50024,
-	InvalidOauth2AccessToken,
+	InvalidOAuth2AccessToken,
 
 	InvalidWebhookToken = 50027,
 


### PR DESCRIPTION
BREAKING CHANGE: This properly capitalizes certain error codes with the right OAuth capitalization

**Please describe the changes this PR makes and why it should be merged:**

it's not an import fix. 

**Reference Discord API Docs PRs or commits:**
