### PR TITLE
chore(ApplicationCommandOptionType): casing changes for subcommands

### DIFF
--- a/deno/payloads/v8/_interactions/slashCommands.ts
+++ b/deno/payloads/v8/_interactions/slashCommands.ts
@@ -68,7 +68,7 @@ export type APIApplicationCommandOption =
  * If the option is a `SUB_COMMAND` or `SUB_COMMAND_GROUP` type, this nested options will be the parameters
  */
 export interface APIApplicationCommandSubCommandOptions extends Omit<APIApplicationCommandOptionBase, 'type'> {
-	type: ApplicationCommandOptionType.SubCommand | ApplicationCommandOptionType.SubCommandGroup;
+	type: ApplicationCommandOptionType.Subcommand | ApplicationCommandOptionType.SubcommandGroup;
 	options?: APIApplicationCommandOption[];
 }
 
@@ -90,8 +90,8 @@ export interface APIApplicationCommandArgumentOptions extends Omit<APIApplicatio
  * https://discord.com/developers/docs/interactions/slash-commands#application-command-object-application-command-option-type
  */
 export enum ApplicationCommandOptionType {
-	SubCommand = 1,
-	SubCommandGroup,
+	Subcommand = 1,
+	SubcommandGroup,
 	String,
 	Integer,
 	Boolean,
@@ -149,13 +149,13 @@ export type APIApplicationCommandInteractionDataOption =
 
 export interface ApplicationCommandInteractionDataOptionSubCommand {
 	name: string;
-	type: ApplicationCommandOptionType.SubCommand;
+	type: ApplicationCommandOptionType.Subcommand;
 	options: APIApplicationCommandInteractionDataOptionWithValues[];
 }
 
 export interface ApplicationCommandInteractionDataOptionSubCommandGroup {
 	name: string;
-	type: ApplicationCommandOptionType.SubCommandGroup;
+	type: ApplicationCommandOptionType.SubcommandGroup;
 	options: ApplicationCommandInteractionDataOptionSubCommand[];
 }
 

--- a/deno/payloads/v9/_interactions/slashCommands.ts
+++ b/deno/payloads/v9/_interactions/slashCommands.ts
@@ -68,7 +68,7 @@ export type APIApplicationCommandOption =
  * If the option is a `SUB_COMMAND` or `SUB_COMMAND_GROUP` type, this nested options will be the parameters
  */
 export interface APIApplicationCommandSubCommandOptions extends Omit<APIApplicationCommandOptionBase, 'type'> {
-	type: ApplicationCommandOptionType.SubCommand | ApplicationCommandOptionType.SubCommandGroup;
+	type: ApplicationCommandOptionType.Subcommand | ApplicationCommandOptionType.SubcommandGroup;
 	options?: APIApplicationCommandOption[];
 }
 
@@ -90,8 +90,8 @@ export interface APIApplicationCommandArgumentOptions extends Omit<APIApplicatio
  * https://discord.com/developers/docs/interactions/slash-commands#application-command-object-application-command-option-type
  */
 export enum ApplicationCommandOptionType {
-	SubCommand = 1,
-	SubCommandGroup,
+	Subcommand = 1,
+	SubcommandGroup,
 	String,
 	Integer,
 	Boolean,
@@ -149,13 +149,13 @@ export type APIApplicationCommandInteractionDataOption =
 
 export interface ApplicationCommandInteractionDataOptionSubCommand {
 	name: string;
-	type: ApplicationCommandOptionType.SubCommand;
+	type: ApplicationCommandOptionType.Subcommand;
 	options: APIApplicationCommandInteractionDataOptionWithValues[];
 }
 
 export interface ApplicationCommandInteractionDataOptionSubCommandGroup {
 	name: string;
-	type: ApplicationCommandOptionType.SubCommandGroup;
+	type: ApplicationCommandOptionType.SubcommandGroup;
 	options: ApplicationCommandInteractionDataOptionSubCommand[];
 }
 

--- a/payloads/v8/_interactions/slashCommands.ts
+++ b/payloads/v8/_interactions/slashCommands.ts
@@ -68,7 +68,7 @@ export type APIApplicationCommandOption =
  * If the option is a `SUB_COMMAND` or `SUB_COMMAND_GROUP` type, this nested options will be the parameters
  */
 export interface APIApplicationCommandSubCommandOptions extends Omit<APIApplicationCommandOptionBase, 'type'> {
-	type: ApplicationCommandOptionType.SubCommand | ApplicationCommandOptionType.SubCommandGroup;
+	type: ApplicationCommandOptionType.Subcommand | ApplicationCommandOptionType.SubcommandGroup;
 	options?: APIApplicationCommandOption[];
 }
 
@@ -90,8 +90,8 @@ export interface APIApplicationCommandArgumentOptions extends Omit<APIApplicatio
  * https://discord.com/developers/docs/interactions/slash-commands#application-command-object-application-command-option-type
  */
 export const enum ApplicationCommandOptionType {
-	SubCommand = 1,
-	SubCommandGroup,
+	Subcommand = 1,
+	SubcommandGroup,
 	String,
 	Integer,
 	Boolean,
@@ -149,13 +149,13 @@ export type APIApplicationCommandInteractionDataOption =
 
 export interface ApplicationCommandInteractionDataOptionSubCommand {
 	name: string;
-	type: ApplicationCommandOptionType.SubCommand;
+	type: ApplicationCommandOptionType.Subcommand;
 	options: APIApplicationCommandInteractionDataOptionWithValues[];
 }
 
 export interface ApplicationCommandInteractionDataOptionSubCommandGroup {
 	name: string;
-	type: ApplicationCommandOptionType.SubCommandGroup;
+	type: ApplicationCommandOptionType.SubcommandGroup;
 	options: ApplicationCommandInteractionDataOptionSubCommand[];
 }
 

--- a/payloads/v9/_interactions/slashCommands.ts
+++ b/payloads/v9/_interactions/slashCommands.ts
@@ -68,7 +68,7 @@ export type APIApplicationCommandOption =
  * If the option is a `SUB_COMMAND` or `SUB_COMMAND_GROUP` type, this nested options will be the parameters
  */
 export interface APIApplicationCommandSubCommandOptions extends Omit<APIApplicationCommandOptionBase, 'type'> {
-	type: ApplicationCommandOptionType.SubCommand | ApplicationCommandOptionType.SubCommandGroup;
+	type: ApplicationCommandOptionType.Subcommand | ApplicationCommandOptionType.SubcommandGroup;
 	options?: APIApplicationCommandOption[];
 }
 
@@ -90,8 +90,8 @@ export interface APIApplicationCommandArgumentOptions extends Omit<APIApplicatio
  * https://discord.com/developers/docs/interactions/slash-commands#application-command-object-application-command-option-type
  */
 export const enum ApplicationCommandOptionType {
-	SubCommand = 1,
-	SubCommandGroup,
+	Subcommand = 1,
+	SubcommandGroup,
 	String,
 	Integer,
 	Boolean,
@@ -149,13 +149,13 @@ export type APIApplicationCommandInteractionDataOption =
 
 export interface ApplicationCommandInteractionDataOptionSubCommand {
 	name: string;
-	type: ApplicationCommandOptionType.SubCommand;
+	type: ApplicationCommandOptionType.Subcommand;
 	options: APIApplicationCommandInteractionDataOptionWithValues[];
 }
 
 export interface ApplicationCommandInteractionDataOptionSubCommandGroup {
 	name: string;
-	type: ApplicationCommandOptionType.SubCommandGroup;
+	type: ApplicationCommandOptionType.SubcommandGroup;
 	options: ApplicationCommandInteractionDataOptionSubCommand[];
 }
 


### PR DESCRIPTION
BREAKING CHANGE: This renames `SubCommand` to `Subcommand`,
and `SubCommandGroup` to `SubcommandGroup`

**Please describe the changes this PR makes and why it should be merged:**

Closes #170 

**Reference Discord API Docs PRs or commits:**
