### PR TITLE
fix(Embed): corrent certain optional types as being required

### DIFF
--- a/deno/payloads/v8/channel.ts
+++ b/deno/payloads/v8/channel.ts
@@ -660,7 +660,7 @@ export interface APIEmbedThumbnail {
 	/**
 	 * Source url of thumbnail (only supports http(s) and attachments)
 	 */
-	url?: string;
+	url: string;
 	/**
 	 * A proxied url of the thumbnail
 	 */
@@ -700,7 +700,7 @@ export interface APIEmbedImage {
 	/**
 	 * Source url of image (only supports http(s) and attachments)
 	 */
-	url?: string;
+	url: string;
 	/**
 	 * A proxied url of the image
 	 */
@@ -738,7 +738,7 @@ export interface APIEmbedAuthor {
 	 *
 	 * Length limit: 256 characters
 	 */
-	name?: string;
+	name: string;
 	/**
 	 * URL of author
 	 */

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -789,7 +789,7 @@ export interface APIEmbedThumbnail {
 	/**
 	 * Source url of thumbnail (only supports http(s) and attachments)
 	 */
-	url?: string;
+	url: string;
 	/**
 	 * A proxied url of the thumbnail
 	 */
@@ -829,7 +829,7 @@ export interface APIEmbedImage {
 	/**
 	 * Source url of image (only supports http(s) and attachments)
 	 */
-	url?: string;
+	url: string;
 	/**
 	 * A proxied url of the image
 	 */
@@ -867,7 +867,7 @@ export interface APIEmbedAuthor {
 	 *
 	 * Length limit: 256 characters
 	 */
-	name?: string;
+	name: string;
 	/**
 	 * URL of author
 	 */

--- a/payloads/v8/channel.ts
+++ b/payloads/v8/channel.ts
@@ -660,7 +660,7 @@ export interface APIEmbedThumbnail {
 	/**
 	 * Source url of thumbnail (only supports http(s) and attachments)
 	 */
-	url?: string;
+	url: string;
 	/**
 	 * A proxied url of the thumbnail
 	 */
@@ -700,7 +700,7 @@ export interface APIEmbedImage {
 	/**
 	 * Source url of image (only supports http(s) and attachments)
 	 */
-	url?: string;
+	url: string;
 	/**
 	 * A proxied url of the image
 	 */
@@ -738,7 +738,7 @@ export interface APIEmbedAuthor {
 	 *
 	 * Length limit: 256 characters
 	 */
-	name?: string;
+	name: string;
 	/**
 	 * URL of author
 	 */

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -789,7 +789,7 @@ export interface APIEmbedThumbnail {
 	/**
 	 * Source url of thumbnail (only supports http(s) and attachments)
 	 */
-	url?: string;
+	url: string;
 	/**
 	 * A proxied url of the thumbnail
 	 */
@@ -829,7 +829,7 @@ export interface APIEmbedImage {
 	/**
 	 * Source url of image (only supports http(s) and attachments)
 	 */
-	url?: string;
+	url: string;
 	/**
 	 * A proxied url of the image
 	 */
@@ -867,7 +867,7 @@ export interface APIEmbedAuthor {
 	 *
 	 * Length limit: 256 characters
 	 */
-	name?: string;
+	name: string;
 	/**
 	 * URL of author
 	 */


### PR DESCRIPTION
BREAKING CHANGE:
- `APIEmbedAuthor#name` is required, not optional
- `APIEmbedThumbnail#url` is required, not optional
- `APIEmbedImage#url` is required, not optional

**Please describe the changes this PR makes and why it should be merged:**

**Reference Discord API Docs PRs or commits:**
https://github.com/discord/discord-api-docs/pull/3610