### PR TITLE
fix(RESTPostAPIBaseApplicationCommandsJSONBody): omit `version` field

### DIFF
--- a/deno/rest/v8/interactions.ts
+++ b/deno/rest/v8/interactions.ts
@@ -27,7 +27,7 @@ export type RESTGetAPIApplicationCommandResult = APIApplicationCommand;
 
 type RESTPostAPIBaseApplicationCommandsJSONBody = Omit<
 	APIApplicationCommand,
-	'id' | 'application_id' | 'description' | 'type'
+	'id' | 'application_id' | 'description' | 'type' | 'version'
 >;
 
 /**

--- a/deno/rest/v9/interactions.ts
+++ b/deno/rest/v9/interactions.ts
@@ -27,7 +27,7 @@ export type RESTGetAPIApplicationCommandResult = APIApplicationCommand;
 
 type RESTPostAPIBaseApplicationCommandsJSONBody = Omit<
 	APIApplicationCommand,
-	'id' | 'application_id' | 'description' | 'type'
+	'id' | 'application_id' | 'description' | 'type' | 'version'
 >;
 
 /**

--- a/rest/v8/interactions.ts
+++ b/rest/v8/interactions.ts
@@ -27,7 +27,7 @@ export type RESTGetAPIApplicationCommandResult = APIApplicationCommand;
 
 type RESTPostAPIBaseApplicationCommandsJSONBody = Omit<
 	APIApplicationCommand,
-	'id' | 'application_id' | 'description' | 'type'
+	'id' | 'application_id' | 'description' | 'type' | 'version'
 >;
 
 /**

--- a/rest/v9/interactions.ts
+++ b/rest/v9/interactions.ts
@@ -27,7 +27,7 @@ export type RESTGetAPIApplicationCommandResult = APIApplicationCommand;
 
 type RESTPostAPIBaseApplicationCommandsJSONBody = Omit<
 	APIApplicationCommand,
-	'id' | 'application_id' | 'description' | 'type'
+	'id' | 'application_id' | 'description' | 'type' | 'version'
 >;
 
 /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
As far as I can tell, the `version` field of APIApplicationCommands is not one that should be included in the POST data. So this omits it from `RESTPostAPIBaseApplicationCommandsJSONBody`.

**Reference Discord API Docs PRs or commits:**
#193, [discord/discord-api-docs#3524](https://github.com/discord/discord-api-docs/pull/3524)