### PR TITLE
refactor(ActivityType): change `Game` to `Playing`

### DIFF
--- a/deno/payloads/v8/gateway.ts
+++ b/deno/payloads/v8/gateway.ts
@@ -220,7 +220,7 @@ export enum ActivityType {
 	/**
 	 * Playing {game}
 	 */
-	Game,
+	Playing,
 	/**
 	 * Streaming {details}
 	 */

--- a/deno/payloads/v9/gateway.ts
+++ b/deno/payloads/v9/gateway.ts
@@ -221,7 +221,7 @@ export enum ActivityType {
 	/**
 	 * Playing {game}
 	 */
-	Game,
+	Playing,
 	/**
 	 * Streaming {details}
 	 */

--- a/payloads/v8/gateway.ts
+++ b/payloads/v8/gateway.ts
@@ -220,7 +220,7 @@ export const enum ActivityType {
 	/**
 	 * Playing {game}
 	 */
-	Game,
+	Playing,
 	/**
 	 * Streaming {details}
 	 */

--- a/payloads/v9/gateway.ts
+++ b/payloads/v9/gateway.ts
@@ -221,7 +221,7 @@ export const enum ActivityType {
 	/**
 	 * Playing {game}
 	 */
-	Game,
+	Playing,
 	/**
 	 * Streaming {details}
 	 */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR changes the "Game" activity type to "Playing" to match with the Discord API docs name (https://discord.com/developers/docs/game-sdk/activities#data-models-activitytype-enum) and to be in line with the old discord.js name for the same type

**Reference Discord API Docs PRs or commits:**
