### PR TITLE
refactor(APIVoiceRegion): removed `vip` property

### DIFF
--- a/deno/payloads/v8/voice.ts
+++ b/deno/payloads/v8/voice.ts
@@ -78,10 +78,6 @@ export interface APIVoiceRegion {
 	 */
 	name: string;
 	/**
-	 * `true` if this is a vip-only server
-	 */
-	vip: boolean;
-	/**
 	 * `true` for a single server that is closest to the current user's client
 	 */
 	optimal: boolean;

--- a/deno/payloads/v9/voice.ts
+++ b/deno/payloads/v9/voice.ts
@@ -78,10 +78,6 @@ export interface APIVoiceRegion {
 	 */
 	name: string;
 	/**
-	 * `true` if this is a vip-only server
-	 */
-	vip: boolean;
-	/**
 	 * `true` for a single server that is closest to the current user's client
 	 */
 	optimal: boolean;

--- a/payloads/v8/voice.ts
+++ b/payloads/v8/voice.ts
@@ -78,10 +78,6 @@ export interface APIVoiceRegion {
 	 */
 	name: string;
 	/**
-	 * `true` if this is a vip-only server
-	 */
-	vip: boolean;
-	/**
 	 * `true` for a single server that is closest to the current user's client
 	 */
 	optimal: boolean;

--- a/payloads/v9/voice.ts
+++ b/payloads/v9/voice.ts
@@ -78,10 +78,6 @@ export interface APIVoiceRegion {
 	 */
 	name: string;
 	/**
-	 * `true` if this is a vip-only server
-	 */
-	vip: boolean;
-	/**
 	 * `true` for a single server that is closest to the current user's client
 	 */
 	optimal: boolean;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

**Reference Discord API Docs PRs or commits:**
- https://github.com/discord/discord-api-docs/pull/3908