### PR TITLE
feat(Routes): add route for oauth2 application assets

### DIFF
--- a/deno/rest/v8/mod.ts
+++ b/deno/rest/v8/mod.ts
@@ -606,6 +606,14 @@ export const Routes = {
 
 	/**
 	 * Route for:
+	 * - GET `/oauth2/applications/{application.id}/assets`
+	 */
+	oauth2ApplicationAssets(applicationId: Snowflake) {
+		return `/oauth2/applications/${applicationId}/assets` as const;
+	},
+
+	/**
+	 * Route for:
 	 * - GET  `/applications/{application.id}/commands`
 	 * - PUT  `/applications/{application.id}/commands`
 	 * - POST `/applications/{application.id}/commands`

--- a/deno/rest/v8/oauth2.ts
+++ b/deno/rest/v8/oauth2.ts
@@ -197,3 +197,16 @@ export interface RESTPostOAuth2AccessTokenWithBotAndWebhookIncomingScopeResult {
 
 export type RESTPostOAuth2AccessTokenWithBotAndGuildsAndWebhookIncomingScopeResult =
 	RESTPostOAuth2AccessTokenWithBotAndGuildsScopeResult & RESTPostOAuth2AccessTokenWithBotAndWebhookIncomingScopeResult;
+
+export enum OAuth2ApplicationAssetType {
+	Small = 1,
+	Big,
+}
+
+export interface APIOAuth2ApplicationAsset {
+	id: Snowflake;
+	name: string;
+	type: OAuth2ApplicationAssetType;
+}
+
+export type RESTGetAPIOAuth2ApplicationAssetsResult = APIOAuth2ApplicationAsset[];

--- a/deno/rest/v9/mod.ts
+++ b/deno/rest/v9/mod.ts
@@ -675,6 +675,14 @@ export const Routes = {
 
 	/**
 	 * Route for:
+	 * - GET `/oauth2/applications/{application.id}/assets`
+	 */
+	oauth2ApplicationAssets(applicationId: Snowflake) {
+		return `/oauth2/applications/${applicationId}/assets` as const;
+	},
+
+	/**
+	 * Route for:
 	 * - GET  `/applications/{application.id}/commands`
 	 * - PUT  `/applications/{application.id}/commands`
 	 * - POST `/applications/{application.id}/commands`

--- a/deno/rest/v9/oauth2.ts
+++ b/deno/rest/v9/oauth2.ts
@@ -197,3 +197,16 @@ export interface RESTPostOAuth2AccessTokenWithBotAndWebhookIncomingScopeResult {
 
 export type RESTPostOAuth2AccessTokenWithBotAndGuildsAndWebhookIncomingScopeResult =
 	RESTPostOAuth2AccessTokenWithBotAndGuildsScopeResult & RESTPostOAuth2AccessTokenWithBotAndWebhookIncomingScopeResult;
+
+export enum OAuth2ApplicationAssetType {
+	Small = 1,
+	Big,
+}
+
+export interface APIOAuth2ApplicationAsset {
+	id: Snowflake;
+	name: string;
+	type: OAuth2ApplicationAssetType;
+}
+
+export type RESTGetAPIOAuth2ApplicationAssetsResult = APIOAuth2ApplicationAsset[];

--- a/rest/v8/index.ts
+++ b/rest/v8/index.ts
@@ -606,6 +606,14 @@ export const Routes = {
 
 	/**
 	 * Route for:
+	 * - GET `/oauth2/applications/{application.id}/assets`
+	 */
+	oauth2ApplicationAssets(applicationId: Snowflake) {
+		return `/oauth2/applications/${applicationId}/assets` as const;
+	},
+
+	/**
+	 * Route for:
 	 * - GET  `/applications/{application.id}/commands`
 	 * - PUT  `/applications/{application.id}/commands`
 	 * - POST `/applications/{application.id}/commands`

--- a/rest/v8/oauth2.ts
+++ b/rest/v8/oauth2.ts
@@ -197,3 +197,16 @@ export interface RESTPostOAuth2AccessTokenWithBotAndWebhookIncomingScopeResult {
 
 export type RESTPostOAuth2AccessTokenWithBotAndGuildsAndWebhookIncomingScopeResult =
 	RESTPostOAuth2AccessTokenWithBotAndGuildsScopeResult & RESTPostOAuth2AccessTokenWithBotAndWebhookIncomingScopeResult;
+
+export enum OAuth2ApplicationAssetType {
+	Small = 1,
+	Big,
+}
+
+export interface APIOAuth2ApplicationAsset {
+	id: Snowflake;
+	name: string;
+	type: OAuth2ApplicationAssetType;
+}
+
+export type RESTGetAPIOAuth2ApplicationAssetsResult = APIOAuth2ApplicationAsset[];

--- a/rest/v9/index.ts
+++ b/rest/v9/index.ts
@@ -675,6 +675,14 @@ export const Routes = {
 
 	/**
 	 * Route for:
+	 * - GET `/oauth2/applications/{application.id}/assets`
+	 */
+	oauth2ApplicationAssets(applicationId: Snowflake) {
+		return `/oauth2/applications/${applicationId}/assets` as const;
+	},
+
+	/**
+	 * Route for:
 	 * - GET  `/applications/{application.id}/commands`
 	 * - PUT  `/applications/{application.id}/commands`
 	 * - POST `/applications/{application.id}/commands`

--- a/rest/v9/oauth2.ts
+++ b/rest/v9/oauth2.ts
@@ -197,3 +197,16 @@ export interface RESTPostOAuth2AccessTokenWithBotAndWebhookIncomingScopeResult {
 
 export type RESTPostOAuth2AccessTokenWithBotAndGuildsAndWebhookIncomingScopeResult =
 	RESTPostOAuth2AccessTokenWithBotAndGuildsScopeResult & RESTPostOAuth2AccessTokenWithBotAndWebhookIncomingScopeResult;
+
+export enum OAuth2ApplicationAssetType {
+	Small = 1,
+	Big,
+}
+
+export interface APIOAuth2ApplicationAsset {
+	id: Snowflake;
+	name: string;
+	type: OAuth2ApplicationAssetType;
+}
+
+export type RESTGetAPIOAuth2ApplicationAssetsResult = APIOAuth2ApplicationAsset[];


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Adds a new route for application assets. I'm actually not sure where this is documented but discord.js uses it so it should exist.

**Reference Discord API Docs PRs or commits:**

https://github.com/discordjs/discord.js/blob/main/packages/discord.js/src/structures/interfaces/Application.js#L108