### PR TITLE
fix(APIRole): make icon and unicode_emoji nullable

### DIFF
--- a/deno/payloads/v8/permissions.ts
+++ b/deno/payloads/v8/permissions.ts
@@ -78,11 +78,11 @@ export interface APIRole {
 	/**
 	 * The role icon hash
 	 */
-	icon?: string;
+	icon?: string | null;
 	/**
 	 * The role unicode emoji as a standard emoji
 	 */
-	unicode_emoji?: string;
+	unicode_emoji?: string | null;
 	/**
 	 * Position of this role
 	 */

--- a/deno/payloads/v9/permissions.ts
+++ b/deno/payloads/v9/permissions.ts
@@ -82,11 +82,11 @@ export interface APIRole {
 	/**
 	 * The role icon hash
 	 */
-	icon?: string;
+	icon?: string | null;
 	/**
 	 * The role unicode emoji as a standard emoji
 	 */
-	unicode_emoji?: string;
+	unicode_emoji?: string | null;
 	/**
 	 * Position of this role
 	 */

--- a/payloads/v8/permissions.ts
+++ b/payloads/v8/permissions.ts
@@ -78,11 +78,11 @@ export interface APIRole {
 	/**
 	 * The role icon hash
 	 */
-	icon?: string;
+	icon?: string | null;
 	/**
 	 * The role unicode emoji as a standard emoji
 	 */
-	unicode_emoji?: string;
+	unicode_emoji?: string | null;
 	/**
 	 * Position of this role
 	 */

--- a/payloads/v9/permissions.ts
+++ b/payloads/v9/permissions.ts
@@ -82,11 +82,11 @@ export interface APIRole {
 	/**
 	 * The role icon hash
 	 */
-	icon?: string;
+	icon?: string | null;
 	/**
 	 * The role unicode emoji as a standard emoji
 	 */
-	unicode_emoji?: string;
+	unicode_emoji?: string | null;
 	/**
 	 * Position of this role
 	 */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

These two were nullable from the beginning. There is a [recently merged PR](https://github.com/discord/discord-api-docs/pull/3893) that documents them as `optional` too, so the `undefined` types are fine and don't need any changes.

**Reference Discord API Docs PRs or commits:**

