### PR TITLE
fix(BasePayload): `s` and `t` can be nullable

### DIFF
--- a/gateway/v9.ts
+++ b/gateway/v9.ts
@@ -1650,11 +1650,11 @@ interface BasePayload {
 	/**
 	 * Sequence number, used for resuming sessions and heartbeats
 	 */
-	s: number;
+	s: number | null;
 	/**
 	 * The event name for this payload
 	 */
-	t?: string;
+	t?: string | null;
 }
 
 type NonDispatchPayload = Omit<BasePayload, 't'>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
In some cases the `s` and `t` fields on gateway payloads can be `null`, e.g. in case of op code `10` (Hello). This was previously not reflected in the typings, which this PR changes.

**Reference Discord API Docs PRs or commits:**
https://github.com/discord/discord-api-docs/blob/master/docs/topics/Gateway.md?plain=1#L28-L31