### PR TITLE
fix(RESTPutAPIChannelPermissionJSONBody): make properties optional and nullable

### DIFF
--- a/deno/rest/v8/channel.ts
+++ b/deno/rest/v8/channel.ts
@@ -332,17 +332,17 @@ export interface RESTPutAPIChannelPermissionJSONBody {
 	 *
 	 * See https://en.wikipedia.org/wiki/Bit_field
 	 */
-	allow: Permissions;
+	allow?: Permissions | null;
 	/**
 	 * The bitwise value of all disallowed permissions
 	 *
 	 * See https://en.wikipedia.org/wiki/Bit_field
 	 */
-	deny: Permissions;
+	deny?: Permissions | null;
 	/**
 	 * `0` for a role or `1` for a member
 	 */
-	type: OverwriteType;
+	type?: OverwriteType | null;
 }
 
 /**

--- a/deno/rest/v8/channel.ts
+++ b/deno/rest/v8/channel.ts
@@ -331,16 +331,19 @@ export interface RESTPutAPIChannelPermissionJSONBody {
 	 * The bitwise value of all allowed permissions
 	 *
 	 * See https://en.wikipedia.org/wiki/Bit_field
+	 * @default '0'
 	 */
 	allow?: Permissions | null;
 	/**
 	 * The bitwise value of all disallowed permissions
 	 *
 	 * See https://en.wikipedia.org/wiki/Bit_field
+	 * @default '0'
 	 */
 	deny?: Permissions | null;
 	/**
 	 * `0` for a role or `1` for a member
+	 * @default OverwriteType.Role
 	 */
 	type?: OverwriteType | null;
 }

--- a/deno/rest/v9/channel.ts
+++ b/deno/rest/v9/channel.ts
@@ -352,16 +352,19 @@ export interface RESTPutAPIChannelPermissionJSONBody {
 	 * The bitwise value of all allowed permissions
 	 *
 	 * See https://en.wikipedia.org/wiki/Bit_field
+	 * @default '0'
 	 */
 	allow?: Permissions | null;
 	/**
 	 * The bitwise value of all disallowed permissions
 	 *
 	 * See https://en.wikipedia.org/wiki/Bit_field
+	 * @default '0'
 	 */
 	deny?: Permissions | null;
 	/**
 	 * `0` for a role or `1` for a member
+	 * @default OverwriteType.Role
 	 */
 	type?: OverwriteType | null;
 }

--- a/deno/rest/v9/channel.ts
+++ b/deno/rest/v9/channel.ts
@@ -353,17 +353,17 @@ export interface RESTPutAPIChannelPermissionJSONBody {
 	 *
 	 * See https://en.wikipedia.org/wiki/Bit_field
 	 */
-	allow: Permissions;
+	allow?: Permissions | null;
 	/**
 	 * The bitwise value of all disallowed permissions
 	 *
 	 * See https://en.wikipedia.org/wiki/Bit_field
 	 */
-	deny: Permissions;
+	deny?: Permissions | null;
 	/**
 	 * `0` for a role or `1` for a member
 	 */
-	type: OverwriteType;
+	type?: OverwriteType | null;
 }
 
 /**

--- a/rest/v8/channel.ts
+++ b/rest/v8/channel.ts
@@ -332,17 +332,17 @@ export interface RESTPutAPIChannelPermissionJSONBody {
 	 *
 	 * See https://en.wikipedia.org/wiki/Bit_field
 	 */
-	allow: Permissions;
+	allow?: Permissions | null;
 	/**
 	 * The bitwise value of all disallowed permissions
 	 *
 	 * See https://en.wikipedia.org/wiki/Bit_field
 	 */
-	deny: Permissions;
+	deny?: Permissions | null;
 	/**
 	 * `0` for a role or `1` for a member
 	 */
-	type: OverwriteType;
+	type?: OverwriteType | null;
 }
 
 /**

--- a/rest/v8/channel.ts
+++ b/rest/v8/channel.ts
@@ -331,16 +331,19 @@ export interface RESTPutAPIChannelPermissionJSONBody {
 	 * The bitwise value of all allowed permissions
 	 *
 	 * See https://en.wikipedia.org/wiki/Bit_field
+	 * @default '0'
 	 */
 	allow?: Permissions | null;
 	/**
 	 * The bitwise value of all disallowed permissions
 	 *
 	 * See https://en.wikipedia.org/wiki/Bit_field
+	 * @default '0'
 	 */
 	deny?: Permissions | null;
 	/**
 	 * `0` for a role or `1` for a member
+	 * @default OverwriteType.Role
 	 */
 	type?: OverwriteType | null;
 }

--- a/rest/v9/channel.ts
+++ b/rest/v9/channel.ts
@@ -352,16 +352,19 @@ export interface RESTPutAPIChannelPermissionJSONBody {
 	 * The bitwise value of all allowed permissions
 	 *
 	 * See https://en.wikipedia.org/wiki/Bit_field
+	 * @default '0'
 	 */
 	allow?: Permissions | null;
 	/**
 	 * The bitwise value of all disallowed permissions
 	 *
 	 * See https://en.wikipedia.org/wiki/Bit_field
+	 * @default '0'
 	 */
 	deny?: Permissions | null;
 	/**
 	 * `0` for a role or `1` for a member
+	 * @default OverwriteType.Role
 	 */
 	type?: OverwriteType | null;
 }

--- a/rest/v9/channel.ts
+++ b/rest/v9/channel.ts
@@ -353,17 +353,17 @@ export interface RESTPutAPIChannelPermissionJSONBody {
 	 *
 	 * See https://en.wikipedia.org/wiki/Bit_field
 	 */
-	allow: Permissions;
+	allow?: Permissions | null;
 	/**
 	 * The bitwise value of all disallowed permissions
 	 *
 	 * See https://en.wikipedia.org/wiki/Bit_field
 	 */
-	deny: Permissions;
+	deny?: Permissions | null;
 	/**
 	 * `0` for a role or `1` for a member
 	 */
-	type: OverwriteType;
+	type?: OverwriteType | null;
 }
 
 /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR makes `allow`, `deny`, and `type` optional and nullable in `RESTPutAPIChannelPermissionJSONBody`, which is also used in `APIGuildCreateOverwrite`.

**Reference Discord API Docs PRs or commits:** https://github.com/discord/discord-api-docs/pull/3094