### PR TITLE
fix: only a partial object is needed when updating attachments

### DIFF
--- a/deno/rest/v8/channel.ts
+++ b/deno/rest/v8/channel.ts
@@ -331,7 +331,7 @@ export interface RESTPatchAPIChannelMessageJSONBody {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#attachment-object
 	 */
-	attachments?: APIAttachment[] | null;
+	attachments?: (Pick<APIAttachment, 'id'> & Partial<Pick<APIAttachment, 'filename' | 'description'>>)[];
 	/**
 	 * The components to include with the message
 	 *

--- a/deno/rest/v8/webhook.ts
+++ b/deno/rest/v8/webhook.ts
@@ -234,7 +234,7 @@ export interface RESTPatchAPIWebhookWithTokenMessageJSONBody
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#attachment-object
 	 */
-	attachments?: APIAttachment[] | null;
+	attachments?: (Pick<APIAttachment, 'id'> & Partial<Pick<APIAttachment, 'filename' | 'description'>>)[];
 }
 
 /**

--- a/deno/rest/v9/channel.ts
+++ b/deno/rest/v9/channel.ts
@@ -365,7 +365,7 @@ export interface RESTPatchAPIChannelMessageJSONBody {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#attachment-object
 	 */
-	attachments?: APIAttachment[] | null;
+	attachments?: (Pick<APIAttachment, 'id'> & Partial<Pick<APIAttachment, 'filename' | 'description'>>)[];
 	/**
 	 * The components to include with the message
 	 *

--- a/deno/rest/v9/webhook.ts
+++ b/deno/rest/v9/webhook.ts
@@ -238,7 +238,7 @@ export interface RESTPatchAPIWebhookWithTokenMessageJSONBody
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#attachment-object
 	 */
-	attachments?: APIAttachment[] | null;
+	attachments?: (Pick<APIAttachment, 'id'> & Partial<Pick<APIAttachment, 'filename' | 'description'>>)[];
 }
 
 /**

--- a/rest/v8/channel.ts
+++ b/rest/v8/channel.ts
@@ -331,7 +331,7 @@ export interface RESTPatchAPIChannelMessageJSONBody {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#attachment-object
 	 */
-	attachments?: APIAttachment[] | null;
+	attachments?: (Pick<APIAttachment, 'id'> & Partial<Pick<APIAttachment, 'filename' | 'description'>>)[];
 	/**
 	 * The components to include with the message
 	 *

--- a/rest/v8/webhook.ts
+++ b/rest/v8/webhook.ts
@@ -234,7 +234,7 @@ export interface RESTPatchAPIWebhookWithTokenMessageJSONBody
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#attachment-object
 	 */
-	attachments?: APIAttachment[] | null;
+	attachments?: (Pick<APIAttachment, 'id'> & Partial<Pick<APIAttachment, 'filename' | 'description'>>)[];
 }
 
 /**

--- a/rest/v9/channel.ts
+++ b/rest/v9/channel.ts
@@ -365,7 +365,7 @@ export interface RESTPatchAPIChannelMessageJSONBody {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#attachment-object
 	 */
-	attachments?: APIAttachment[] | null;
+	attachments?: (Pick<APIAttachment, 'id'> & Partial<Pick<APIAttachment, 'filename' | 'description'>>)[];
 	/**
 	 * The components to include with the message
 	 *

--- a/rest/v9/webhook.ts
+++ b/rest/v9/webhook.ts
@@ -238,7 +238,7 @@ export interface RESTPatchAPIWebhookWithTokenMessageJSONBody
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#attachment-object
 	 */
-	attachments?: APIAttachment[] | null;
+	attachments?: (Pick<APIAttachment, 'id'> & Partial<Pick<APIAttachment, 'filename' | 'description'>>)[];
 }
 
 /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR changes the type of the `attachments` field of every message update body from a complete attachment object to only a partial object, with only the ID required.

It is currently impossible to send a query with all the information the typings are asking for, and sending fields like `filename` for already uploaded files results in an error from the API.

**Reference Discord API Docs PRs or commits:**
None