### PR TITLE
fix(deno): faulty import paths for guild scheduled events

### DIFF
--- a/deno/rest/v8/guildScheduledEvent.ts
+++ b/deno/rest/v8/guildScheduledEvent.ts
@@ -7,7 +7,7 @@ import type {
 	GuildScheduledEventStatus,
 	APIGuildMember,
 	APIUser,
-} from '../../payloads/v8.ts';
+} from '../../v8.ts';
 
 /**
  * https://discord.com/developers/docs/resources/guild-scheduled-event#list-scheduled-events-for-guild

--- a/deno/rest/v9/guildScheduledEvent.ts
+++ b/deno/rest/v9/guildScheduledEvent.ts
@@ -7,7 +7,7 @@ import type {
 	GuildScheduledEventStatus,
 	APIGuildMember,
 	APIUser,
-} from '../../payloads/v9.ts';
+} from '../../v9.ts';
 
 /**
  * https://discord.com/developers/docs/resources/guild-scheduled-event#list-scheduled-events-for-guild

--- a/rest/v8/guildScheduledEvent.ts
+++ b/rest/v8/guildScheduledEvent.ts
@@ -7,7 +7,7 @@ import type {
 	GuildScheduledEventStatus,
 	APIGuildMember,
 	APIUser,
-} from '../../payloads/v8';
+} from '../../v8';
 
 /**
  * https://discord.com/developers/docs/resources/guild-scheduled-event#list-scheduled-events-for-guild

--- a/rest/v9/guildScheduledEvent.ts
+++ b/rest/v9/guildScheduledEvent.ts
@@ -7,7 +7,7 @@ import type {
 	GuildScheduledEventStatus,
 	APIGuildMember,
 	APIUser,
-} from '../../payloads/v9';
+} from '../../v9';
 
 /**
  * https://discord.com/developers/docs/resources/guild-scheduled-event#list-scheduled-events-for-guild


### PR DESCRIPTION
Currently importing this library in deno (1.16.3) on version 0.25.0 will cause this error:
```
error: Import 'https://deno.land/x/discord_api_types@0.25.0/payloads/v9.ts' failed, not found.
    at https://deno.land/x/discord_api_types@0.25.0/rest/v9/guildScheduledEvent.ts:10:8
```

Here's my `import_map.json`:
```json
{
    "imports": {
        "discord_api_types": "https://deno.land/x/discord_api_types@0.25.0/v9.ts"
    }
}
```

Reproduction: https://gitpod.io#snapshot/a6632653-7af6-4e60-bf9f-105616df115b
Run `curl -fsSL https://deno.land/x/install/install.sh | sudo DENO_INSTALL=/usr/local sh` to install Deno and run `deno run --import-map=import_map.json main.ts`