### PR TITLE
chore: bump LICENSE year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 vladfrangu
+Copyright (c) 2020 - 2022 vladfrangu
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Another year, another bump. Bumps the license year to 2022!

Note: "2020 - 2022" instead for consistency.
