### PR TITLE
fix(package.json) missing main attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
 	"version": "0.26.0",
 	"description": "Discord API typings that are kept up to date for use in bot library creation.",
 	"types": "./v9.d.ts",
+	"main": "./v9.js",
 	"exports": {
 		"./globals": {
 			"require": "./globals.js",


### PR DESCRIPTION
I'm using ``discord-api-types`` in a react-native project, however bundling fails because ``package.json`` doesn't have a ``main`` attribute, which indicates the main entry point of the module.
That's why I set ``"main"`` to the current up to date file ``"./v9.js"``.