### PR TITLE
fix(Gateway): thread list sync now sends an array as documented

### DIFF
--- a/deno/payloads/v9/gateway.ts
+++ b/deno/payloads/v9/gateway.ts
@@ -331,10 +331,8 @@ export interface GatewayThreadListSync {
 	/**
 	 * The member objects for the client user in each joined thread that was synced
 	 */
-	members: Record<Snowflake, GatewayThreadListSyncMember>;
+	members: APIThreadMember[];
 }
-
-export type GatewayThreadListSyncMember = Omit<APIThreadMember, 'id' | 'user_id'>;
 
 /**
  * https://discord.com/developers/docs/topics/gateway#thread-members-update-thread-members-update-event-fields

--- a/payloads/v9/gateway.ts
+++ b/payloads/v9/gateway.ts
@@ -331,10 +331,8 @@ export interface GatewayThreadListSync {
 	/**
 	 * The member objects for the client user in each joined thread that was synced
 	 */
-	members: Record<Snowflake, GatewayThreadListSyncMember>;
+	members: APIThreadMember[];
 }
-
-export type GatewayThreadListSyncMember = Omit<APIThreadMember, 'id' | 'user_id'>;
 
 /**
  * https://discord.com/developers/docs/topics/gateway#thread-members-update-thread-members-update-event-fields


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Not sure when, but this finally got changed, oh and the members are full thread members now

**Reference Discord API Docs PRs or commits:**
