### PR TITLE
feat(Channel): add embeds to post / patch

### DIFF
--- a/deno/rest/v8/channel.ts
+++ b/deno/rest/v8/channel.ts
@@ -177,6 +177,12 @@ export interface RESTPostAPIChannelMessageJSONBody {
 	 */
 	tts?: boolean;
 	/**
+	 * Embedded `rich` content (up to 6000 characters)
+	 *
+	 * See https://discord.com/developers/docs/resources/channel#embed-object
+	 */
+	embeds?: APIEmbed[];
+	/**
 	 * Embedded `rich` content
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#embed-object
@@ -281,6 +287,10 @@ export interface RESTPatchAPIChannelMessageJSONBody {
 	 * The new message contents (up to 2000 characters)
 	 */
 	content?: string | null;
+	/**
+	 * Embedded `rich` content (up to 6000 characters)
+	 */
+	embeds?: APIEmbed[];
 	/**
 	 * Embedded `rich` content
 	 */

--- a/deno/rest/v9/channel.ts
+++ b/deno/rest/v9/channel.ts
@@ -207,7 +207,7 @@ export interface RESTPostAPIChannelMessageJSONBody {
 	 * Embedded `rich` content
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#embed-object
-	 * @deprecated
+	 * @deprecated Use `embeds` instead
 	 */
 	embed?: APIEmbed;
 	/**
@@ -315,7 +315,7 @@ export interface RESTPatchAPIChannelMessageJSONBody {
 	embeds?: APIEmbed[];
 	/**
 	 * Embedded `rich` content
-	 * @deprecated
+	 * @deprecated Use `embeds` instead
 	 */
 	embed?: APIEmbed | null;
 	/**

--- a/deno/rest/v9/channel.ts
+++ b/deno/rest/v9/channel.ts
@@ -198,9 +198,16 @@ export interface RESTPostAPIChannelMessageJSONBody {
 	 */
 	tts?: boolean;
 	/**
+	 * Embedded `rich` content (up to 6000 characters)
+	 *
+	 * See https://discord.com/developers/docs/resources/channel#embed-object
+	 */
+	embeds?: APIEmbed[];
+	/**
 	 * Embedded `rich` content
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#embed-object
+	 * @deprecated
 	 */
 	embed?: APIEmbed;
 	/**
@@ -303,7 +310,12 @@ export interface RESTPatchAPIChannelMessageJSONBody {
 	 */
 	content?: string | null;
 	/**
+	 * Embedded `rich` content (up to 6000 characters)
+	 */
+	embeds?: APIEmbed[];
+	/**
 	 * Embedded `rich` content
+	 * @deprecated
 	 */
 	embed?: APIEmbed | null;
 	/**

--- a/rest/v8/channel.ts
+++ b/rest/v8/channel.ts
@@ -177,6 +177,12 @@ export interface RESTPostAPIChannelMessageJSONBody {
 	 */
 	tts?: boolean;
 	/**
+	 * Embedded `rich` content (up to 6000 characters)
+	 *
+	 * See https://discord.com/developers/docs/resources/channel#embed-object
+	 */
+	embeds?: APIEmbed[];
+	/**
 	 * Embedded `rich` content
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#embed-object
@@ -281,6 +287,10 @@ export interface RESTPatchAPIChannelMessageJSONBody {
 	 * The new message contents (up to 2000 characters)
 	 */
 	content?: string | null;
+	/**
+	 * Embedded `rich` content (up to 6000 characters)
+	 */
+	embeds?: APIEmbed[];
 	/**
 	 * Embedded `rich` content
 	 */

--- a/rest/v9/channel.ts
+++ b/rest/v9/channel.ts
@@ -207,7 +207,7 @@ export interface RESTPostAPIChannelMessageJSONBody {
 	 * Embedded `rich` content
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#embed-object
-	 * @deprecated
+	 * @deprecated Use `embeds` instead
 	 */
 	embed?: APIEmbed;
 	/**
@@ -315,7 +315,7 @@ export interface RESTPatchAPIChannelMessageJSONBody {
 	embeds?: APIEmbed[];
 	/**
 	 * Embedded `rich` content
-	 * @deprecated
+	 * @deprecated Use `embeds` instead
 	 */
 	embed?: APIEmbed | null;
 	/**

--- a/rest/v9/channel.ts
+++ b/rest/v9/channel.ts
@@ -198,9 +198,16 @@ export interface RESTPostAPIChannelMessageJSONBody {
 	 */
 	tts?: boolean;
 	/**
+	 * Embedded `rich` content (up to 6000 characters)
+	 *
+	 * See https://discord.com/developers/docs/resources/channel#embed-object
+	 */
+	embeds?: APIEmbed[];
+	/**
 	 * Embedded `rich` content
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#embed-object
+	 * @deprecated
 	 */
 	embed?: APIEmbed;
 	/**
@@ -303,7 +310,12 @@ export interface RESTPatchAPIChannelMessageJSONBody {
 	 */
 	content?: string | null;
 	/**
+	 * Embedded `rich` content (up to 6000 characters)
+	 */
+	embeds?: APIEmbed[];
+	/**
 	 * Embedded `rich` content
+	 * @deprecated
 	 */
 	embed?: APIEmbed | null;
 	/**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Adds the now supported embeds param to post / patch routes for standard messages, deprecates embed on v9.

**Reference Discord API Docs PRs or commits:**

https://github.com/discord/discord-api-docs/pull/3105