### PR TITLE
feat(Interactions): add interaction response and followup route

### DIFF
--- a/deno/rest/v8/interactions.ts
+++ b/deno/rest/v8/interactions.ts
@@ -3,7 +3,16 @@ import type {
 	APIApplicationCommandPermission,
 	APIGuildApplicationCommandPermissions,
 	APIInteractionResponse,
+	APIInteractionResponseCallbackData,
 } from '../../payloads/v8/mod.ts';
+import type {
+	RESTDeleteAPIWebhookWithTokenMessageResult,
+	RESTGetAPIWebhookWithTokenMessageResult,
+	RESTPatchAPIWebhookWithTokenMessageFormDataBody,
+	RESTPatchAPIWebhookWithTokenMessageJSONBody,
+	RESTPatchAPIWebhookWithTokenMessageResult,
+	RESTPostAPIWebhookWithTokenWaitResult,
+} from './webhook.ts';
 
 /**
  * https://discord.com/developers/docs/interactions/slash-commands#get-global-application-commands
@@ -110,6 +119,87 @@ export type RESTPostAPIInteractionCallbackFormDataBody =
 			 */
 			file: unknown;
 	  });
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#get-original-interaction-response
+ */
+export type RESTGetAPIInteractionOriginalResponseResult = RESTGetAPIWebhookWithTokenMessageResult;
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#edit-original-interaction-response
+ */
+export type RESTPatchAPIInteractionOriginalResponseJSONBody = RESTPatchAPIWebhookWithTokenMessageJSONBody;
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#edit-original-interaction-response
+ */
+export type RESTPatchAPIInteractionOriginalResponseFormDataBody = RESTPatchAPIWebhookWithTokenMessageFormDataBody;
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#edit-original-interaction-response
+ */
+export type RESTPatchAPIInteractionOriginalResponseResult = RESTPatchAPIWebhookWithTokenMessageResult;
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#delete-original-interaction-response
+ */
+export type RESTDeleteAPIInteractionOriginalResponseResult = RESTDeleteAPIWebhookWithTokenMessageResult;
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#create-followup-message
+ */
+export type RESTPostAPIInteractionFollowupJSONBody = APIInteractionResponseCallbackData;
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#create-followup-message
+ */
+export type RESTPostAPIInteractionFollowupFormDataBody =
+	| {
+			/**
+			 * JSON stringified message body
+			 */
+			payload_json?: string;
+			/**
+			 * The file contents
+			 */
+			file: unknown;
+	  }
+	| (RESTPostAPIInteractionFollowupJSONBody & {
+			/**
+			 * The file contents
+			 */
+			file: unknown;
+	  });
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#create-followup-message
+ */
+export type RESTPostAPIInteractionFollowupResult = RESTPostAPIWebhookWithTokenWaitResult;
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#get-followup-message
+ */
+export type RESTGetAPIInteractionFollowupResult = RESTGetAPIWebhookWithTokenMessageResult;
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#edit-followup-message
+ */
+export type RESTPatchAPIInteractionFollowupJSONBody = RESTPatchAPIWebhookWithTokenMessageJSONBody;
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#edit-followup-message
+ */
+export type RESTPatchAPIInteractionFollowupFormDataBody = RESTPatchAPIWebhookWithTokenMessageFormDataBody;
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#edit-followup-message
+ */
+export type RESTPatchAPIInteractionFollowupResult = RESTPatchAPIWebhookWithTokenMessageResult;
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#delete-followup-message
+ */
+export type RESTDeleteAPIInteractionFollowupResult = RESTDeleteAPIWebhookWithTokenMessageResult;
 
 /**
  * https://discord.com/developers/docs/interactions/slash-commands#get-guild-application-command-permissions

--- a/deno/rest/v8/webhook.ts
+++ b/deno/rest/v8/webhook.ts
@@ -221,6 +221,11 @@ export type RESTPostAPIWebhookWithTokenGitHubResult = never;
 export type RESTPostAPIWebhookWithTokenGitHubWaitResult = APIMessage;
 
 /**
+ * https://discord.com/developers/docs/resources/webhook#get-webhook-message
+ */
+export type RESTGetAPIWebhookWithTokenMessageResult = APIMessage;
+
+/**
  * https://discord.com/developers/docs/resources/webhook#edit-webhook-message
  */
 export interface RESTPatchAPIWebhookWithTokenMessageJSONBody
@@ -255,11 +260,6 @@ export type RESTPatchAPIWebhookWithTokenMessageFormDataBody =
 			 */
 			file: unknown;
 	  });
-
-/**
- * https://discord.com/developers/docs/resources/webhook#get-webhook-message
- */
-export type RESTGetAPIWebhookWithTokenMessageResult = APIMessage;
 
 /**
  * https://discord.com/developers/docs/resources/webhook#edit-webhook-message

--- a/deno/rest/v9/interactions.ts
+++ b/deno/rest/v9/interactions.ts
@@ -3,7 +3,16 @@ import type {
 	APIApplicationCommandPermission,
 	APIGuildApplicationCommandPermissions,
 	APIInteractionResponse,
+	APIInteractionResponseCallbackData,
 } from '../../payloads/v9/mod.ts';
+import type {
+	RESTDeleteAPIWebhookWithTokenMessageResult,
+	RESTGetAPIWebhookWithTokenMessageResult,
+	RESTPatchAPIWebhookWithTokenMessageFormDataBody,
+	RESTPatchAPIWebhookWithTokenMessageJSONBody,
+	RESTPatchAPIWebhookWithTokenMessageResult,
+	RESTPostAPIWebhookWithTokenWaitResult,
+} from './webhook.ts';
 
 /**
  * https://discord.com/developers/docs/interactions/slash-commands#get-global-application-commands
@@ -110,6 +119,87 @@ export type RESTPostAPIInteractionCallbackFormDataBody =
 			 */
 			file: unknown;
 	  });
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#get-original-interaction-response
+ */
+export type RESTGetAPIInteractionOriginalResponseResult = RESTGetAPIWebhookWithTokenMessageResult;
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#edit-original-interaction-response
+ */
+export type RESTPatchAPIInteractionOriginalResponseJSONBody = RESTPatchAPIWebhookWithTokenMessageJSONBody;
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#edit-original-interaction-response
+ */
+export type RESTPatchAPIInteractionOriginalResponseFormDataBody = RESTPatchAPIWebhookWithTokenMessageFormDataBody;
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#edit-original-interaction-response
+ */
+export type RESTPatchAPIInteractionOriginalResponseResult = RESTPatchAPIWebhookWithTokenMessageResult;
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#delete-original-interaction-response
+ */
+export type RESTDeleteAPIInteractionOriginalResponseResult = RESTDeleteAPIWebhookWithTokenMessageResult;
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#create-followup-message
+ */
+export type RESTPostAPIInteractionFollowupJSONBody = APIInteractionResponseCallbackData;
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#create-followup-message
+ */
+export type RESTPostAPIInteractionFollowupFormDataBody =
+	| {
+			/**
+			 * JSON stringified message body
+			 */
+			payload_json?: string;
+			/**
+			 * The file contents
+			 */
+			file: unknown;
+	  }
+	| (RESTPostAPIInteractionFollowupJSONBody & {
+			/**
+			 * The file contents
+			 */
+			file: unknown;
+	  });
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#create-followup-message
+ */
+export type RESTPostAPIInteractionFollowupResult = RESTPostAPIWebhookWithTokenWaitResult;
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#get-followup-message
+ */
+export type RESTGetAPIInteractionFollowupResult = RESTGetAPIWebhookWithTokenMessageResult;
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#edit-followup-message
+ */
+export type RESTPatchAPIInteractionFollowupJSONBody = RESTPatchAPIWebhookWithTokenMessageJSONBody;
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#edit-followup-message
+ */
+export type RESTPatchAPIInteractionFollowupFormDataBody = RESTPatchAPIWebhookWithTokenMessageFormDataBody;
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#edit-followup-message
+ */
+export type RESTPatchAPIInteractionFollowupResult = RESTPatchAPIWebhookWithTokenMessageResult;
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#delete-followup-message
+ */
+export type RESTDeleteAPIInteractionFollowupResult = RESTDeleteAPIWebhookWithTokenMessageResult;
 
 /**
  * https://discord.com/developers/docs/interactions/slash-commands#get-guild-application-command-permissions

--- a/deno/rest/v9/webhook.ts
+++ b/deno/rest/v9/webhook.ts
@@ -225,6 +225,11 @@ export type RESTPostAPIWebhookWithTokenGitHubResult = never;
 export type RESTPostAPIWebhookWithTokenGitHubWaitResult = APIMessage;
 
 /**
+ * https://discord.com/developers/docs/resources/webhook#get-webhook-message
+ */
+export type RESTGetAPIWebhookWithTokenMessageResult = APIMessage;
+
+/**
  * https://discord.com/developers/docs/resources/webhook#edit-webhook-message
  */
 export interface RESTPatchAPIWebhookWithTokenMessageJSONBody
@@ -259,11 +264,6 @@ export type RESTPatchAPIWebhookWithTokenMessageFormDataBody =
 			 */
 			file: unknown;
 	  });
-
-/**
- * https://discord.com/developers/docs/resources/webhook#get-webhook-message
- */
-export type RESTGetAPIWebhookWithTokenMessageResult = APIMessage;
 
 /**
  * https://discord.com/developers/docs/resources/webhook#edit-webhook-message

--- a/rest/v8/interactions.ts
+++ b/rest/v8/interactions.ts
@@ -3,7 +3,16 @@ import type {
 	APIApplicationCommandPermission,
 	APIGuildApplicationCommandPermissions,
 	APIInteractionResponse,
+	APIInteractionResponseCallbackData,
 } from '../../payloads/v8/index';
+import type {
+	RESTDeleteAPIWebhookWithTokenMessageResult,
+	RESTGetAPIWebhookWithTokenMessageResult,
+	RESTPatchAPIWebhookWithTokenMessageFormDataBody,
+	RESTPatchAPIWebhookWithTokenMessageJSONBody,
+	RESTPatchAPIWebhookWithTokenMessageResult,
+	RESTPostAPIWebhookWithTokenWaitResult,
+} from './webhook';
 
 /**
  * https://discord.com/developers/docs/interactions/slash-commands#get-global-application-commands
@@ -110,6 +119,87 @@ export type RESTPostAPIInteractionCallbackFormDataBody =
 			 */
 			file: unknown;
 	  });
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#get-original-interaction-response
+ */
+export type RESTGetAPIInteractionOriginalResponseResult = RESTGetAPIWebhookWithTokenMessageResult;
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#edit-original-interaction-response
+ */
+export type RESTPatchAPIInteractionOriginalResponseJSONBody = RESTPatchAPIWebhookWithTokenMessageJSONBody;
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#edit-original-interaction-response
+ */
+export type RESTPatchAPIInteractionOriginalResponseFormDataBody = RESTPatchAPIWebhookWithTokenMessageFormDataBody;
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#edit-original-interaction-response
+ */
+export type RESTPatchAPIInteractionOriginalResponseResult = RESTPatchAPIWebhookWithTokenMessageResult;
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#delete-original-interaction-response
+ */
+export type RESTDeleteAPIInteractionOriginalResponseResult = RESTDeleteAPIWebhookWithTokenMessageResult;
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#create-followup-message
+ */
+export type RESTPostAPIInteractionFollowupJSONBody = APIInteractionResponseCallbackData;
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#create-followup-message
+ */
+export type RESTPostAPIInteractionFollowupFormDataBody =
+	| {
+			/**
+			 * JSON stringified message body
+			 */
+			payload_json?: string;
+			/**
+			 * The file contents
+			 */
+			file: unknown;
+	  }
+	| (RESTPostAPIInteractionFollowupJSONBody & {
+			/**
+			 * The file contents
+			 */
+			file: unknown;
+	  });
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#create-followup-message
+ */
+export type RESTPostAPIInteractionFollowupResult = RESTPostAPIWebhookWithTokenWaitResult;
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#get-followup-message
+ */
+export type RESTGetAPIInteractionFollowupResult = RESTGetAPIWebhookWithTokenMessageResult;
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#edit-followup-message
+ */
+export type RESTPatchAPIInteractionFollowupJSONBody = RESTPatchAPIWebhookWithTokenMessageJSONBody;
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#edit-followup-message
+ */
+export type RESTPatchAPIInteractionFollowupFormDataBody = RESTPatchAPIWebhookWithTokenMessageFormDataBody;
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#edit-followup-message
+ */
+export type RESTPatchAPIInteractionFollowupResult = RESTPatchAPIWebhookWithTokenMessageResult;
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#delete-followup-message
+ */
+export type RESTDeleteAPIInteractionFollowupResult = RESTDeleteAPIWebhookWithTokenMessageResult;
 
 /**
  * https://discord.com/developers/docs/interactions/slash-commands#get-guild-application-command-permissions

--- a/rest/v8/webhook.ts
+++ b/rest/v8/webhook.ts
@@ -221,6 +221,11 @@ export type RESTPostAPIWebhookWithTokenGitHubResult = never;
 export type RESTPostAPIWebhookWithTokenGitHubWaitResult = APIMessage;
 
 /**
+ * https://discord.com/developers/docs/resources/webhook#get-webhook-message
+ */
+export type RESTGetAPIWebhookWithTokenMessageResult = APIMessage;
+
+/**
  * https://discord.com/developers/docs/resources/webhook#edit-webhook-message
  */
 export interface RESTPatchAPIWebhookWithTokenMessageJSONBody
@@ -255,11 +260,6 @@ export type RESTPatchAPIWebhookWithTokenMessageFormDataBody =
 			 */
 			file: unknown;
 	  });
-
-/**
- * https://discord.com/developers/docs/resources/webhook#get-webhook-message
- */
-export type RESTGetAPIWebhookWithTokenMessageResult = APIMessage;
 
 /**
  * https://discord.com/developers/docs/resources/webhook#edit-webhook-message

--- a/rest/v9/interactions.ts
+++ b/rest/v9/interactions.ts
@@ -3,7 +3,16 @@ import type {
 	APIApplicationCommandPermission,
 	APIGuildApplicationCommandPermissions,
 	APIInteractionResponse,
+	APIInteractionResponseCallbackData,
 } from '../../payloads/v9/index';
+import type {
+	RESTDeleteAPIWebhookWithTokenMessageResult,
+	RESTGetAPIWebhookWithTokenMessageResult,
+	RESTPatchAPIWebhookWithTokenMessageFormDataBody,
+	RESTPatchAPIWebhookWithTokenMessageJSONBody,
+	RESTPatchAPIWebhookWithTokenMessageResult,
+	RESTPostAPIWebhookWithTokenWaitResult,
+} from './webhook';
 
 /**
  * https://discord.com/developers/docs/interactions/slash-commands#get-global-application-commands
@@ -110,6 +119,87 @@ export type RESTPostAPIInteractionCallbackFormDataBody =
 			 */
 			file: unknown;
 	  });
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#get-original-interaction-response
+ */
+export type RESTGetAPIInteractionOriginalResponseResult = RESTGetAPIWebhookWithTokenMessageResult;
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#edit-original-interaction-response
+ */
+export type RESTPatchAPIInteractionOriginalResponseJSONBody = RESTPatchAPIWebhookWithTokenMessageJSONBody;
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#edit-original-interaction-response
+ */
+export type RESTPatchAPIInteractionOriginalResponseFormDataBody = RESTPatchAPIWebhookWithTokenMessageFormDataBody;
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#edit-original-interaction-response
+ */
+export type RESTPatchAPIInteractionOriginalResponseResult = RESTPatchAPIWebhookWithTokenMessageResult;
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#delete-original-interaction-response
+ */
+export type RESTDeleteAPIInteractionOriginalResponseResult = RESTDeleteAPIWebhookWithTokenMessageResult;
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#create-followup-message
+ */
+export type RESTPostAPIInteractionFollowupJSONBody = APIInteractionResponseCallbackData;
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#create-followup-message
+ */
+export type RESTPostAPIInteractionFollowupFormDataBody =
+	| {
+			/**
+			 * JSON stringified message body
+			 */
+			payload_json?: string;
+			/**
+			 * The file contents
+			 */
+			file: unknown;
+	  }
+	| (RESTPostAPIInteractionFollowupJSONBody & {
+			/**
+			 * The file contents
+			 */
+			file: unknown;
+	  });
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#create-followup-message
+ */
+export type RESTPostAPIInteractionFollowupResult = RESTPostAPIWebhookWithTokenWaitResult;
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#get-followup-message
+ */
+export type RESTGetAPIInteractionFollowupResult = RESTGetAPIWebhookWithTokenMessageResult;
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#edit-followup-message
+ */
+export type RESTPatchAPIInteractionFollowupJSONBody = RESTPatchAPIWebhookWithTokenMessageJSONBody;
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#edit-followup-message
+ */
+export type RESTPatchAPIInteractionFollowupFormDataBody = RESTPatchAPIWebhookWithTokenMessageFormDataBody;
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#edit-followup-message
+ */
+export type RESTPatchAPIInteractionFollowupResult = RESTPatchAPIWebhookWithTokenMessageResult;
+
+/**
+ * https://discord.com/developers/docs/interactions/slash-commands#delete-followup-message
+ */
+export type RESTDeleteAPIInteractionFollowupResult = RESTDeleteAPIWebhookWithTokenMessageResult;
 
 /**
  * https://discord.com/developers/docs/interactions/slash-commands#get-guild-application-command-permissions

--- a/rest/v9/webhook.ts
+++ b/rest/v9/webhook.ts
@@ -225,6 +225,11 @@ export type RESTPostAPIWebhookWithTokenGitHubResult = never;
 export type RESTPostAPIWebhookWithTokenGitHubWaitResult = APIMessage;
 
 /**
+ * https://discord.com/developers/docs/resources/webhook#get-webhook-message
+ */
+export type RESTGetAPIWebhookWithTokenMessageResult = APIMessage;
+
+/**
  * https://discord.com/developers/docs/resources/webhook#edit-webhook-message
  */
 export interface RESTPatchAPIWebhookWithTokenMessageJSONBody
@@ -259,11 +264,6 @@ export type RESTPatchAPIWebhookWithTokenMessageFormDataBody =
 			 */
 			file: unknown;
 	  });
-
-/**
- * https://discord.com/developers/docs/resources/webhook#get-webhook-message
- */
-export type RESTGetAPIWebhookWithTokenMessageResult = APIMessage;
 
 /**
  * https://discord.com/developers/docs/resources/webhook#edit-webhook-message


### PR DESCRIPTION
other than Create Interaction Response, these are just aliases for the equivalent webhook routes, but not including them is inconsistent and can be confusing to the user

this also moves a Get Webhook Message type up so it isn't sandwiched between Edit Webhook Message types anymore