### PR TITLE
feat(Routes): add missing OAuth2 routes

### DIFF
--- a/deno/rest/v8/mod.ts
+++ b/deno/rest/v8/mod.ts
@@ -752,12 +752,12 @@ export const RouteBases = {
 Object.freeze(RouteBases);
 
 export const OAuth2Routes = {
-	authorizationURL: `https://discord.com/api/v${APIVersion}/oauth2/authorize`,
-	tokenURL: `https://discord.com/api/v${APIVersion}/oauth2/token`,
+	authorizationURL: `${RouteBases.api}${Routes.oauth2Authorization()}`,
+	tokenURL: `${RouteBases.api}${Routes.oauth2TokenExchange()}`,
 	/**
 	 * See https://tools.ietf.org/html/rfc7009
 	 */
-	tokenRevocationURL: `https://discord.com/api/v${APIVersion}/oauth2/token/revoke`,
+	tokenRevocationURL: `${RouteBases.api}${Routes.oauth2TokenRevocation()}`,
 } as const;
 
 // Freeze OAuth2 route object

--- a/deno/rest/v9/mod.ts
+++ b/deno/rest/v9/mod.ts
@@ -820,12 +820,12 @@ export const RouteBases = {
 Object.freeze(RouteBases);
 
 export const OAuth2Routes = {
-	authorizationURL: `https://discord.com/api/v${APIVersion}/oauth2/authorize`,
-	tokenURL: `https://discord.com/api/v${APIVersion}/oauth2/token`,
+	authorizationURL: `${RouteBases.api}${Routes.oauth2Authorization()}`,
+	tokenURL: `${RouteBases.api}${Routes.oauth2TokenExchange()}`,
 	/**
 	 * See https://tools.ietf.org/html/rfc7009
 	 */
-	tokenRevocationURL: `https://discord.com/api/v${APIVersion}/oauth2/token/revoke`,
+	tokenRevocationURL: `${RouteBases.api}${Routes.oauth2TokenRevocation()}`,
 } as const;
 
 // Freeze OAuth2 route object

--- a/rest/v8/index.ts
+++ b/rest/v8/index.ts
@@ -752,12 +752,12 @@ export const RouteBases = {
 Object.freeze(RouteBases);
 
 export const OAuth2Routes = {
-	authorizationURL: `https://discord.com/api/v${APIVersion}/oauth2/authorize`,
-	tokenURL: `https://discord.com/api/v${APIVersion}/oauth2/token`,
+	authorizationURL: `${RouteBases.api}${Routes.oauth2Authorization()}`,
+	tokenURL: `${RouteBases.api}${Routes.oauth2TokenExchange()}`,
 	/**
 	 * See https://tools.ietf.org/html/rfc7009
 	 */
-	tokenRevocationURL: `https://discord.com/api/v${APIVersion}/oauth2/token/revoke`,
+	tokenRevocationURL: `${RouteBases.api}${Routes.oauth2TokenRevocation()}`,
 } as const;
 
 // Freeze OAuth2 route object

--- a/rest/v9/index.ts
+++ b/rest/v9/index.ts
@@ -820,12 +820,12 @@ export const RouteBases = {
 Object.freeze(RouteBases);
 
 export const OAuth2Routes = {
-	authorizationURL: `https://discord.com/api/v${APIVersion}/oauth2/authorize`,
-	tokenURL: `https://discord.com/api/v${APIVersion}/oauth2/token`,
+	authorizationURL: `${RouteBases.api}${Routes.oauth2Authorization()}`,
+	tokenURL: `${RouteBases.api}${Routes.oauth2TokenExchange()}`,
 	/**
 	 * See https://tools.ietf.org/html/rfc7009
 	 */
-	tokenRevocationURL: `https://discord.com/api/v${APIVersion}/oauth2/token/revoke`,
+	tokenRevocationURL: `${RouteBases.api}${Routes.oauth2TokenRevocation()}`,
 } as const;
 
 // Freeze OAuth2 route object


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The OAuth2 token flow routes are currently only available in `OAuth2Routes`, but these are already prefixed with the API base, which makes them inconsistent with all the other route helpers. This PR adds the OAuth2 token flow routes to the main `Routes` object in a consistent format with all other routes.

This PR does not remove them from `OAuth2Routes`, to ensure that this is a non-breaking change.

**Reference Discord API Docs PRs or commits:**

https://discord.com/developers/docs/topics/oauth2