### PR TITLE
fix: correct types for REST attachments

### DIFF
--- a/deno/rest/v8/channel.ts
+++ b/deno/rest/v8/channel.ts
@@ -217,7 +217,7 @@ export interface RESTPostAPIChannelMessageJSONBody {
 	/**
 	 * Attachment objects with filename and description
 	 */
-	attachments?: Pick<APIAttachment, 'id' | 'description'> & Partial<Pick<APIAttachment, 'filename'>>[];
+	attachments?: (Pick<APIAttachment, 'id' | 'description'> & Partial<Pick<APIAttachment, 'filename'>>)[];
 }
 
 /**

--- a/deno/rest/v8/webhook.ts
+++ b/deno/rest/v8/webhook.ts
@@ -138,7 +138,7 @@ export interface RESTPostAPIWebhookWithTokenJSONBody {
 	/**
 	 * Attachment objects with filename and description
 	 */
-	attachments?: Pick<APIAttachment, 'id' | 'description'> & Partial<Pick<APIAttachment, 'filename'>>[];
+	attachments?: (Pick<APIAttachment, 'id' | 'description'> & Partial<Pick<APIAttachment, 'filename'>>)[];
 }
 
 /**

--- a/deno/rest/v9/channel.ts
+++ b/deno/rest/v9/channel.ts
@@ -251,7 +251,7 @@ export interface RESTPostAPIChannelMessageJSONBody {
 	/**
 	 * Attachment objects with filename and description
 	 */
-	attachments?: Pick<APIAttachment, 'id' | 'description'> & Partial<Pick<APIAttachment, 'filename'>>[];
+	attachments?: (Pick<APIAttachment, 'id' | 'description'> & Partial<Pick<APIAttachment, 'filename'>>)[];
 }
 
 /**

--- a/deno/rest/v9/webhook.ts
+++ b/deno/rest/v9/webhook.ts
@@ -138,7 +138,7 @@ export interface RESTPostAPIWebhookWithTokenJSONBody {
 	/**
 	 * Attachment objects with filename and description
 	 */
-	attachments?: Pick<APIAttachment, 'id' | 'description'> & Partial<Pick<APIAttachment, 'filename'>>[];
+	attachments?: (Pick<APIAttachment, 'id' | 'description'> & Partial<Pick<APIAttachment, 'filename'>>)[];
 }
 
 /**

--- a/rest/v8/channel.ts
+++ b/rest/v8/channel.ts
@@ -217,7 +217,7 @@ export interface RESTPostAPIChannelMessageJSONBody {
 	/**
 	 * Attachment objects with filename and description
 	 */
-	attachments?: Pick<APIAttachment, 'id' | 'description'> & Partial<Pick<APIAttachment, 'filename'>>[];
+	attachments?: (Pick<APIAttachment, 'id' | 'description'> & Partial<Pick<APIAttachment, 'filename'>>)[];
 }
 
 /**

--- a/rest/v8/webhook.ts
+++ b/rest/v8/webhook.ts
@@ -138,7 +138,7 @@ export interface RESTPostAPIWebhookWithTokenJSONBody {
 	/**
 	 * Attachment objects with filename and description
 	 */
-	attachments?: Pick<APIAttachment, 'id' | 'description'> & Partial<Pick<APIAttachment, 'filename'>>[];
+	attachments?: (Pick<APIAttachment, 'id' | 'description'> & Partial<Pick<APIAttachment, 'filename'>>)[];
 }
 
 /**

--- a/rest/v9/channel.ts
+++ b/rest/v9/channel.ts
@@ -251,7 +251,7 @@ export interface RESTPostAPIChannelMessageJSONBody {
 	/**
 	 * Attachment objects with filename and description
 	 */
-	attachments?: Pick<APIAttachment, 'id' | 'description'> & Partial<Pick<APIAttachment, 'filename'>>[];
+	attachments?: (Pick<APIAttachment, 'id' | 'description'> & Partial<Pick<APIAttachment, 'filename'>>)[];
 }
 
 /**

--- a/rest/v9/webhook.ts
+++ b/rest/v9/webhook.ts
@@ -138,7 +138,7 @@ export interface RESTPostAPIWebhookWithTokenJSONBody {
 	/**
 	 * Attachment objects with filename and description
 	 */
-	attachments?: Pick<APIAttachment, 'id' | 'description'> & Partial<Pick<APIAttachment, 'filename'>>[];
+	attachments?: (Pick<APIAttachment, 'id' | 'description'> & Partial<Pick<APIAttachment, 'filename'>>)[];
 }
 
 /**


### PR DESCRIPTION
It seem like these types are doing this:

```ts
attachments: (object) & (object[])
```
instead of
```ts
attachments: (object & object)[]
```

[typescript playground link to demonstrate](https://www.typescriptlang.org/play?#code/KYDwDg9gTgLgBASwHY2FAZgQwMbDgQQAUBJfGGHACwFtgU4BvAKDlcQBMAuOAZximQBzANws26BABs6mWtz4CkIsa3bAe2AWBgIISAPzz+Q0WzjY9qFAH0YATzDBDvY0tNseCAF7BuSAK7UAEZo7qz+UJJGispmYFAQIHbWEVEuMWFwlMAIgpQwzgHBaHAAPnABkpKZAO4I7DCUhYEhUGUV-lWZwGDZtFCYks5BEBDSmEiiAL5MsxZIfHB1jRD+MISYUHQ83IQI2ADWADxEpORUtCgANHAA5GoaWjp6t+239bcAfHAAZHAbsAQgyOe0OJxIZAo2BodBgN1uEmkSFkwC+nwA2gBdOAAXjg6KYAEhmITCfVuLcAAy3K5EwkPTQIbS6JAU4jUTCCPAQdBwTDmNZ4SQIcjScyYGA0umImRyO4ygB0YCUtyJU1pxLp5LuAEYpaSGU8WRSAEr7A4JKpwQQIdD6wky5Fy27UOw29AK92qwkzTGiJjzRbLSgA7bcAAUoOOp0hF1h8MNTOeSFe5Xe7C+v3+mx0wKj4LOUJh13lUllqM+nwAlFjcfiiSSyVw7tSNfT1IzmXo2RyuXAeXyBag4MLRXhsBL7Y6URTFcrBN71Q2tc3bnq24mu6y7mbDpbJNbbVOy07fHdXe7PUe1Uw-UA)