### PR TITLE
fix(MessageComponent): emoji.name is not optional

### DIFF
--- a/deno/payloads/v8/channel.ts
+++ b/deno/payloads/v8/channel.ts
@@ -970,7 +970,7 @@ export interface APIMessageComponentEmoji {
 	/**
 	 * Emoji name
 	 */
-	name?: string;
+	name: string;
 	/**
 	 * Whether this emoji is animated
 	 */

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -1095,7 +1095,7 @@ export interface APIMessageComponentEmoji {
 	/**
 	 * Emoji name
 	 */
-	name?: string;
+	name: string;
 	/**
 	 * Whether this emoji is animated
 	 */

--- a/payloads/v8/channel.ts
+++ b/payloads/v8/channel.ts
@@ -970,7 +970,7 @@ export interface APIMessageComponentEmoji {
 	/**
 	 * Emoji name
 	 */
-	name?: string;
+	name: string;
 	/**
 	 * Whether this emoji is animated
 	 */

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -1095,7 +1095,7 @@ export interface APIMessageComponentEmoji {
 	/**
 	 * Emoji name
 	 */
-	name?: string;
+	name: string;
 	/**
 	 * Whether this emoji is animated
 	 */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

`[APIMessageComponentEmoji].name` is always required.

**Reference Discord API Docs PRs or commits:**

https://discord.com/developers/docs/resources/emoji#emoji-object-emoji-structure
> name: ?string **(can be null only in reaction emoji objects)**
