### PR TITLE
fix(NonDispatchPayload): `t` & `s` fields are always null on non-dispatch payloads

### DIFF
--- a/deno/gateway/v8.ts
+++ b/deno/gateway/v8.ts
@@ -1568,7 +1568,10 @@ interface BasePayload {
 	t?: string;
 }
 
-type NonDispatchPayload = Omit<BasePayload, 't'>;
+type NonDispatchPayload = Omit<BasePayload, 't' | 's'> & {
+	t: null;
+	s: null;
+};
 
 interface DataPayload<Event extends GatewayDispatchEvents, D = unknown> extends BasePayload {
 	op: GatewayOpcodes.Dispatch;

--- a/deno/gateway/v9.ts
+++ b/deno/gateway/v9.ts
@@ -1657,7 +1657,10 @@ interface BasePayload {
 	t?: string;
 }
 
-type NonDispatchPayload = Omit<BasePayload, 't'>;
+type NonDispatchPayload = Omit<BasePayload, 't' | 's'> & {
+	t: null;
+	s: null;
+};
 
 interface DataPayload<Event extends GatewayDispatchEvents, D = unknown> extends BasePayload {
 	op: GatewayOpcodes.Dispatch;

--- a/gateway/v8.ts
+++ b/gateway/v8.ts
@@ -1568,7 +1568,10 @@ interface BasePayload {
 	t?: string;
 }
 
-type NonDispatchPayload = Omit<BasePayload, 't'>;
+type NonDispatchPayload = Omit<BasePayload, 't' | 's'> & {
+	t: null;
+	s: null;
+};
 
 interface DataPayload<Event extends GatewayDispatchEvents, D = unknown> extends BasePayload {
 	op: GatewayOpcodes.Dispatch;

--- a/gateway/v9.ts
+++ b/gateway/v9.ts
@@ -1657,7 +1657,10 @@ interface BasePayload {
 	t?: string;
 }
 
-type NonDispatchPayload = Omit<BasePayload, 't'>;
+type NonDispatchPayload = Omit<BasePayload, 't' | 's'> & {
+	t: null;
+	s: null;
+};
 
 interface DataPayload<Event extends GatewayDispatchEvents, D = unknown> extends BasePayload {
 	op: GatewayOpcodes.Dispatch;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR does pretty much does the same thing as #258, except in a more elegant way. #258 would have made the field `t` and `s` always nullable, not just on non-dispatch payloads like this PR now does.

**Reference Discord API Docs PRs or commits:**
https://github.com/discord/discord-api-docs/blob/master/docs/topics/Gateway.md?plain=1#L28-L31