### PR TITLE
refactor: rename `isStyledButton` to `isInteractionButton`

### DIFF
--- a/deno/utils/v8.ts
+++ b/deno/utils/v8.ts
@@ -98,6 +98,6 @@ export function isLinkButton(component: APIButtonComponent): component is APIBut
  * @param button The button to check against
  * @returns A boolean that indicates if the button has a `custom_id` attached to it
  */
-export function isStyledButton(component: APIButtonComponent): component is APIButtonComponentWithCustomID {
+export function isInteractionButton(component: APIButtonComponent): component is APIButtonComponentWithCustomID {
 	return component.style !== ButtonStyle.Link;
 }

--- a/deno/utils/v9.ts
+++ b/deno/utils/v9.ts
@@ -98,6 +98,6 @@ export function isLinkButton(component: APIButtonComponent): component is APIBut
  * @param button The button to check against
  * @returns A boolean that indicates if the button has a `custom_id` attached to it
  */
-export function isStyledButton(component: APIButtonComponent): component is APIButtonComponentWithCustomID {
+export function isInteractionButton(component: APIButtonComponent): component is APIButtonComponentWithCustomID {
 	return component.style !== ButtonStyle.Link;
 }

--- a/utils/v8.ts
+++ b/utils/v8.ts
@@ -98,6 +98,6 @@ export function isLinkButton(component: APIButtonComponent): component is APIBut
  * @param button The button to check against
  * @returns A boolean that indicates if the button has a `custom_id` attached to it
  */
-export function isStyledButton(component: APIButtonComponent): component is APIButtonComponentWithCustomID {
+export function isInteractionButton(component: APIButtonComponent): component is APIButtonComponentWithCustomID {
 	return component.style !== ButtonStyle.Link;
 }

--- a/utils/v9.ts
+++ b/utils/v9.ts
@@ -98,6 +98,6 @@ export function isLinkButton(component: APIButtonComponent): component is APIBut
  * @param button The button to check against
  * @returns A boolean that indicates if the button has a `custom_id` attached to it
  */
-export function isStyledButton(component: APIButtonComponent): component is APIButtonComponentWithCustomID {
+export function isInteractionButton(component: APIButtonComponent): component is APIButtonComponentWithCustomID {
 	return component.style !== ButtonStyle.Link;
 }


### PR DESCRIPTION
isStyledButton doesn't really describe what it does because all buttons have a style; isInteractionButton makes more sense because it says whether the button triggers an interaction when clicked