### PR TITLE
feat(APIGuildScheduledEvent): add more precise types for stage instance/voice/external events

### DIFF
--- a/deno/payloads/v8/guildScheduledEvent.ts
+++ b/deno/payloads/v8/guildScheduledEvent.ts
@@ -2,7 +2,7 @@ import type { APIUser } from './user.ts';
 import type { APIGuildMember } from './guild.ts';
 import type { Snowflake } from '../../globals.ts';
 
-export interface APIGuildScheduledEvent {
+interface APIGuildScheduledEventBase<Type extends GuildScheduledEventEntityType> {
 	/**
 	 * The id of the guild event
 	 */
@@ -46,7 +46,7 @@ export interface APIGuildScheduledEvent {
 	/**
 	 * The type of hosting entity associated with the scheduled event
 	 */
-	entity_type: GuildScheduledEventEntityType;
+	entity_type: Type;
 	/**
 	 * The id of the hosting entity associated with the scheduled event
 	 */
@@ -54,7 +54,7 @@ export interface APIGuildScheduledEvent {
 	/**
 	 * The entity metadata for the scheduled event
 	 */
-	entity_metadata: APIGuildScheduledEventEntityMetadata;
+	entity_metadata: APIGuildScheduledEventEntityMetadata | null;
 	/**
 	 * The user that created the scheduled event
 	 */
@@ -64,6 +64,31 @@ export interface APIGuildScheduledEvent {
 	 */
 	user_count?: number;
 }
+
+export interface APIStageInstanceGuildScheduledEvent
+	extends APIGuildScheduledEventBase<GuildScheduledEventEntityType.StageInstance> {
+	channel_id: Snowflake;
+	entity_metadata: null;
+}
+
+export interface APIVoiceGuildScheduledEvent extends APIGuildScheduledEventBase<GuildScheduledEventEntityType.Voice> {
+	channel_id: Snowflake;
+	entity_metadata: null;
+}
+
+export interface APIExternalGuildScheduledEvent
+	extends APIGuildScheduledEventBase<GuildScheduledEventEntityType.External> {
+	channel_id: null;
+	entity_metadata: Required<APIGuildScheduledEventEntityMetadata>;
+}
+
+/**
+ * https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-structure
+ */
+export type APIGuildScheduledEvent =
+	| APIStageInstanceGuildScheduledEvent
+	| APIVoiceGuildScheduledEvent
+	| APIExternalGuildScheduledEvent;
 
 /**
  * https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-entity-metadata

--- a/deno/payloads/v9/guildScheduledEvent.ts
+++ b/deno/payloads/v9/guildScheduledEvent.ts
@@ -2,7 +2,7 @@ import type { APIUser } from './user.ts';
 import type { APIGuildMember } from './guild.ts';
 import type { Snowflake } from '../../globals.ts';
 
-export interface APIGuildScheduledEvent {
+interface APIGuildScheduledEventBase<Type extends GuildScheduledEventEntityType> {
 	/**
 	 * The id of the guild event
 	 */
@@ -46,7 +46,7 @@ export interface APIGuildScheduledEvent {
 	/**
 	 * The type of hosting entity associated with the scheduled event
 	 */
-	entity_type: GuildScheduledEventEntityType;
+	entity_type: Type;
 	/**
 	 * The id of the hosting entity associated with the scheduled event
 	 */
@@ -54,7 +54,7 @@ export interface APIGuildScheduledEvent {
 	/**
 	 * The entity metadata for the scheduled event
 	 */
-	entity_metadata: APIGuildScheduledEventEntityMetadata;
+	entity_metadata: APIGuildScheduledEventEntityMetadata | null;
 	/**
 	 * The user that created the scheduled event
 	 */
@@ -64,6 +64,31 @@ export interface APIGuildScheduledEvent {
 	 */
 	user_count?: number;
 }
+
+export interface APIStageInstanceGuildScheduledEvent
+	extends APIGuildScheduledEventBase<GuildScheduledEventEntityType.StageInstance> {
+	channel_id: Snowflake;
+	entity_metadata: null;
+}
+
+export interface APIVoiceGuildScheduledEvent extends APIGuildScheduledEventBase<GuildScheduledEventEntityType.Voice> {
+	channel_id: Snowflake;
+	entity_metadata: null;
+}
+
+export interface APIExternalGuildScheduledEvent
+	extends APIGuildScheduledEventBase<GuildScheduledEventEntityType.External> {
+	channel_id: null;
+	entity_metadata: Required<APIGuildScheduledEventEntityMetadata>;
+}
+
+/**
+ * https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-structure
+ */
+export type APIGuildScheduledEvent =
+	| APIStageInstanceGuildScheduledEvent
+	| APIVoiceGuildScheduledEvent
+	| APIExternalGuildScheduledEvent;
 
 /**
  * https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-entity-metadata

--- a/payloads/v8/guildScheduledEvent.ts
+++ b/payloads/v8/guildScheduledEvent.ts
@@ -2,7 +2,7 @@ import type { APIUser } from './user';
 import type { APIGuildMember } from './guild';
 import type { Snowflake } from '../../globals';
 
-export interface APIGuildScheduledEvent {
+interface APIGuildScheduledEventBase<Type extends GuildScheduledEventEntityType> {
 	/**
 	 * The id of the guild event
 	 */
@@ -46,7 +46,7 @@ export interface APIGuildScheduledEvent {
 	/**
 	 * The type of hosting entity associated with the scheduled event
 	 */
-	entity_type: GuildScheduledEventEntityType;
+	entity_type: Type;
 	/**
 	 * The id of the hosting entity associated with the scheduled event
 	 */
@@ -54,7 +54,7 @@ export interface APIGuildScheduledEvent {
 	/**
 	 * The entity metadata for the scheduled event
 	 */
-	entity_metadata: APIGuildScheduledEventEntityMetadata;
+	entity_metadata: APIGuildScheduledEventEntityMetadata | null;
 	/**
 	 * The user that created the scheduled event
 	 */
@@ -64,6 +64,31 @@ export interface APIGuildScheduledEvent {
 	 */
 	user_count?: number;
 }
+
+export interface APIStageInstanceGuildScheduledEvent
+	extends APIGuildScheduledEventBase<GuildScheduledEventEntityType.StageInstance> {
+	channel_id: Snowflake;
+	entity_metadata: null;
+}
+
+export interface APIVoiceGuildScheduledEvent extends APIGuildScheduledEventBase<GuildScheduledEventEntityType.Voice> {
+	channel_id: Snowflake;
+	entity_metadata: null;
+}
+
+export interface APIExternalGuildScheduledEvent
+	extends APIGuildScheduledEventBase<GuildScheduledEventEntityType.External> {
+	channel_id: null;
+	entity_metadata: Required<APIGuildScheduledEventEntityMetadata>;
+}
+
+/**
+ * https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-structure
+ */
+export type APIGuildScheduledEvent =
+	| APIStageInstanceGuildScheduledEvent
+	| APIVoiceGuildScheduledEvent
+	| APIExternalGuildScheduledEvent;
 
 /**
  * https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-entity-metadata

--- a/payloads/v9/guildScheduledEvent.ts
+++ b/payloads/v9/guildScheduledEvent.ts
@@ -2,7 +2,7 @@ import type { APIUser } from './user';
 import type { APIGuildMember } from './guild';
 import type { Snowflake } from '../../globals';
 
-export interface APIGuildScheduledEvent {
+interface APIGuildScheduledEventBase<Type extends GuildScheduledEventEntityType> {
 	/**
 	 * The id of the guild event
 	 */
@@ -46,7 +46,7 @@ export interface APIGuildScheduledEvent {
 	/**
 	 * The type of hosting entity associated with the scheduled event
 	 */
-	entity_type: GuildScheduledEventEntityType;
+	entity_type: Type;
 	/**
 	 * The id of the hosting entity associated with the scheduled event
 	 */
@@ -54,7 +54,7 @@ export interface APIGuildScheduledEvent {
 	/**
 	 * The entity metadata for the scheduled event
 	 */
-	entity_metadata: APIGuildScheduledEventEntityMetadata;
+	entity_metadata: APIGuildScheduledEventEntityMetadata | null;
 	/**
 	 * The user that created the scheduled event
 	 */
@@ -64,6 +64,31 @@ export interface APIGuildScheduledEvent {
 	 */
 	user_count?: number;
 }
+
+export interface APIStageInstanceGuildScheduledEvent
+	extends APIGuildScheduledEventBase<GuildScheduledEventEntityType.StageInstance> {
+	channel_id: Snowflake;
+	entity_metadata: null;
+}
+
+export interface APIVoiceGuildScheduledEvent extends APIGuildScheduledEventBase<GuildScheduledEventEntityType.Voice> {
+	channel_id: Snowflake;
+	entity_metadata: null;
+}
+
+export interface APIExternalGuildScheduledEvent
+	extends APIGuildScheduledEventBase<GuildScheduledEventEntityType.External> {
+	channel_id: null;
+	entity_metadata: Required<APIGuildScheduledEventEntityMetadata>;
+}
+
+/**
+ * https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-structure
+ */
+export type APIGuildScheduledEvent =
+	| APIStageInstanceGuildScheduledEvent
+	| APIVoiceGuildScheduledEvent
+	| APIExternalGuildScheduledEvent;
 
 /**
  * https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-entity-metadata


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR turns `APIGuildScheduledEvent` into a union of `APIStageInstanceGuildScheduledEvent`, `APIVoiceGuildScheduledEvent`, and `APIExternalGuildScheduledEvent`, which each has more precise types according to the docs.

This PR also fixes a bug as previously `APIGuildScheduledEvent#entity_metadata` was not nullable, even though it should be.

**Reference Discord API Docs PRs or commits:**

- https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-field-requirements-by-entity-type

---

Technically, `entity_metadata` isn’t always `null` for stage instance events (see https://github.com/discord/discord-api-docs/issues/4198) and contains a `speaker_ids` field, but that [isn’t documented anymore](https://github.com/discord/discord-api-docs/pull/4113#discussion_r751815818).

From [this comment](https://github.com/discord/discord-api-docs/issues/4198#issuecomment-988227322):

> there are currently no plans on publicly supporting this field for events with type STAGE_INSTANCE. this is more of a free form metadata property with no guarantees for this field to be non-null in the future for STAGE_INSTANCE events.

I decided to make `entity_metadata` `null` for stage instance events as that is what the documentation states.