### PR TITLE
feat: add stage instance related typings to audit logs

### DIFF
--- a/deno/payloads/v8/auditLog.ts
+++ b/deno/payloads/v8/auditLog.ts
@@ -15,6 +15,7 @@ import type {
 import type { APIRole } from './permissions.ts';
 import type { APIUser } from './user.ts';
 import type { APIWebhook } from './webhook.ts';
+import type { StageInstancePrivacyLevel } from './stageInstance.ts';
 
 /**
  * https://discord.com/developers/docs/resources/audit-log#audit-log-object-audit-log-structure
@@ -135,6 +136,10 @@ export enum AuditLogEvent {
 	IntegrationCreate = 80,
 	IntegrationUpdate,
 	IntegrationDelete,
+
+	StageInstanceCreate = 83,
+	StageInstanceUpdate,
+	StageInstanceDelete,
 }
 
 /**
@@ -164,6 +169,9 @@ export interface APIAuditLogOptions {
 	 * - MESSAGE_PIN
 	 * - MESSAGE_UNPIN
 	 * - MESSAGE_DELETE
+	 * - STAGE_INSTANCE_CREATE
+	 * - STAGE_INSTANCE_UPDATE
+	 * - STAGE_INSTANCE_DELETE
 	 */
 	channel_id?: Snowflake;
 
@@ -284,7 +292,8 @@ export type APIAuditLogChange =
 	| APIAuditLogChangeKeyEnableEmoticons
 	| APIAuditLogChangeKeyExpireBehavior
 	| APIAuditLogChangeKeyExpireGracePeriod
-	| APIAuditLogChangeKeyUserLimit;
+	| APIAuditLogChangeKeyUserLimit
+	| APIAuditLogChangeKeyPrivacyLevel;
 
 /**
  * Returned when a guild's name is changed
@@ -562,6 +571,11 @@ export type APIAuditLogChangeKeyExpireGracePeriod = AuditLogChangeData<'expire_g
  * Returned when a voice channel's user_limit is changed
  */
 export type APIAuditLogChangeKeyUserLimit = AuditLogChangeData<'user_limit', number>;
+
+/**
+ * Returned when privacy level of a stage instance is changed
+ */
+export type APIAuditLogChangeKeyPrivacyLevel = AuditLogChangeData<'privacy_level', StageInstancePrivacyLevel>;
 
 interface AuditLogChangeData<K extends string, D extends unknown> {
 	key: K;

--- a/deno/payloads/v9/auditLog.ts
+++ b/deno/payloads/v9/auditLog.ts
@@ -15,6 +15,7 @@ import type {
 import type { APIRole } from './permissions.ts';
 import type { APIUser } from './user.ts';
 import type { APIWebhook } from './webhook.ts';
+import type { StageInstancePrivacyLevel } from './stageInstance.ts';
 
 /**
  * https://discord.com/developers/docs/resources/audit-log#audit-log-object-audit-log-structure
@@ -135,6 +136,10 @@ export enum AuditLogEvent {
 	IntegrationCreate = 80,
 	IntegrationUpdate,
 	IntegrationDelete,
+
+	StageInstanceCreate = 83,
+	StageInstanceUpdate,
+	StageInstanceDelete,
 }
 
 /**
@@ -164,6 +169,9 @@ export interface APIAuditLogOptions {
 	 * - MESSAGE_PIN
 	 * - MESSAGE_UNPIN
 	 * - MESSAGE_DELETE
+	 * - STAGE_INSTANCE_CREATE
+	 * - STAGE_INSTANCE_UPDATE
+	 * - STAGE_INSTANCE_DELETE
 	 */
 	channel_id?: Snowflake;
 
@@ -284,7 +292,8 @@ export type APIAuditLogChange =
 	| APIAuditLogChangeKeyEnableEmoticons
 	| APIAuditLogChangeKeyExpireBehavior
 	| APIAuditLogChangeKeyExpireGracePeriod
-	| APIAuditLogChangeKeyUserLimit;
+	| APIAuditLogChangeKeyUserLimit
+	| APIAuditLogChangeKeyPrivacyLevel;
 
 /**
  * Returned when a guild's name is changed
@@ -562,6 +571,11 @@ export type APIAuditLogChangeKeyExpireGracePeriod = AuditLogChangeData<'expire_g
  * Returned when a voice channel's user_limit is changed
  */
 export type APIAuditLogChangeKeyUserLimit = AuditLogChangeData<'user_limit', number>;
+
+/**
+ * Returned when privacy level of a stage instance is changed
+ */
+export type APIAuditLogChangeKeyPrivacyLevel = AuditLogChangeData<'privacy_level', StageInstancePrivacyLevel>;
 
 interface AuditLogChangeData<K extends string, D extends unknown> {
 	key: K;

--- a/payloads/v8/auditLog.ts
+++ b/payloads/v8/auditLog.ts
@@ -15,6 +15,7 @@ import type {
 import type { APIRole } from './permissions';
 import type { APIUser } from './user';
 import type { APIWebhook } from './webhook';
+import type { StageInstancePrivacyLevel } from './stageInstance';
 
 /**
  * https://discord.com/developers/docs/resources/audit-log#audit-log-object-audit-log-structure
@@ -135,6 +136,10 @@ export const enum AuditLogEvent {
 	IntegrationCreate = 80,
 	IntegrationUpdate,
 	IntegrationDelete,
+
+	StageInstanceCreate = 83,
+	StageInstanceUpdate,
+	StageInstanceDelete,
 }
 
 /**
@@ -164,6 +169,9 @@ export interface APIAuditLogOptions {
 	 * - MESSAGE_PIN
 	 * - MESSAGE_UNPIN
 	 * - MESSAGE_DELETE
+	 * - STAGE_INSTANCE_CREATE
+	 * - STAGE_INSTANCE_UPDATE
+	 * - STAGE_INSTANCE_DELETE
 	 */
 	channel_id?: Snowflake;
 
@@ -284,7 +292,8 @@ export type APIAuditLogChange =
 	| APIAuditLogChangeKeyEnableEmoticons
 	| APIAuditLogChangeKeyExpireBehavior
 	| APIAuditLogChangeKeyExpireGracePeriod
-	| APIAuditLogChangeKeyUserLimit;
+	| APIAuditLogChangeKeyUserLimit
+	| APIAuditLogChangeKeyPrivacyLevel;
 
 /**
  * Returned when a guild's name is changed
@@ -562,6 +571,11 @@ export type APIAuditLogChangeKeyExpireGracePeriod = AuditLogChangeData<'expire_g
  * Returned when a voice channel's user_limit is changed
  */
 export type APIAuditLogChangeKeyUserLimit = AuditLogChangeData<'user_limit', number>;
+
+/**
+ * Returned when privacy level of a stage instance is changed
+ */
+export type APIAuditLogChangeKeyPrivacyLevel = AuditLogChangeData<'privacy_level', StageInstancePrivacyLevel>;
 
 interface AuditLogChangeData<K extends string, D extends unknown> {
 	key: K;

--- a/payloads/v9/auditLog.ts
+++ b/payloads/v9/auditLog.ts
@@ -15,6 +15,7 @@ import type {
 import type { APIRole } from './permissions';
 import type { APIUser } from './user';
 import type { APIWebhook } from './webhook';
+import type { StageInstancePrivacyLevel } from './stageInstance';
 
 /**
  * https://discord.com/developers/docs/resources/audit-log#audit-log-object-audit-log-structure
@@ -135,6 +136,10 @@ export const enum AuditLogEvent {
 	IntegrationCreate = 80,
 	IntegrationUpdate,
 	IntegrationDelete,
+
+	StageInstanceCreate = 83,
+	StageInstanceUpdate,
+	StageInstanceDelete,
 }
 
 /**
@@ -164,6 +169,9 @@ export interface APIAuditLogOptions {
 	 * - MESSAGE_PIN
 	 * - MESSAGE_UNPIN
 	 * - MESSAGE_DELETE
+	 * - STAGE_INSTANCE_CREATE
+	 * - STAGE_INSTANCE_UPDATE
+	 * - STAGE_INSTANCE_DELETE
 	 */
 	channel_id?: Snowflake;
 
@@ -284,7 +292,8 @@ export type APIAuditLogChange =
 	| APIAuditLogChangeKeyEnableEmoticons
 	| APIAuditLogChangeKeyExpireBehavior
 	| APIAuditLogChangeKeyExpireGracePeriod
-	| APIAuditLogChangeKeyUserLimit;
+	| APIAuditLogChangeKeyUserLimit
+	| APIAuditLogChangeKeyPrivacyLevel;
 
 /**
  * Returned when a guild's name is changed
@@ -562,6 +571,11 @@ export type APIAuditLogChangeKeyExpireGracePeriod = AuditLogChangeData<'expire_g
  * Returned when a voice channel's user_limit is changed
  */
 export type APIAuditLogChangeKeyUserLimit = AuditLogChangeData<'user_limit', number>;
+
+/**
+ * Returned when privacy level of a stage instance is changed
+ */
+export type APIAuditLogChangeKeyPrivacyLevel = AuditLogChangeData<'privacy_level', StageInstancePrivacyLevel>;
 
 interface AuditLogChangeData<K extends string, D extends unknown> {
 	key: K;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR adds typings for stage instance related audit logs.

**Reference Discord API Docs PRs or commits:**

[#3060](https://github.com/discord/discord-api-docs/pull/3060)