### PR TITLE
feat(APIGuild): add `nsfw_level`

### DIFF
--- a/deno/payloads/v8/guild.ts
+++ b/deno/payloads/v8/guild.ts
@@ -305,11 +305,11 @@ export interface APIGuild extends APIPartialGuild {
 	 */
 	welcome_screen?: APIGuildWelcomeScreen;
 	/**
-	 * `true` if this guild is designated as NSFW
+	 * The nsfw level of the guild
 	 *
-	 * See https://support.discord.com/hc/en-us/articles/1500005389362-NSFW-Server-Designation
+	 * See https://discord.com/developers/docs/resources/guild#guild-object-guild-nsfw-level
 	 */
-	nsfw: boolean;
+	nsfw_level: GuildNSFWLevel;
 	/**
 	 * The stage instances in the guild
 	 *
@@ -343,6 +343,16 @@ export enum GuildExplicitContentFilter {
 export enum GuildMFALevel {
 	None,
 	Elevated,
+}
+
+/**
+ * https://discord.com/developers/docs/resources/guild#guild-object-guild-nsfw-level
+ */
+export enum GuildNSFWLevel {
+	Default,
+	Explicit,
+	Safe,
+	AgeRestricted,
 }
 
 /**

--- a/deno/payloads/v9/guild.ts
+++ b/deno/payloads/v9/guild.ts
@@ -313,11 +313,11 @@ export interface APIGuild extends APIPartialGuild {
 	 */
 	welcome_screen?: APIGuildWelcomeScreen;
 	/**
-	 * `true` if this guild is designated as NSFW
+	 * The nsfw level of the guild
 	 *
-	 * See https://support.discord.com/hc/en-us/articles/1500005389362-NSFW-Server-Designation
+	 * See https://discord.com/developers/docs/resources/guild#guild-object-guild-nsfw-level
 	 */
-	nsfw: boolean;
+	nsfw_level: GuildNSFWLevel;
 	/**
 	 * The stage instances in the guild
 	 *
@@ -351,6 +351,16 @@ export enum GuildExplicitContentFilter {
 export enum GuildMFALevel {
 	None,
 	Elevated,
+}
+
+/**
+ * https://discord.com/developers/docs/resources/guild#guild-object-guild-nsfw-level
+ */
+export enum GuildNSFWLevel {
+	Default,
+	Explicit,
+	Safe,
+	AgeRestricted,
 }
 
 /**

--- a/payloads/v8/guild.ts
+++ b/payloads/v8/guild.ts
@@ -305,11 +305,11 @@ export interface APIGuild extends APIPartialGuild {
 	 */
 	welcome_screen?: APIGuildWelcomeScreen;
 	/**
-	 * `true` if this guild is designated as NSFW
+	 * The nsfw level of the guild
 	 *
-	 * See https://support.discord.com/hc/en-us/articles/1500005389362-NSFW-Server-Designation
+	 * See https://discord.com/developers/docs/resources/guild#guild-object-guild-nsfw-level
 	 */
-	nsfw: boolean;
+	nsfw_level: GuildNSFWLevel;
 	/**
 	 * The stage instances in the guild
 	 *
@@ -343,6 +343,16 @@ export const enum GuildExplicitContentFilter {
 export const enum GuildMFALevel {
 	None,
 	Elevated,
+}
+
+/**
+ * https://discord.com/developers/docs/resources/guild#guild-object-guild-nsfw-level
+ */
+export const enum GuildNSFWLevel {
+	Default,
+	Explicit,
+	Safe,
+	AgeRestricted,
 }
 
 /**

--- a/payloads/v9/guild.ts
+++ b/payloads/v9/guild.ts
@@ -313,11 +313,11 @@ export interface APIGuild extends APIPartialGuild {
 	 */
 	welcome_screen?: APIGuildWelcomeScreen;
 	/**
-	 * `true` if this guild is designated as NSFW
+	 * The nsfw level of the guild
 	 *
-	 * See https://support.discord.com/hc/en-us/articles/1500005389362-NSFW-Server-Designation
+	 * See https://discord.com/developers/docs/resources/guild#guild-object-guild-nsfw-level
 	 */
-	nsfw: boolean;
+	nsfw_level: GuildNSFWLevel;
 	/**
 	 * The stage instances in the guild
 	 *
@@ -351,6 +351,16 @@ export const enum GuildExplicitContentFilter {
 export const enum GuildMFALevel {
 	None,
 	Elevated,
+}
+
+/**
+ * https://discord.com/developers/docs/resources/guild#guild-object-guild-nsfw-level
+ */
+export const enum GuildNSFWLevel {
+	Default,
+	Explicit,
+	Safe,
+	AgeRestricted,
 }
 
 /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR replaces the `nsfw` property of a guild payload with `nsfw_level`

**Reference Discord API Docs PRs or commits:**

[#2976](https://github.com/discord/discord-api-docs/pull/2976)