### PR TITLE
feat(APIInteraction): add locale props to interactions

### DIFF
--- a/deno/payloads/v8/_interactions/base.ts
+++ b/deno/payloads/v8/_interactions/base.ts
@@ -86,6 +86,14 @@ export interface APIBaseInteraction<Type extends InteractionType, Data extends u
 	 * For components, the message they were attached to
 	 */
 	message?: APIMessage;
+	/**
+	 * The selected language of the invoking user
+	 */
+	locale: string;
+	/**
+	 * The guild's preferred locale, if invoked in a guild
+	 */
+	guild_locale?: string;
 }
 
 export type APIDMInteractionWrapper<Original extends APIBaseInteraction<InteractionType, unknown>> = Omit<

--- a/deno/payloads/v8/_interactions/ping.ts
+++ b/deno/payloads/v8/_interactions/ping.ts
@@ -1,4 +1,4 @@
 import type { APIBaseInteraction } from './base.ts';
 import type { InteractionType } from './responses.ts';
 
-export type APIPingInteraction = APIBaseInteraction<InteractionType.Ping, never>;
+export type APIPingInteraction = Omit<APIBaseInteraction<InteractionType.Ping, never>, 'locale'>;

--- a/deno/payloads/v9/_interactions/base.ts
+++ b/deno/payloads/v9/_interactions/base.ts
@@ -86,6 +86,14 @@ export interface APIBaseInteraction<Type extends InteractionType, Data extends u
 	 * For components, the message they were attached to
 	 */
 	message?: APIMessage;
+	/**
+	 * The selected language of the invoking user
+	 */
+	locale: string;
+	/**
+	 * The guild's preferred locale, if invoked in a guild
+	 */
+	guild_locale?: string;
 }
 
 export type APIDMInteractionWrapper<Original extends APIBaseInteraction<InteractionType, unknown>> = Omit<

--- a/deno/payloads/v9/_interactions/ping.ts
+++ b/deno/payloads/v9/_interactions/ping.ts
@@ -1,4 +1,4 @@
 import type { APIBaseInteraction } from './base.ts';
 import type { InteractionType } from './responses.ts';
 
-export type APIPingInteraction = APIBaseInteraction<InteractionType.Ping, never>;
+export type APIPingInteraction = Omit<APIBaseInteraction<InteractionType.Ping, never>, 'locale'>;

--- a/payloads/v8/_interactions/base.ts
+++ b/payloads/v8/_interactions/base.ts
@@ -86,6 +86,14 @@ export interface APIBaseInteraction<Type extends InteractionType, Data extends u
 	 * For components, the message they were attached to
 	 */
 	message?: APIMessage;
+	/**
+	 * The selected language of the invoking user
+	 */
+	locale: string;
+	/**
+	 * The guild's preferred locale, if invoked in a guild
+	 */
+	guild_locale?: string;
 }
 
 export type APIDMInteractionWrapper<Original extends APIBaseInteraction<InteractionType, unknown>> = Omit<

--- a/payloads/v8/_interactions/ping.ts
+++ b/payloads/v8/_interactions/ping.ts
@@ -1,4 +1,4 @@
 import type { APIBaseInteraction } from './base';
 import type { InteractionType } from './responses';
 
-export type APIPingInteraction = APIBaseInteraction<InteractionType.Ping, never>;
+export type APIPingInteraction = Omit<APIBaseInteraction<InteractionType.Ping, never>, 'locale'>;

--- a/payloads/v9/_interactions/base.ts
+++ b/payloads/v9/_interactions/base.ts
@@ -86,6 +86,14 @@ export interface APIBaseInteraction<Type extends InteractionType, Data extends u
 	 * For components, the message they were attached to
 	 */
 	message?: APIMessage;
+	/**
+	 * The selected language of the invoking user
+	 */
+	locale: string;
+	/**
+	 * The guild's preferred locale, if invoked in a guild
+	 */
+	guild_locale?: string;
 }
 
 export type APIDMInteractionWrapper<Original extends APIBaseInteraction<InteractionType, unknown>> = Omit<

--- a/payloads/v9/_interactions/ping.ts
+++ b/payloads/v9/_interactions/ping.ts
@@ -1,4 +1,4 @@
 import type { APIBaseInteraction } from './base';
 import type { InteractionType } from './responses';
 
-export type APIPingInteraction = APIBaseInteraction<InteractionType.Ping, never>;
+export type APIPingInteraction = Omit<APIBaseInteraction<InteractionType.Ping, never>, 'locale'>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Note: `locale` is being set to required on `APIBaseInteraction` simply because it's `Omit`'ed from the Ping interaction. Ping is the only case where `locale` isn't present.

**Reference Discord API Docs PRs or commits:**
- https://github.com/discord/discord-api-docs/pull/4265
