### PR TITLE
fix: change resolved index types to string

### DIFF
--- a/deno/payloads/v8/_interactions/slashCommands.ts
+++ b/deno/payloads/v8/_interactions/slashCommands.ts
@@ -114,10 +114,10 @@ export interface APIApplicationCommandInteractionData {
 	name: string;
 	options?: APIApplicationCommandInteractionDataOption[];
 	resolved?: {
-		users?: Record<Snowflake, APIUser>;
-		roles?: Record<Snowflake, APIRole>;
-		members?: Record<Snowflake, APIInteractionDataResolvedGuildMember>;
-		channels?: Record<Snowflake, APIInteractionDataResolvedChannel>;
+		users?: Record<string, APIUser>;
+		roles?: Record<string, APIRole>;
+		members?: Record<string, APIInteractionDataResolvedGuildMember>;
+		channels?: Record<string, APIInteractionDataResolvedChannel>;
 	};
 }
 

--- a/deno/payloads/v9/_interactions/slashCommands.ts
+++ b/deno/payloads/v9/_interactions/slashCommands.ts
@@ -114,10 +114,10 @@ export interface APIApplicationCommandInteractionData {
 	name: string;
 	options?: APIApplicationCommandInteractionDataOption[];
 	resolved?: {
-		users?: Record<Snowflake, APIUser>;
-		roles?: Record<Snowflake, APIRole>;
-		members?: Record<Snowflake, APIInteractionDataResolvedGuildMember>;
-		channels?: Record<Snowflake, APIInteractionDataResolvedChannel>;
+		users?: Record<string, APIUser>;
+		roles?: Record<string, APIRole>;
+		members?: Record<string, APIInteractionDataResolvedGuildMember>;
+		channels?: Record<string, APIInteractionDataResolvedChannel>;
 	};
 }
 

--- a/payloads/v8/_interactions/slashCommands.ts
+++ b/payloads/v8/_interactions/slashCommands.ts
@@ -114,10 +114,10 @@ export interface APIApplicationCommandInteractionData {
 	name: string;
 	options?: APIApplicationCommandInteractionDataOption[];
 	resolved?: {
-		users?: Record<Snowflake, APIUser>;
-		roles?: Record<Snowflake, APIRole>;
-		members?: Record<Snowflake, APIInteractionDataResolvedGuildMember>;
-		channels?: Record<Snowflake, APIInteractionDataResolvedChannel>;
+		users?: Record<string, APIUser>;
+		roles?: Record<string, APIRole>;
+		members?: Record<string, APIInteractionDataResolvedGuildMember>;
+		channels?: Record<string, APIInteractionDataResolvedChannel>;
 	};
 }
 

--- a/payloads/v9/_interactions/slashCommands.ts
+++ b/payloads/v9/_interactions/slashCommands.ts
@@ -114,10 +114,10 @@ export interface APIApplicationCommandInteractionData {
 	name: string;
 	options?: APIApplicationCommandInteractionDataOption[];
 	resolved?: {
-		users?: Record<Snowflake, APIUser>;
-		roles?: Record<Snowflake, APIRole>;
-		members?: Record<Snowflake, APIInteractionDataResolvedGuildMember>;
-		channels?: Record<Snowflake, APIInteractionDataResolvedChannel>;
+		users?: Record<string, APIUser>;
+		roles?: Record<string, APIRole>;
+		members?: Record<string, APIInteractionDataResolvedGuildMember>;
+		channels?: Record<string, APIInteractionDataResolvedChannel>;
 	};
 }
 


### PR DESCRIPTION
this lets you access resolved fields using ts 4.3.

this should be reverted once ts 4.4 releases ([august 24](https://github.com/microsoft/TypeScript/issues/44237))