### PR TITLE
fix(APISelectMenuComponent): `options` property is required

### DIFF
--- a/deno/payloads/v8/channel.ts
+++ b/deno/payloads/v8/channel.ts
@@ -1027,7 +1027,7 @@ export interface APISelectMenuComponent extends APIBaseMessageComponent<Componen
 	/**
 	 * The choices in the select, max 25
 	 */
-	options?: APISelectMenuOption[];
+	options: APISelectMenuOption[];
 	/**
 	 * Custom placeholder text if nothing is selected, max 100 characters
 	 */

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -1156,7 +1156,7 @@ export interface APISelectMenuComponent extends APIBaseMessageComponent<Componen
 	/**
 	 * The choices in the select, max 25
 	 */
-	options?: APISelectMenuOption[];
+	options: APISelectMenuOption[];
 	/**
 	 * Custom placeholder text if nothing is selected, max 100 characters
 	 */

--- a/payloads/v8/channel.ts
+++ b/payloads/v8/channel.ts
@@ -1027,7 +1027,7 @@ export interface APISelectMenuComponent extends APIBaseMessageComponent<Componen
 	/**
 	 * The choices in the select, max 25
 	 */
-	options?: APISelectMenuOption[];
+	options: APISelectMenuOption[];
 	/**
 	 * Custom placeholder text if nothing is selected, max 100 characters
 	 */

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -1156,7 +1156,7 @@ export interface APISelectMenuComponent extends APIBaseMessageComponent<Componen
 	/**
 	 * The choices in the select, max 25
 	 */
-	options?: APISelectMenuOption[];
+	options: APISelectMenuOption[];
 	/**
 	 * Custom placeholder text if nothing is selected, max 100 characters
 	 */


### PR DESCRIPTION
close https://github.com/discordjs/discord-api-types/issues/247