### PR TITLE
fix: make subcommand options optional

### DIFF
--- a/deno/payloads/v8/_interactions/_applicationCommands/chatInput.ts
+++ b/deno/payloads/v8/_interactions/_applicationCommands/chatInput.ts
@@ -164,7 +164,7 @@ export type APIApplicationCommandInteractionDataOption =
 export interface ApplicationCommandInteractionDataOptionSubCommand {
 	name: string;
 	type: ApplicationCommandOptionType.Subcommand;
-	options: APIApplicationCommandInteractionDataOptionWithValues[];
+	options?: APIApplicationCommandInteractionDataOptionWithValues[];
 }
 
 export interface ApplicationCommandInteractionDataOptionSubCommandGroup {

--- a/deno/payloads/v9/_interactions/_applicationCommands/chatInput.ts
+++ b/deno/payloads/v9/_interactions/_applicationCommands/chatInput.ts
@@ -160,7 +160,7 @@ export type APIApplicationCommandInteractionDataOption =
 export interface ApplicationCommandInteractionDataOptionSubCommand {
 	name: string;
 	type: ApplicationCommandOptionType.Subcommand;
-	options: APIApplicationCommandInteractionDataOptionWithValues[];
+	options?: APIApplicationCommandInteractionDataOptionWithValues[];
 }
 
 export interface ApplicationCommandInteractionDataOptionSubCommandGroup {

--- a/payloads/v8/_interactions/_applicationCommands/chatInput.ts
+++ b/payloads/v8/_interactions/_applicationCommands/chatInput.ts
@@ -164,7 +164,7 @@ export type APIApplicationCommandInteractionDataOption =
 export interface ApplicationCommandInteractionDataOptionSubCommand {
 	name: string;
 	type: ApplicationCommandOptionType.Subcommand;
-	options: APIApplicationCommandInteractionDataOptionWithValues[];
+	options?: APIApplicationCommandInteractionDataOptionWithValues[];
 }
 
 export interface ApplicationCommandInteractionDataOptionSubCommandGroup {

--- a/payloads/v9/_interactions/_applicationCommands/chatInput.ts
+++ b/payloads/v9/_interactions/_applicationCommands/chatInput.ts
@@ -160,7 +160,7 @@ export type APIApplicationCommandInteractionDataOption =
 export interface ApplicationCommandInteractionDataOptionSubCommand {
 	name: string;
 	type: ApplicationCommandOptionType.Subcommand;
-	options: APIApplicationCommandInteractionDataOptionWithValues[];
+	options?: APIApplicationCommandInteractionDataOptionWithValues[];
 }
 
 export interface ApplicationCommandInteractionDataOptionSubCommandGroup {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Subcommand options can be optional, 
example:

```ts
	options: [
		{
			name: 'command',
			description: 'The command you want to invoke.',
			type: ApplicationCommandOptionType.SubcommandGroup,
			options: [
				{
					name: 'spawnrandomcards',
					description: 'Spawn lots of random cards.',
					type: ApplicationCommandOptionType.Subcommand
				}
			]
		}
	],
```
and discord sends:

```js
[
    {
        "type": 2,
        "options": [
            {
                "type": 1,
                "name": "spawnrandomcards"
                // types think that "options" is always here
            }
        ],
        "name": "command"
    }
]
```

**Reference Discord API Docs PRs or commits:**

Not sure if this is even listed in the discord docs, but I deduced this just based off `console.log`'ing an interaction.
