### PR TITLE
types: make application command option union easier to use

### DIFF
--- a/deno/payloads/v8/_interactions/_applicationCommands/chatInput.ts
+++ b/deno/payloads/v8/_interactions/_applicationCommands/chatInput.ts
@@ -25,11 +25,14 @@ interface APIApplicationCommandOptionBase {
  * https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure
  */
 export type APIApplicationCommandOption =
-	| APIApplicationCommandChoiceArgumentOptions
+	| APIApplicationCommandStringArgumentOptions
 	| APIApplicationCommandSubCommandOptions
+	| APIApplicationCommandOptionBase
 	| APIApplicationCommandChannelOptions
 	| APIApplicationCommandOptionBase
-	| APIApplicationCommandNumberArgumentOptions;
+	| APIApplicationCommandNumberArgumentOptions
+	| APIApplicationCommandStringAutocompleteOptions
+	| APIApplicationCommandNumericAutocompleteOptions;
 
 /**
  * This type is exported as a way to make it stricter for you when you're writing your commands
@@ -45,16 +48,11 @@ export interface APIApplicationCommandSubCommandOptions extends Omit<APIApplicat
  * This type is exported as a way to make it stricter for you when you're writing your commands
  *
  * In contrast to `APIApplicationCommandSubCommandOptions`, these types cannot have an `options` array,
- * but they can have a either a `choices` or a `autocomplete` field.
+ * but they can have a `choices` one
  */
-export interface APIApplicationCommandChoiceArgumentOptions
-	extends Omit<APIApplicationCommandOptionBase, 'type' | 'autocomplete'> {
-	type:
-		| ApplicationCommandOptionType.String
-		| ApplicationCommandOptionType.Integer
-		| ApplicationCommandOptionType.Number;
+export interface APIApplicationCommandStringArgumentOptions extends Omit<APIApplicationCommandOptionBase, 'type'> {
+	type: ApplicationCommandOptionType.String;
 	choices?: APIApplicationCommandOptionChoice[];
-	autocomplete?: boolean;
 }
 
 /**
@@ -85,6 +83,38 @@ export interface APIApplicationCommandArgumentOptions
 		| ApplicationCommandOptionType.Number;
 	choices?: APIApplicationCommandOptionChoice[];
 	autocomplete?: false;
+}
+
+/**
+ * This type is exported as a way to make it stricter for you when you're writing your commands
+ *
+ * In contrast to `APIApplicationCommandArgumentOptions`, these types cannot have an `choices` array,
+ * but they can a `autocomplete` field where it's set to `true`
+ */
+export interface APIApplicationCommandStringAutocompleteOptions
+	extends Omit<APIApplicationCommandOptionBase, 'type' | 'autocomplete'> {
+	type: ApplicationCommandOptionType.String;
+	autocomplete: true;
+}
+
+/**
+ * This type is exported as a way to make it stricter for you when you're writing your commands
+ *
+ * In contrast to `APIApplicationCommandArgumentOptions`, these types cannot have an `choices` array,
+ * but they can a `autocomplete` field where it's set to `true`
+ */
+export interface APIApplicationCommandNumericAutocompleteOptions
+	extends Omit<APIApplicationCommandOptionBase, 'type' | 'autocomplete'> {
+	type: ApplicationCommandOptionType.Integer | ApplicationCommandOptionType.Number;
+	autocomplete: true;
+	/**
+	 * If the option is an `INTEGER` or `NUMBER` type, the minimum value permitted.
+	 */
+	min_value?: number;
+	/**
+	 * If the option is an `INTEGER` or `NUMBER` type, the minimum value permitted.
+	 */
+	max_value?: number;
 }
 
 /**

--- a/deno/payloads/v8/_interactions/_applicationCommands/chatInput.ts
+++ b/deno/payloads/v8/_interactions/_applicationCommands/chatInput.ts
@@ -25,14 +25,11 @@ interface APIApplicationCommandOptionBase {
  * https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure
  */
 export type APIApplicationCommandOption =
-	| APIApplicationCommandStringArgumentOptions
+	| APIApplicationCommandChoiceArgumentOptions
 	| APIApplicationCommandSubCommandOptions
-	| APIApplicationCommandOptionBase
 	| APIApplicationCommandChannelOptions
 	| APIApplicationCommandOptionBase
-	| APIApplicationCommandNumberArgumentOptions
-	| APIApplicationCommandStringAutocompleteOptions
-	| APIApplicationCommandNumericAutocompleteOptions;
+	| APIApplicationCommandNumberArgumentOptions;
 
 /**
  * This type is exported as a way to make it stricter for you when you're writing your commands
@@ -48,11 +45,16 @@ export interface APIApplicationCommandSubCommandOptions extends Omit<APIApplicat
  * This type is exported as a way to make it stricter for you when you're writing your commands
  *
  * In contrast to `APIApplicationCommandSubCommandOptions`, these types cannot have an `options` array,
- * but they can have a `choices` one
+ * but they can have a either a `choices` or a `autocomplete` field.
  */
-export interface APIApplicationCommandStringArgumentOptions extends Omit<APIApplicationCommandOptionBase, 'type'> {
-	type: ApplicationCommandOptionType.String;
+export interface APIApplicationCommandChoiceArgumentOptions
+	extends Omit<APIApplicationCommandOptionBase, 'type' | 'autocomplete'> {
+	type:
+		| ApplicationCommandOptionType.String
+		| ApplicationCommandOptionType.Integer
+		| ApplicationCommandOptionType.Number;
 	choices?: APIApplicationCommandOptionChoice[];
+	autocomplete?: boolean;
 }
 
 /**
@@ -83,38 +85,6 @@ export interface APIApplicationCommandArgumentOptions
 		| ApplicationCommandOptionType.Number;
 	choices?: APIApplicationCommandOptionChoice[];
 	autocomplete?: false;
-}
-
-/**
- * This type is exported as a way to make it stricter for you when you're writing your commands
- *
- * In contrast to `APIApplicationCommandArgumentOptions`, these types cannot have an `choices` array,
- * but they can a `autocomplete` field where it's set to `true`
- */
-export interface APIApplicationCommandStringAutocompleteOptions
-	extends Omit<APIApplicationCommandOptionBase, 'type' | 'autocomplete'> {
-	type: ApplicationCommandOptionType.String;
-	autocomplete: true;
-}
-
-/**
- * This type is exported as a way to make it stricter for you when you're writing your commands
- *
- * In contrast to `APIApplicationCommandArgumentOptions`, these types cannot have an `choices` array,
- * but they can a `autocomplete` field where it's set to `true`
- */
-export interface APIApplicationCommandNumericAutocompleteOptions
-	extends Omit<APIApplicationCommandOptionBase, 'type' | 'autocomplete'> {
-	type: ApplicationCommandOptionType.Integer | ApplicationCommandOptionType.Number;
-	autocomplete: true;
-	/**
-	 * If the option is an `INTEGER` or `NUMBER` type, the minimum value permitted.
-	 */
-	min_value?: number;
-	/**
-	 * If the option is an `INTEGER` or `NUMBER` type, the minimum value permitted.
-	 */
-	max_value?: number;
 }
 
 /**

--- a/deno/payloads/v8/_interactions/_applicationCommands/chatInput.ts
+++ b/deno/payloads/v8/_interactions/_applicationCommands/chatInput.ts
@@ -94,7 +94,7 @@ export interface APIApplicationCommandArgumentOptions
 export interface APIApplicationCommandStringAutocompleteOptions
 	extends Omit<APIApplicationCommandOptionBase, 'type' | 'autocomplete'> {
 	type: ApplicationCommandOptionType.String;
-	autocomplete: true;
+	autocomplete?: true;
 }
 
 /**
@@ -106,7 +106,7 @@ export interface APIApplicationCommandStringAutocompleteOptions
 export interface APIApplicationCommandNumericAutocompleteOptions
 	extends Omit<APIApplicationCommandOptionBase, 'type' | 'autocomplete'> {
 	type: ApplicationCommandOptionType.Integer | ApplicationCommandOptionType.Number;
-	autocomplete: true;
+	autocomplete?: true;
 	/**
 	 * If the option is an `INTEGER` or `NUMBER` type, the minimum value permitted.
 	 */

--- a/deno/payloads/v8/_interactions/_applicationCommands/chatInput.ts
+++ b/deno/payloads/v8/_interactions/_applicationCommands/chatInput.ts
@@ -18,7 +18,6 @@ interface APIApplicationCommandOptionBase {
 	name: string;
 	description: string;
 	required?: boolean;
-	autocomplete?: never;
 }
 
 /**
@@ -94,7 +93,7 @@ export interface APIApplicationCommandArgumentOptions
 export interface APIApplicationCommandStringAutocompleteOptions
 	extends Omit<APIApplicationCommandOptionBase, 'type' | 'autocomplete'> {
 	type: ApplicationCommandOptionType.String;
-	autocomplete?: true;
+	autocomplete: true;
 }
 
 /**
@@ -106,7 +105,7 @@ export interface APIApplicationCommandStringAutocompleteOptions
 export interface APIApplicationCommandNumericAutocompleteOptions
 	extends Omit<APIApplicationCommandOptionBase, 'type' | 'autocomplete'> {
 	type: ApplicationCommandOptionType.Integer | ApplicationCommandOptionType.Number;
-	autocomplete?: true;
+	autocomplete: true;
 	/**
 	 * If the option is an `INTEGER` or `NUMBER` type, the minimum value permitted.
 	 */

--- a/deno/payloads/v9/_interactions/_applicationCommands/chatInput.ts
+++ b/deno/payloads/v9/_interactions/_applicationCommands/chatInput.ts
@@ -29,7 +29,6 @@ export type APIApplicationCommandOption =
 	| APIApplicationCommandSubCommandOptions
 	| APIApplicationCommandOptionBase
 	| APIApplicationCommandChannelOptions
-	| APIApplicationCommandOptionBase
 	| APIApplicationCommandNumberArgumentOptions
 	| APIApplicationCommandStringAutocompleteOptions
 	| APIApplicationCommandNumericAutocompleteOptions;
@@ -69,7 +68,7 @@ export interface APIApplicationCommandStringArgumentOptions
 export interface APIApplicationCommandStringAutocompleteOptions
 	extends Omit<APIApplicationCommandOptionBase, 'type' | 'autocomplete'> {
 	type: ApplicationCommandOptionType.String;
-	autocomplete: true;
+	autocomplete?: true;
 }
 
 /**
@@ -81,7 +80,7 @@ export interface APIApplicationCommandStringAutocompleteOptions
 export interface APIApplicationCommandNumericAutocompleteOptions
 	extends Omit<APIApplicationCommandOptionBase, 'type' | 'autocomplete'> {
 	type: ApplicationCommandOptionType.Integer | ApplicationCommandOptionType.Number;
-	autocomplete: true;
+	autocomplete?: true;
 	/**
 	 * If the option is an `INTEGER` or `NUMBER` type, the minimum value permitted.
 	 */

--- a/deno/payloads/v9/_interactions/_applicationCommands/chatInput.ts
+++ b/deno/payloads/v9/_interactions/_applicationCommands/chatInput.ts
@@ -18,17 +18,21 @@ interface APIApplicationCommandOptionBase {
 	name: string;
 	description: string;
 	required?: boolean;
+	autocomplete?: never;
 }
 
 /**
  * https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure
  */
 export type APIApplicationCommandOption =
-	| APIApplicationCommandChoiceArgumentOptions
+	| APIApplicationCommandStringArgumentOptions
 	| APIApplicationCommandSubCommandOptions
+	| APIApplicationCommandOptionBase
 	| APIApplicationCommandChannelOptions
 	| APIApplicationCommandOptionBase
-	| APIApplicationCommandNumberArgumentOptions;
+	| APIApplicationCommandNumberArgumentOptions
+	| APIApplicationCommandStringAutocompleteOptions
+	| APIApplicationCommandNumericAutocompleteOptions;
 
 /**
  * This type is exported as a way to make it stricter for you when you're writing your commands
@@ -44,16 +48,48 @@ export interface APIApplicationCommandSubCommandOptions extends Omit<APIApplicat
  * This type is exported as a way to make it stricter for you when you're writing your commands
  *
  * In contrast to `APIApplicationCommandSubCommandOptions`, these types cannot have an `options` array,
- * but they can have a either a `choices` or a `autocomplete` field.
+ * but they can have a either a `choices` or a `autocomplete` field where it's set to false.
  */
-export interface APIApplicationCommandChoiceArgumentOptions
+export interface APIApplicationCommandStringArgumentOptions
 	extends Omit<APIApplicationCommandOptionBase, 'type' | 'autocomplete'> {
 	type:
 		| ApplicationCommandOptionType.String
 		| ApplicationCommandOptionType.Integer
 		| ApplicationCommandOptionType.Number;
 	choices?: APIApplicationCommandOptionChoice[];
-	autocomplete?: boolean;
+	autocomplete?: false;
+}
+
+/**
+ * This type is exported as a way to make it stricter for you when you're writing your commands
+ *
+ * In contrast to `APIApplicationCommandArgumentOptions`, these types cannot have an `choices` array,
+ * but they can a `autocomplete` field where it's set to `true`
+ */
+export interface APIApplicationCommandStringAutocompleteOptions
+	extends Omit<APIApplicationCommandOptionBase, 'type' | 'autocomplete'> {
+	type: ApplicationCommandOptionType.String;
+	autocomplete: true;
+}
+
+/**
+ * This type is exported as a way to make it stricter for you when you're writing your commands
+ *
+ * In contrast to `APIApplicationCommandArgumentOptions`, these types cannot have an `choices` array,
+ * but they can a `autocomplete` field where it's set to `true`
+ */
+export interface APIApplicationCommandNumericAutocompleteOptions
+	extends Omit<APIApplicationCommandOptionBase, 'type' | 'autocomplete'> {
+	type: ApplicationCommandOptionType.Integer | ApplicationCommandOptionType.Number;
+	autocomplete: true;
+	/**
+	 * If the option is an `INTEGER` or `NUMBER` type, the minimum value permitted.
+	 */
+	min_value?: number;
+	/**
+	 * If the option is an `INTEGER` or `NUMBER` type, the minimum value permitted.
+	 */
+	max_value?: number;
 }
 
 /**

--- a/deno/payloads/v9/_interactions/_applicationCommands/chatInput.ts
+++ b/deno/payloads/v9/_interactions/_applicationCommands/chatInput.ts
@@ -18,21 +18,17 @@ interface APIApplicationCommandOptionBase {
 	name: string;
 	description: string;
 	required?: boolean;
-	autocomplete?: never;
 }
 
 /**
  * https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure
  */
 export type APIApplicationCommandOption =
-	| APIApplicationCommandStringArgumentOptions
+	| APIApplicationCommandChoiceArgumentOptions
 	| APIApplicationCommandSubCommandOptions
-	| APIApplicationCommandOptionBase
 	| APIApplicationCommandChannelOptions
 	| APIApplicationCommandOptionBase
-	| APIApplicationCommandNumberArgumentOptions
-	| APIApplicationCommandStringAutocompleteOptions
-	| APIApplicationCommandNumericAutocompleteOptions;
+	| APIApplicationCommandNumberArgumentOptions;
 
 /**
  * This type is exported as a way to make it stricter for you when you're writing your commands
@@ -48,48 +44,16 @@ export interface APIApplicationCommandSubCommandOptions extends Omit<APIApplicat
  * This type is exported as a way to make it stricter for you when you're writing your commands
  *
  * In contrast to `APIApplicationCommandSubCommandOptions`, these types cannot have an `options` array,
- * but they can have a either a `choices` or a `autocomplete` field where it's set to false.
+ * but they can have a either a `choices` or a `autocomplete` field.
  */
-export interface APIApplicationCommandStringArgumentOptions
+export interface APIApplicationCommandChoiceArgumentOptions
 	extends Omit<APIApplicationCommandOptionBase, 'type' | 'autocomplete'> {
 	type:
 		| ApplicationCommandOptionType.String
 		| ApplicationCommandOptionType.Integer
 		| ApplicationCommandOptionType.Number;
 	choices?: APIApplicationCommandOptionChoice[];
-	autocomplete?: false;
-}
-
-/**
- * This type is exported as a way to make it stricter for you when you're writing your commands
- *
- * In contrast to `APIApplicationCommandArgumentOptions`, these types cannot have an `choices` array,
- * but they can a `autocomplete` field where it's set to `true`
- */
-export interface APIApplicationCommandStringAutocompleteOptions
-	extends Omit<APIApplicationCommandOptionBase, 'type' | 'autocomplete'> {
-	type: ApplicationCommandOptionType.String;
-	autocomplete: true;
-}
-
-/**
- * This type is exported as a way to make it stricter for you when you're writing your commands
- *
- * In contrast to `APIApplicationCommandArgumentOptions`, these types cannot have an `choices` array,
- * but they can a `autocomplete` field where it's set to `true`
- */
-export interface APIApplicationCommandNumericAutocompleteOptions
-	extends Omit<APIApplicationCommandOptionBase, 'type' | 'autocomplete'> {
-	type: ApplicationCommandOptionType.Integer | ApplicationCommandOptionType.Number;
-	autocomplete: true;
-	/**
-	 * If the option is an `INTEGER` or `NUMBER` type, the minimum value permitted.
-	 */
-	min_value?: number;
-	/**
-	 * If the option is an `INTEGER` or `NUMBER` type, the minimum value permitted.
-	 */
-	max_value?: number;
+	autocomplete?: boolean;
 }
 
 /**

--- a/deno/payloads/v9/_interactions/_applicationCommands/chatInput.ts
+++ b/deno/payloads/v9/_interactions/_applicationCommands/chatInput.ts
@@ -18,7 +18,6 @@ interface APIApplicationCommandOptionBase {
 	name: string;
 	description: string;
 	required?: boolean;
-	autocomplete?: never;
 }
 
 /**
@@ -68,7 +67,7 @@ export interface APIApplicationCommandStringArgumentOptions
 export interface APIApplicationCommandStringAutocompleteOptions
 	extends Omit<APIApplicationCommandOptionBase, 'type' | 'autocomplete'> {
 	type: ApplicationCommandOptionType.String;
-	autocomplete?: true;
+	autocomplete: true;
 }
 
 /**
@@ -80,7 +79,7 @@ export interface APIApplicationCommandStringAutocompleteOptions
 export interface APIApplicationCommandNumericAutocompleteOptions
 	extends Omit<APIApplicationCommandOptionBase, 'type' | 'autocomplete'> {
 	type: ApplicationCommandOptionType.Integer | ApplicationCommandOptionType.Number;
-	autocomplete?: true;
+	autocomplete: true;
 	/**
 	 * If the option is an `INTEGER` or `NUMBER` type, the minimum value permitted.
 	 */

--- a/payloads/v8/_interactions/_applicationCommands/chatInput.ts
+++ b/payloads/v8/_interactions/_applicationCommands/chatInput.ts
@@ -25,11 +25,14 @@ interface APIApplicationCommandOptionBase {
  * https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure
  */
 export type APIApplicationCommandOption =
-	| APIApplicationCommandChoiceArgumentOptions
+	| APIApplicationCommandStringArgumentOptions
 	| APIApplicationCommandSubCommandOptions
+	| APIApplicationCommandOptionBase
 	| APIApplicationCommandChannelOptions
 	| APIApplicationCommandOptionBase
-	| APIApplicationCommandNumberArgumentOptions;
+	| APIApplicationCommandNumberArgumentOptions
+	| APIApplicationCommandStringAutocompleteOptions
+	| APIApplicationCommandNumericAutocompleteOptions;
 
 /**
  * This type is exported as a way to make it stricter for you when you're writing your commands
@@ -45,16 +48,11 @@ export interface APIApplicationCommandSubCommandOptions extends Omit<APIApplicat
  * This type is exported as a way to make it stricter for you when you're writing your commands
  *
  * In contrast to `APIApplicationCommandSubCommandOptions`, these types cannot have an `options` array,
- * but they can have a either a `choices` or a `autocomplete` field.
+ * but they can have a `choices` one
  */
-export interface APIApplicationCommandChoiceArgumentOptions
-	extends Omit<APIApplicationCommandOptionBase, 'type' | 'autocomplete'> {
-	type:
-		| ApplicationCommandOptionType.String
-		| ApplicationCommandOptionType.Integer
-		| ApplicationCommandOptionType.Number;
+export interface APIApplicationCommandStringArgumentOptions extends Omit<APIApplicationCommandOptionBase, 'type'> {
+	type: ApplicationCommandOptionType.String;
 	choices?: APIApplicationCommandOptionChoice[];
-	autocomplete?: boolean;
 }
 
 /**
@@ -85,6 +83,38 @@ export interface APIApplicationCommandArgumentOptions
 		| ApplicationCommandOptionType.Number;
 	choices?: APIApplicationCommandOptionChoice[];
 	autocomplete?: false;
+}
+
+/**
+ * This type is exported as a way to make it stricter for you when you're writing your commands
+ *
+ * In contrast to `APIApplicationCommandArgumentOptions`, these types cannot have an `choices` array,
+ * but they can a `autocomplete` field where it's set to `true`
+ */
+export interface APIApplicationCommandStringAutocompleteOptions
+	extends Omit<APIApplicationCommandOptionBase, 'type' | 'autocomplete'> {
+	type: ApplicationCommandOptionType.String;
+	autocomplete: true;
+}
+
+/**
+ * This type is exported as a way to make it stricter for you when you're writing your commands
+ *
+ * In contrast to `APIApplicationCommandArgumentOptions`, these types cannot have an `choices` array,
+ * but they can a `autocomplete` field where it's set to `true`
+ */
+export interface APIApplicationCommandNumericAutocompleteOptions
+	extends Omit<APIApplicationCommandOptionBase, 'type' | 'autocomplete'> {
+	type: ApplicationCommandOptionType.Integer | ApplicationCommandOptionType.Number;
+	autocomplete: true;
+	/**
+	 * If the option is an `INTEGER` or `NUMBER` type, the minimum value permitted.
+	 */
+	min_value?: number;
+	/**
+	 * If the option is an `INTEGER` or `NUMBER` type, the minimum value permitted.
+	 */
+	max_value?: number;
 }
 
 /**

--- a/payloads/v8/_interactions/_applicationCommands/chatInput.ts
+++ b/payloads/v8/_interactions/_applicationCommands/chatInput.ts
@@ -25,14 +25,11 @@ interface APIApplicationCommandOptionBase {
  * https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure
  */
 export type APIApplicationCommandOption =
-	| APIApplicationCommandStringArgumentOptions
+	| APIApplicationCommandChoiceArgumentOptions
 	| APIApplicationCommandSubCommandOptions
-	| APIApplicationCommandOptionBase
 	| APIApplicationCommandChannelOptions
 	| APIApplicationCommandOptionBase
-	| APIApplicationCommandNumberArgumentOptions
-	| APIApplicationCommandStringAutocompleteOptions
-	| APIApplicationCommandNumericAutocompleteOptions;
+	| APIApplicationCommandNumberArgumentOptions;
 
 /**
  * This type is exported as a way to make it stricter for you when you're writing your commands
@@ -48,11 +45,16 @@ export interface APIApplicationCommandSubCommandOptions extends Omit<APIApplicat
  * This type is exported as a way to make it stricter for you when you're writing your commands
  *
  * In contrast to `APIApplicationCommandSubCommandOptions`, these types cannot have an `options` array,
- * but they can have a `choices` one
+ * but they can have a either a `choices` or a `autocomplete` field.
  */
-export interface APIApplicationCommandStringArgumentOptions extends Omit<APIApplicationCommandOptionBase, 'type'> {
-	type: ApplicationCommandOptionType.String;
+export interface APIApplicationCommandChoiceArgumentOptions
+	extends Omit<APIApplicationCommandOptionBase, 'type' | 'autocomplete'> {
+	type:
+		| ApplicationCommandOptionType.String
+		| ApplicationCommandOptionType.Integer
+		| ApplicationCommandOptionType.Number;
 	choices?: APIApplicationCommandOptionChoice[];
+	autocomplete?: boolean;
 }
 
 /**
@@ -83,38 +85,6 @@ export interface APIApplicationCommandArgumentOptions
 		| ApplicationCommandOptionType.Number;
 	choices?: APIApplicationCommandOptionChoice[];
 	autocomplete?: false;
-}
-
-/**
- * This type is exported as a way to make it stricter for you when you're writing your commands
- *
- * In contrast to `APIApplicationCommandArgumentOptions`, these types cannot have an `choices` array,
- * but they can a `autocomplete` field where it's set to `true`
- */
-export interface APIApplicationCommandStringAutocompleteOptions
-	extends Omit<APIApplicationCommandOptionBase, 'type' | 'autocomplete'> {
-	type: ApplicationCommandOptionType.String;
-	autocomplete: true;
-}
-
-/**
- * This type is exported as a way to make it stricter for you when you're writing your commands
- *
- * In contrast to `APIApplicationCommandArgumentOptions`, these types cannot have an `choices` array,
- * but they can a `autocomplete` field where it's set to `true`
- */
-export interface APIApplicationCommandNumericAutocompleteOptions
-	extends Omit<APIApplicationCommandOptionBase, 'type' | 'autocomplete'> {
-	type: ApplicationCommandOptionType.Integer | ApplicationCommandOptionType.Number;
-	autocomplete: true;
-	/**
-	 * If the option is an `INTEGER` or `NUMBER` type, the minimum value permitted.
-	 */
-	min_value?: number;
-	/**
-	 * If the option is an `INTEGER` or `NUMBER` type, the minimum value permitted.
-	 */
-	max_value?: number;
 }
 
 /**

--- a/payloads/v8/_interactions/_applicationCommands/chatInput.ts
+++ b/payloads/v8/_interactions/_applicationCommands/chatInput.ts
@@ -94,7 +94,7 @@ export interface APIApplicationCommandArgumentOptions
 export interface APIApplicationCommandStringAutocompleteOptions
 	extends Omit<APIApplicationCommandOptionBase, 'type' | 'autocomplete'> {
 	type: ApplicationCommandOptionType.String;
-	autocomplete: true;
+	autocomplete?: true;
 }
 
 /**
@@ -106,7 +106,7 @@ export interface APIApplicationCommandStringAutocompleteOptions
 export interface APIApplicationCommandNumericAutocompleteOptions
 	extends Omit<APIApplicationCommandOptionBase, 'type' | 'autocomplete'> {
 	type: ApplicationCommandOptionType.Integer | ApplicationCommandOptionType.Number;
-	autocomplete: true;
+	autocomplete?: true;
 	/**
 	 * If the option is an `INTEGER` or `NUMBER` type, the minimum value permitted.
 	 */

--- a/payloads/v8/_interactions/_applicationCommands/chatInput.ts
+++ b/payloads/v8/_interactions/_applicationCommands/chatInput.ts
@@ -18,7 +18,6 @@ interface APIApplicationCommandOptionBase {
 	name: string;
 	description: string;
 	required?: boolean;
-	autocomplete?: never;
 }
 
 /**
@@ -94,7 +93,7 @@ export interface APIApplicationCommandArgumentOptions
 export interface APIApplicationCommandStringAutocompleteOptions
 	extends Omit<APIApplicationCommandOptionBase, 'type' | 'autocomplete'> {
 	type: ApplicationCommandOptionType.String;
-	autocomplete?: true;
+	autocomplete: true;
 }
 
 /**
@@ -106,7 +105,7 @@ export interface APIApplicationCommandStringAutocompleteOptions
 export interface APIApplicationCommandNumericAutocompleteOptions
 	extends Omit<APIApplicationCommandOptionBase, 'type' | 'autocomplete'> {
 	type: ApplicationCommandOptionType.Integer | ApplicationCommandOptionType.Number;
-	autocomplete?: true;
+	autocomplete: true;
 	/**
 	 * If the option is an `INTEGER` or `NUMBER` type, the minimum value permitted.
 	 */

--- a/payloads/v9/_interactions/_applicationCommands/chatInput.ts
+++ b/payloads/v9/_interactions/_applicationCommands/chatInput.ts
@@ -29,7 +29,6 @@ export type APIApplicationCommandOption =
 	| APIApplicationCommandSubCommandOptions
 	| APIApplicationCommandOptionBase
 	| APIApplicationCommandChannelOptions
-	| APIApplicationCommandOptionBase
 	| APIApplicationCommandNumberArgumentOptions
 	| APIApplicationCommandStringAutocompleteOptions
 	| APIApplicationCommandNumericAutocompleteOptions;
@@ -69,7 +68,7 @@ export interface APIApplicationCommandStringArgumentOptions
 export interface APIApplicationCommandStringAutocompleteOptions
 	extends Omit<APIApplicationCommandOptionBase, 'type' | 'autocomplete'> {
 	type: ApplicationCommandOptionType.String;
-	autocomplete: true;
+	autocomplete?: true;
 }
 
 /**
@@ -81,7 +80,7 @@ export interface APIApplicationCommandStringAutocompleteOptions
 export interface APIApplicationCommandNumericAutocompleteOptions
 	extends Omit<APIApplicationCommandOptionBase, 'type' | 'autocomplete'> {
 	type: ApplicationCommandOptionType.Integer | ApplicationCommandOptionType.Number;
-	autocomplete: true;
+	autocomplete?: true;
 	/**
 	 * If the option is an `INTEGER` or `NUMBER` type, the minimum value permitted.
 	 */

--- a/payloads/v9/_interactions/_applicationCommands/chatInput.ts
+++ b/payloads/v9/_interactions/_applicationCommands/chatInput.ts
@@ -18,17 +18,21 @@ interface APIApplicationCommandOptionBase {
 	name: string;
 	description: string;
 	required?: boolean;
+	autocomplete?: never;
 }
 
 /**
  * https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure
  */
 export type APIApplicationCommandOption =
-	| APIApplicationCommandChoiceArgumentOptions
+	| APIApplicationCommandStringArgumentOptions
 	| APIApplicationCommandSubCommandOptions
+	| APIApplicationCommandOptionBase
 	| APIApplicationCommandChannelOptions
 	| APIApplicationCommandOptionBase
-	| APIApplicationCommandNumberArgumentOptions;
+	| APIApplicationCommandNumberArgumentOptions
+	| APIApplicationCommandStringAutocompleteOptions
+	| APIApplicationCommandNumericAutocompleteOptions;
 
 /**
  * This type is exported as a way to make it stricter for you when you're writing your commands
@@ -44,16 +48,48 @@ export interface APIApplicationCommandSubCommandOptions extends Omit<APIApplicat
  * This type is exported as a way to make it stricter for you when you're writing your commands
  *
  * In contrast to `APIApplicationCommandSubCommandOptions`, these types cannot have an `options` array,
- * but they can have a either a `choices` or a `autocomplete` field.
+ * but they can have a either a `choices` or a `autocomplete` field where it's set to false.
  */
-export interface APIApplicationCommandChoiceArgumentOptions
+export interface APIApplicationCommandStringArgumentOptions
 	extends Omit<APIApplicationCommandOptionBase, 'type' | 'autocomplete'> {
 	type:
 		| ApplicationCommandOptionType.String
 		| ApplicationCommandOptionType.Integer
 		| ApplicationCommandOptionType.Number;
 	choices?: APIApplicationCommandOptionChoice[];
-	autocomplete?: boolean;
+	autocomplete?: false;
+}
+
+/**
+ * This type is exported as a way to make it stricter for you when you're writing your commands
+ *
+ * In contrast to `APIApplicationCommandArgumentOptions`, these types cannot have an `choices` array,
+ * but they can a `autocomplete` field where it's set to `true`
+ */
+export interface APIApplicationCommandStringAutocompleteOptions
+	extends Omit<APIApplicationCommandOptionBase, 'type' | 'autocomplete'> {
+	type: ApplicationCommandOptionType.String;
+	autocomplete: true;
+}
+
+/**
+ * This type is exported as a way to make it stricter for you when you're writing your commands
+ *
+ * In contrast to `APIApplicationCommandArgumentOptions`, these types cannot have an `choices` array,
+ * but they can a `autocomplete` field where it's set to `true`
+ */
+export interface APIApplicationCommandNumericAutocompleteOptions
+	extends Omit<APIApplicationCommandOptionBase, 'type' | 'autocomplete'> {
+	type: ApplicationCommandOptionType.Integer | ApplicationCommandOptionType.Number;
+	autocomplete: true;
+	/**
+	 * If the option is an `INTEGER` or `NUMBER` type, the minimum value permitted.
+	 */
+	min_value?: number;
+	/**
+	 * If the option is an `INTEGER` or `NUMBER` type, the minimum value permitted.
+	 */
+	max_value?: number;
 }
 
 /**

--- a/payloads/v9/_interactions/_applicationCommands/chatInput.ts
+++ b/payloads/v9/_interactions/_applicationCommands/chatInput.ts
@@ -18,21 +18,17 @@ interface APIApplicationCommandOptionBase {
 	name: string;
 	description: string;
 	required?: boolean;
-	autocomplete?: never;
 }
 
 /**
  * https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure
  */
 export type APIApplicationCommandOption =
-	| APIApplicationCommandStringArgumentOptions
+	| APIApplicationCommandChoiceArgumentOptions
 	| APIApplicationCommandSubCommandOptions
-	| APIApplicationCommandOptionBase
 	| APIApplicationCommandChannelOptions
 	| APIApplicationCommandOptionBase
-	| APIApplicationCommandNumberArgumentOptions
-	| APIApplicationCommandStringAutocompleteOptions
-	| APIApplicationCommandNumericAutocompleteOptions;
+	| APIApplicationCommandNumberArgumentOptions;
 
 /**
  * This type is exported as a way to make it stricter for you when you're writing your commands
@@ -48,48 +44,16 @@ export interface APIApplicationCommandSubCommandOptions extends Omit<APIApplicat
  * This type is exported as a way to make it stricter for you when you're writing your commands
  *
  * In contrast to `APIApplicationCommandSubCommandOptions`, these types cannot have an `options` array,
- * but they can have a either a `choices` or a `autocomplete` field where it's set to false.
+ * but they can have a either a `choices` or a `autocomplete` field.
  */
-export interface APIApplicationCommandStringArgumentOptions
+export interface APIApplicationCommandChoiceArgumentOptions
 	extends Omit<APIApplicationCommandOptionBase, 'type' | 'autocomplete'> {
 	type:
 		| ApplicationCommandOptionType.String
 		| ApplicationCommandOptionType.Integer
 		| ApplicationCommandOptionType.Number;
 	choices?: APIApplicationCommandOptionChoice[];
-	autocomplete?: false;
-}
-
-/**
- * This type is exported as a way to make it stricter for you when you're writing your commands
- *
- * In contrast to `APIApplicationCommandArgumentOptions`, these types cannot have an `choices` array,
- * but they can a `autocomplete` field where it's set to `true`
- */
-export interface APIApplicationCommandStringAutocompleteOptions
-	extends Omit<APIApplicationCommandOptionBase, 'type' | 'autocomplete'> {
-	type: ApplicationCommandOptionType.String;
-	autocomplete: true;
-}
-
-/**
- * This type is exported as a way to make it stricter for you when you're writing your commands
- *
- * In contrast to `APIApplicationCommandArgumentOptions`, these types cannot have an `choices` array,
- * but they can a `autocomplete` field where it's set to `true`
- */
-export interface APIApplicationCommandNumericAutocompleteOptions
-	extends Omit<APIApplicationCommandOptionBase, 'type' | 'autocomplete'> {
-	type: ApplicationCommandOptionType.Integer | ApplicationCommandOptionType.Number;
-	autocomplete: true;
-	/**
-	 * If the option is an `INTEGER` or `NUMBER` type, the minimum value permitted.
-	 */
-	min_value?: number;
-	/**
-	 * If the option is an `INTEGER` or `NUMBER` type, the minimum value permitted.
-	 */
-	max_value?: number;
+	autocomplete?: boolean;
 }
 
 /**

--- a/payloads/v9/_interactions/_applicationCommands/chatInput.ts
+++ b/payloads/v9/_interactions/_applicationCommands/chatInput.ts
@@ -18,7 +18,6 @@ interface APIApplicationCommandOptionBase {
 	name: string;
 	description: string;
 	required?: boolean;
-	autocomplete?: never;
 }
 
 /**
@@ -68,7 +67,7 @@ export interface APIApplicationCommandStringArgumentOptions
 export interface APIApplicationCommandStringAutocompleteOptions
 	extends Omit<APIApplicationCommandOptionBase, 'type' | 'autocomplete'> {
 	type: ApplicationCommandOptionType.String;
-	autocomplete?: true;
+	autocomplete: true;
 }
 
 /**
@@ -80,7 +79,7 @@ export interface APIApplicationCommandStringAutocompleteOptions
 export interface APIApplicationCommandNumericAutocompleteOptions
 	extends Omit<APIApplicationCommandOptionBase, 'type' | 'autocomplete'> {
 	type: ApplicationCommandOptionType.Integer | ApplicationCommandOptionType.Number;
-	autocomplete?: true;
+	autocomplete: true;
 	/**
 	 * If the option is an `INTEGER` or `NUMBER` type, the minimum value permitted.
 	 */

--- a/tests/v9/chatInputOptions.test-d.ts
+++ b/tests/v9/chatInputOptions.test-d.ts
@@ -1,0 +1,62 @@
+import { expectAssignable, expectNotAssignable, expectNotType } from 'tsd';
+import {
+	APIApplicationCommandNumericAutocompleteOptions,
+	APIApplicationCommandOption,
+	APIApplicationCommandStringAutocompleteOptions,
+	ApplicationCommandOptionType,
+} from '../../v9';
+
+const baseValues = {
+	name: 'test',
+	description: 'test',
+};
+
+expectAssignable<APIApplicationCommandStringAutocompleteOptions>({
+	...baseValues,
+	type: ApplicationCommandOptionType.String,
+	autocomplete: true,
+});
+
+expectAssignable<APIApplicationCommandNumericAutocompleteOptions>({
+	...baseValues,
+	type: ApplicationCommandOptionType.Integer,
+	autocomplete: true,
+});
+
+expectAssignable<APIApplicationCommandNumericAutocompleteOptions>({
+	...baseValues,
+	type: ApplicationCommandOptionType.Number,
+	autocomplete: true,
+});
+
+expectNotType<APIApplicationCommandStringAutocompleteOptions>({
+	...baseValues,
+	type: ApplicationCommandOptionType.String,
+	choices: [],
+});
+
+expectNotAssignable<APIApplicationCommandStringAutocompleteOptions>({
+	...baseValues,
+	type: ApplicationCommandOptionType.String,
+	choices: [],
+	autocomplete: true,
+});
+
+expectNotAssignable<APIApplicationCommandStringAutocompleteOptions>({
+	...baseValues,
+	type: ApplicationCommandOptionType.String,
+	choices: [],
+	autocomplete: false,
+});
+
+expectNotAssignable<APIApplicationCommandNumericAutocompleteOptions>({
+	...baseValues,
+	type: ApplicationCommandOptionType.Number,
+	choices: [],
+});
+
+expectNotAssignable<APIApplicationCommandOption>({
+	...baseValues,
+	type: ApplicationCommandOptionType.Boolean,
+	autocomplete: true,
+});


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The previous way that autocomplete was enforced create types that were hard/near impossible to use. This PR sacrifices the type strength for usability making it waaay easier to adopt. So essentially `choices` and `autocomplete` are no longer mutually exclusive.