### PR TITLE
Add timeout-related fields to Modify Guild Member JSON body

### DIFF
--- a/rest/v8/guild.ts
+++ b/rest/v8/guild.ts
@@ -435,6 +435,10 @@ export type RESTPatchAPIGuildMemberJSONBody = AddUndefinedToPossiblyUndefinedPro
 	 * Requires `MOVE_MEMBERS` permission
 	 */
 	channel_id?: Snowflake | null;
+	/**
+	 * Timestamp of when the time out will be removed; until then, they cannot interact with the guild
+	 */
+	communication_disabled_until?: string | null;
 }>;
 
 /**

--- a/rest/v9/guild.ts
+++ b/rest/v9/guild.ts
@@ -441,6 +441,10 @@ export type RESTPatchAPIGuildMemberJSONBody = AddUndefinedToPossiblyUndefinedPro
 	 * Requires `MOVE_MEMBERS` permission
 	 */
 	channel_id?: Snowflake | null;
+	/**
+	 * Timestamp of when the time out will be removed; until then, they cannot interact with the guild
+	 */
+	communication_disabled_until?: string | null;
 }>;
 
 /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:** `communication_disabled_until` is an accepted field in the "Modify Guild Member" JSON body. This is a minor change that updates the corresponding type in API v8 and v9 to reflect that.

**Reference Discord API Docs PRs or commits:**
https://github.com/discord/discord-api-docs/pull/4075