### PR TITLE
fix(GatewayStageInstance): Stage Instance dispatches not included in `GatewayDispatchPayload`

### DIFF
--- a/deno/gateway/v9.ts
+++ b/deno/gateway/v9.ts
@@ -302,6 +302,9 @@ export type GatewayDispatchPayload =
 	| GatewayMessageReactionRemoveEmojiDispatch
 	| GatewayMessageUpdateDispatch
 	| GatewayPresenceUpdateDispatch
+	| GatewayStageInstanceCreateDispatch
+	| GatewayStageInstanceDeleteDispatch
+	| GatewayStageInstanceUpdateDispatch
 	| GatewayReadyDispatch
 	| GatewayResumedDispatch
 	| GatewayThreadListSyncDispatch

--- a/gateway/v9.ts
+++ b/gateway/v9.ts
@@ -302,6 +302,9 @@ export type GatewayDispatchPayload =
 	| GatewayMessageReactionRemoveEmojiDispatch
 	| GatewayMessageUpdateDispatch
 	| GatewayPresenceUpdateDispatch
+	| GatewayStageInstanceCreateDispatch
+	| GatewayStageInstanceDeleteDispatch
+	| GatewayStageInstanceUpdateDispatch
 	| GatewayReadyDispatch
 	| GatewayResumedDispatch
 	| GatewayThreadListSyncDispatch


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Adds `GatewayStageInstanceCreateDispatch`, `GatewayStageInstanceDeleteDispatch`, and `GatewayStageInstanceUpdateDispatch` to `GatewayDispatchPayload` in `/gateway/v9`.

**Reference Discord API Docs PRs or commits:**
- [Discord API Reference](https://discord.com/developers/docs/topics/gateway#commands-and-events-gateway-events)
- Stage Instance dispatches are already [included in v8](https://github.com/discordjs/discord-api-types/blob/315ce3584917635b93a26123470f37a10bd8d846/gateway/v8.ts#L296-L298)