### PR TITLE
fix: change never type to boolean for autocomplete in options

### DIFF
--- a/deno/payloads/v9/_interactions/_applicationCommands/chatInput.ts
+++ b/deno/payloads/v9/_interactions/_applicationCommands/chatInput.ts
@@ -18,7 +18,7 @@ interface APIApplicationCommandOptionBase {
 	name: string;
 	description: string;
 	required?: boolean;
-	autocomplete?: never;
+	autocomplete?: boolean;
 }
 
 /**

--- a/payloads/v9/_interactions/_applicationCommands/chatInput.ts
+++ b/payloads/v9/_interactions/_applicationCommands/chatInput.ts
@@ -18,7 +18,7 @@ interface APIApplicationCommandOptionBase {
 	name: string;
 	description: string;
 	required?: boolean;
-	autocomplete?: never;
+	autocomplete?: boolean;
 }
 
 /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This fix a typing issue for the `autocomplete` option in the APIApplicationCommandOptionBase interface.

**Reference Discord API Docs PRs or commits:**
https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure

(I'm not sure I did something wrong because I have a lot of changed files in my commit, feel free to tell me what's the right thing to do)