### PR TITLE
feat(Globals): revert template bigint type to string type

### DIFF
--- a/deno/globals.ts
+++ b/deno/globals.ts
@@ -1,13 +1,13 @@
 /**
  * https://discord.com/developers/docs/reference#snowflakes
  */
-export type Snowflake = `${bigint}`;
+export type Snowflake = string;
 
 /**
  * https://discord.com/developers/docs/topics/permissions
  * @internal
  */
-export type Permissions = `${bigint}`;
+export type Permissions = string;
 
 /**
  * https://discord.com/developers/docs/reference#message-formatting-formats

--- a/globals.ts
+++ b/globals.ts
@@ -1,13 +1,13 @@
 /**
  * https://discord.com/developers/docs/reference#snowflakes
  */
-export type Snowflake = `${bigint}`;
+export type Snowflake = string;
 
 /**
  * https://discord.com/developers/docs/topics/permissions
  * @internal
  */
-export type Permissions = `${bigint}`;
+export type Permissions = string;
 
 /**
  * https://discord.com/developers/docs/reference#message-formatting-formats


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This reverts the `${bigint}` template type because it was hard to use for some developers
