### PR TITLE
refactor: change const enums to regular enums

### DIFF
--- a/deno/voice/v4.ts
+++ b/deno/voice/v4.ts
@@ -3,7 +3,7 @@ export const VoiceGatewayVersion = '4';
 /**
  * https://discord.com/developers/docs/topics/opcodes-and-status-codes#voice-voice-opcodes
  */
-export const enum VoiceOpcodes {
+export enum VoiceOpcodes {
 	/**
 	 * Begin a voice websocket connection
 	 */
@@ -57,7 +57,7 @@ export const enum VoiceOpcodes {
 /**
  * https://discord.com/developers/docs/topics/opcodes-and-status-codes#voice-voice-close-event-codes
  */
-export const enum VoiceCloseCodes {
+export enum VoiceCloseCodes {
 	/**
 	 * You sent an invalid opcode
 	 */

--- a/deno/voice/v4.ts
+++ b/deno/voice/v4.ts
@@ -3,7 +3,7 @@ export const VoiceGatewayVersion = '4';
 /**
  * https://discord.com/developers/docs/topics/opcodes-and-status-codes#voice-voice-opcodes
  */
-export enum VoiceOpcodes {
+export const enum VoiceOpcodes {
 	/**
 	 * Begin a voice websocket connection
 	 */
@@ -57,7 +57,7 @@ export enum VoiceOpcodes {
 /**
  * https://discord.com/developers/docs/topics/opcodes-and-status-codes#voice-voice-close-event-codes
  */
-export enum VoiceCloseCodes {
+export const enum VoiceCloseCodes {
 	/**
 	 * You sent an invalid opcode
 	 */

--- a/gateway/v8.ts
+++ b/gateway/v8.ts
@@ -34,7 +34,7 @@ export const GatewayVersion = '8';
 /**
  * https://discord.com/developers/docs/topics/opcodes-and-status-codes#gateway-gateway-opcodes
  */
-export const enum GatewayOpcodes {
+export enum GatewayOpcodes {
 	/**
 	 * An event was dispatched
 	 */
@@ -85,7 +85,7 @@ export const enum GatewayOpcodes {
 /**
  * https://discord.com/developers/docs/topics/opcodes-and-status-codes#gateway-gateway-close-event-codes
  */
-export const enum GatewayCloseCodes {
+export enum GatewayCloseCodes {
 	/**
 	 * We're not sure what went wrong. Try reconnecting?
 	 */
@@ -168,7 +168,7 @@ export const enum GatewayCloseCodes {
 /**
  * https://discord.com/developers/docs/topics/gateway#list-of-intents
  */
-export const enum GatewayIntentBits {
+export enum GatewayIntentBits {
 	Guilds = 1 << 0,
 	GuildMembers = 1 << 1,
 	GuildBans = 1 << 2,
@@ -190,7 +190,7 @@ export const enum GatewayIntentBits {
 /**
  * https://discord.com/developers/docs/topics/gateway#commands-and-events-gateway-events
  */
-export const enum GatewayDispatchEvents {
+export enum GatewayDispatchEvents {
 	ChannelCreate = 'CHANNEL_CREATE',
 	ChannelDelete = 'CHANNEL_DELETE',
 	ChannelPinsUpdate = 'CHANNEL_PINS_UPDATE',

--- a/gateway/v9.ts
+++ b/gateway/v9.ts
@@ -37,7 +37,7 @@ export const GatewayVersion = '9';
 /**
  * https://discord.com/developers/docs/topics/opcodes-and-status-codes#gateway-gateway-opcodes
  */
-export const enum GatewayOpcodes {
+export enum GatewayOpcodes {
 	/**
 	 * An event was dispatched
 	 */
@@ -88,7 +88,7 @@ export const enum GatewayOpcodes {
 /**
  * https://discord.com/developers/docs/topics/opcodes-and-status-codes#gateway-gateway-close-event-codes
  */
-export const enum GatewayCloseCodes {
+export enum GatewayCloseCodes {
 	/**
 	 * We're not sure what went wrong. Try reconnecting?
 	 */
@@ -171,7 +171,7 @@ export const enum GatewayCloseCodes {
 /**
  * https://discord.com/developers/docs/topics/gateway#list-of-intents
  */
-export const enum GatewayIntentBits {
+export enum GatewayIntentBits {
 	Guilds = 1 << 0,
 	GuildMembers = 1 << 1,
 	GuildBans = 1 << 2,
@@ -193,7 +193,7 @@ export const enum GatewayIntentBits {
 /**
  * https://discord.com/developers/docs/topics/gateway#commands-and-events-gateway-events
  */
-export const enum GatewayDispatchEvents {
+export enum GatewayDispatchEvents {
 	ChannelCreate = 'CHANNEL_CREATE',
 	ChannelDelete = 'CHANNEL_DELETE',
 	ChannelPinsUpdate = 'CHANNEL_PINS_UPDATE',

--- a/payloads/v8/_interactions/_applicationCommands/_chatInput/shared.ts
+++ b/payloads/v8/_interactions/_applicationCommands/_chatInput/shared.ts
@@ -1,7 +1,7 @@
 /**
  * https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-type
  */
-export const enum ApplicationCommandOptionType {
+export enum ApplicationCommandOptionType {
 	Subcommand = 1,
 	SubcommandGroup,
 	String,

--- a/payloads/v8/_interactions/_applicationCommands/permissions.ts
+++ b/payloads/v8/_interactions/_applicationCommands/permissions.ts
@@ -43,7 +43,7 @@ export interface APIApplicationCommandPermission {
 /**
  * https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-application-command-permission-type
  */
-export const enum ApplicationCommandPermissionType {
+export enum ApplicationCommandPermissionType {
 	Role = 1,
 	User,
 }

--- a/payloads/v8/_interactions/applicationCommands.ts
+++ b/payloads/v8/_interactions/applicationCommands.ts
@@ -68,7 +68,7 @@ export interface APIApplicationCommand {
 /**
  * https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-types
  */
-export const enum ApplicationCommandType {
+export enum ApplicationCommandType {
 	ChatInput = 1,
 	User,
 	Message,

--- a/payloads/v8/_interactions/responses.ts
+++ b/payloads/v8/_interactions/responses.ts
@@ -5,7 +5,7 @@ import type { APIApplicationCommandOptionChoice } from './applicationCommands';
 /**
  * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-type
  */
-export const enum InteractionType {
+export enum InteractionType {
 	Ping = 1,
 	ApplicationCommand,
 	MessageComponent,
@@ -54,7 +54,7 @@ export interface APIInteractionResponseUpdateMessage {
 /**
  * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object-interaction-callback-type
  */
-export const enum InteractionResponseType {
+export enum InteractionResponseType {
 	/**
 	 * ACK a `Ping`
 	 */

--- a/payloads/v8/application.ts
+++ b/payloads/v8/application.ts
@@ -96,7 +96,7 @@ export interface APIApplication {
 /**
  * https://discord.com/developers/docs/resources/application#application-object-application-flags
  */
-export const enum ApplicationFlags {
+export enum ApplicationFlags {
 	EmbeddedReleased = 1 << 1,
 	ManagedEmoji = 1 << 2,
 	GroupDMCreate = 1 << 4,

--- a/payloads/v8/auditLog.ts
+++ b/payloads/v8/auditLog.ts
@@ -104,7 +104,7 @@ export interface APIAuditLogEntry {
 /**
  * https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events
  */
-export const enum AuditLogEvent {
+export enum AuditLogEvent {
 	GuildUpdate = 1,
 
 	ChannelCreate = 10,
@@ -249,7 +249,7 @@ export interface APIAuditLogOptions {
 	role_name?: string;
 }
 
-export const enum AuditLogOptionsType {
+export enum AuditLogOptionsType {
 	Role = '0',
 	Member = '1',
 }

--- a/payloads/v8/channel.ts
+++ b/payloads/v8/channel.ts
@@ -180,7 +180,7 @@ export type APIChannel =
 /**
  * https://discord.com/developers/docs/resources/channel#channel-object-channel-types
  */
-export const enum ChannelType {
+export enum ChannelType {
 	/**
 	 * A text channel within a guild
 	 */
@@ -223,7 +223,7 @@ export const enum ChannelType {
 	GuildStageVoice = 13,
 }
 
-export const enum VideoQualityMode {
+export enum VideoQualityMode {
 	/**
 	 * Discord chooses the quality for optimal performance
 	 */
@@ -425,7 +425,7 @@ export interface APIMessage {
 /**
  * https://discord.com/developers/docs/resources/channel#message-object-message-types
  */
-export const enum MessageType {
+export enum MessageType {
 	Default,
 	RecipientAdd,
 	RecipientRemove,
@@ -488,7 +488,7 @@ export interface APIMessageReference {
 /**
  * https://discord.com/developers/docs/resources/channel#message-object-message-activity-types
  */
-export const enum MessageActivityType {
+export enum MessageActivityType {
 	Join = 1,
 	Spectate,
 	Listen,
@@ -498,7 +498,7 @@ export const enum MessageActivityType {
 /**
  * https://discord.com/developers/docs/resources/channel#message-object-message-flags
  */
-export const enum MessageFlags {
+export enum MessageFlags {
 	/**
 	 * This message has been published to subscribed channels (via Channel Following)
 	 */
@@ -595,7 +595,7 @@ export interface APIOverwrite {
 	deny: Permissions;
 }
 
-export const enum OverwriteType {
+export enum OverwriteType {
 	Role,
 	Member,
 }
@@ -688,7 +688,7 @@ export interface APIEmbed {
  * https://discord.com/developers/docs/resources/channel#embed-object-embed-types
  * @deprecated *Embed types should be considered deprecated and might be removed in a future API version*
  */
-export const enum EmbedType {
+export enum EmbedType {
 	/**
 	 * Generic embed rendered from embed attributes
 	 */
@@ -932,7 +932,7 @@ export interface APIChannelMention {
 /**
  * https://discord.com/developers/docs/resources/channel#allowed-mentions-object-allowed-mention-types
  */
-export const enum AllowedMentionsTypes {
+export enum AllowedMentionsTypes {
 	/**
 	 * Controls @everyone and @here mentions
 	 */
@@ -986,7 +986,7 @@ export interface APIBaseMessageComponent<T extends ComponentType> {
 /**
  * https://discord.com/developers/docs/interactions/message-components#component-types
  */
-export const enum ComponentType {
+export enum ComponentType {
 	/**
 	 * Action Row component
 	 */
@@ -1070,7 +1070,7 @@ export type APIButtonComponent = APIButtonComponentWithCustomId | APIButtonCompo
 /**
  * https://discord.com/developers/docs/interactions/message-components#button-object-button-styles
  */
-export const enum ButtonStyle {
+export enum ButtonStyle {
 	Primary = 1,
 	Secondary,
 	Success,

--- a/payloads/v8/gateway.ts
+++ b/payloads/v8/gateway.ts
@@ -91,7 +91,7 @@ export interface GatewayPresenceUpdate {
 	client_status?: GatewayPresenceClientStatus;
 }
 
-export const enum PresenceUpdateStatus {
+export enum PresenceUpdateStatus {
 	Online = 'online',
 	DoNotDisturb = 'dnd',
 	Idle = 'idle',
@@ -216,7 +216,7 @@ export enum ActivityPlatform {
 /**
  * https://discord.com/developers/docs/topics/gateway#activity-object-activity-types
  */
-export const enum ActivityType {
+export enum ActivityType {
 	/**
 	 * Playing {game}
 	 */
@@ -291,7 +291,7 @@ export type GatewayActivitySecrets = Partial<Record<'join' | 'spectate' | 'match
 /**
  * https://discord.com/developers/docs/topics/gateway#activity-object-activity-flags
  */
-export const enum ActivityFlags {
+export enum ActivityFlags {
 	Instance = 1 << 0,
 	Join = 1 << 1,
 	Spectate = 1 << 2,

--- a/payloads/v8/guild.ts
+++ b/payloads/v8/guild.ts
@@ -343,7 +343,7 @@ export interface APIGuild extends APIPartialGuild {
 /**
  * https://discord.com/developers/docs/resources/guild#guild-object-default-message-notification-level
  */
-export const enum GuildDefaultMessageNotifications {
+export enum GuildDefaultMessageNotifications {
 	AllMessages,
 	OnlyMentions,
 }
@@ -351,7 +351,7 @@ export const enum GuildDefaultMessageNotifications {
 /**
  * https://discord.com/developers/docs/resources/guild#guild-object-explicit-content-filter-level
  */
-export const enum GuildExplicitContentFilter {
+export enum GuildExplicitContentFilter {
 	Disabled,
 	MembersWithoutRoles,
 	AllMembers,
@@ -360,7 +360,7 @@ export const enum GuildExplicitContentFilter {
 /**
  * https://discord.com/developers/docs/resources/guild#guild-object-mfa-level
  */
-export const enum GuildMFALevel {
+export enum GuildMFALevel {
 	None,
 	Elevated,
 }
@@ -368,7 +368,7 @@ export const enum GuildMFALevel {
 /**
  * https://discord.com/developers/docs/resources/guild#guild-object-guild-nsfw-level
  */
-export const enum GuildNSFWLevel {
+export enum GuildNSFWLevel {
 	Default,
 	Explicit,
 	Safe,
@@ -378,7 +378,7 @@ export const enum GuildNSFWLevel {
 /**
  * https://discord.com/developers/docs/resources/guild#guild-object-verification-level
  */
-export const enum GuildVerificationLevel {
+export enum GuildVerificationLevel {
 	/**
 	 * Unrestricted
 	 */
@@ -404,7 +404,7 @@ export const enum GuildVerificationLevel {
 /**
  * https://discord.com/developers/docs/resources/guild#guild-object-premium-tier
  */
-export const enum GuildPremiumTier {
+export enum GuildPremiumTier {
 	None,
 	Tier1,
 	Tier2,
@@ -414,7 +414,7 @@ export const enum GuildPremiumTier {
 /**
  * https://discord.com/developers/docs/resources/guild#guild-object-system-channel-flags
  */
-export const enum GuildSystemChannelFlags {
+export enum GuildSystemChannelFlags {
 	/**
 	 * Suppress member join notifications
 	 */
@@ -436,7 +436,7 @@ export const enum GuildSystemChannelFlags {
 /**
  * https://discord.com/developers/docs/resources/guild#guild-object-guild-features
  */
-export const enum GuildFeature {
+export enum GuildFeature {
 	/**
 	 * Guild has access to set an animated guild icon
 	 */
@@ -757,7 +757,7 @@ export type APIGuildInteractionType = 'twitch' | 'youtube' | 'discord';
 /**
  * https://discord.com/developers/docs/resources/guild#integration-object-integration-expire-behaviors
  */
-export const enum IntegrationExpireBehavior {
+export enum IntegrationExpireBehavior {
 	RemoveRole,
 	Kick,
 }
@@ -861,7 +861,7 @@ export interface APIGuildWidgetMember {
 /**
  * https://discord.com/developers/docs/resources/guild#get-guild-widget-image-widget-style-options
  */
-export const enum GuildWidgetStyle {
+export enum GuildWidgetStyle {
 	/**
 	 * Shield style widget with Discord icon and guild members online count
 	 */
@@ -951,7 +951,7 @@ export interface APIGuildMembershipScreeningField {
 	required: boolean;
 }
 
-export const enum MembershipScreeningFieldType {
+export enum MembershipScreeningFieldType {
 	/**
 	 * Server Rules
 	 */

--- a/payloads/v8/guildScheduledEvent.ts
+++ b/payloads/v8/guildScheduledEvent.ts
@@ -103,7 +103,7 @@ export interface APIGuildScheduledEventEntityMetadata {
 /**
  * https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-entity-types
  */
-export const enum GuildScheduledEventEntityType {
+export enum GuildScheduledEventEntityType {
 	StageInstance = 1,
 	Voice,
 	External,
@@ -112,7 +112,7 @@ export const enum GuildScheduledEventEntityType {
 /**
  * https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-status
  */
-export const enum GuildScheduledEventStatus {
+export enum GuildScheduledEventStatus {
 	Scheduled = 1,
 	Active,
 	Completed,
@@ -122,7 +122,7 @@ export const enum GuildScheduledEventStatus {
 /**
  * https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-privacy-level
  */
-export const enum GuildScheduledEventPrivacyLevel {
+export enum GuildScheduledEventPrivacyLevel {
 	/**
 	 * The scheduled event is only accessible to guild members
 	 */

--- a/payloads/v8/invite.ts
+++ b/payloads/v8/invite.ts
@@ -78,7 +78,7 @@ export interface APIInvite {
 /**
  * https://discord.com/developers/docs/resources/invite#invite-object-invite-target-types
  */
-export const enum InviteTargetType {
+export enum InviteTargetType {
 	Stream = 1,
 	EmbeddedApplication,
 }

--- a/payloads/v8/oauth2.ts
+++ b/payloads/v8/oauth2.ts
@@ -2,7 +2,7 @@
  * Types extracted from https://discord.com/developers/docs/topics/oauth2
  */
 
-export const enum OAuth2Scopes {
+export enum OAuth2Scopes {
 	/**
 	 * For oauth2 bots, this puts the bot in the user's selected guild by default
 	 */

--- a/payloads/v8/stageInstance.ts
+++ b/payloads/v8/stageInstance.ts
@@ -36,7 +36,7 @@ export interface APIStageInstance {
 /**
  * https://discord.com/developers/docs/resources/stage-instance#stage-instance-object-privacy-level
  */
-export const enum StageInstancePrivacyLevel {
+export enum StageInstancePrivacyLevel {
 	/**
 	 * The stage instance is visible publicly, such as on stage discovery
 	 */

--- a/payloads/v8/sticker.ts
+++ b/payloads/v8/sticker.ts
@@ -67,7 +67,7 @@ export interface APISticker {
 /**
  * https://discord.com/developers/docs/resources/sticker#sticker-object-sticker-types
  */
-export const enum StickerType {
+export enum StickerType {
 	/**
 	 * An official sticker in a pack, part of Nitro or in a removed purchasable pack
 	 */
@@ -81,7 +81,7 @@ export const enum StickerType {
 /**
  * https://discord.com/developers/docs/resources/sticker#sticker-object-sticker-format-types
  */
-export const enum StickerFormatType {
+export enum StickerFormatType {
 	PNG = 1,
 	APNG,
 	Lottie,

--- a/payloads/v8/teams.ts
+++ b/payloads/v8/teams.ts
@@ -60,7 +60,7 @@ export interface APITeamMember {
 /**
  * https://discord.com/developers/docs/topics/teams#data-models-membership-state-enum
  */
-export const enum TeamMemberMembershipState {
+export enum TeamMemberMembershipState {
 	Invited = 1,
 	Accepted,
 }

--- a/payloads/v8/user.ts
+++ b/payloads/v8/user.ts
@@ -84,7 +84,7 @@ export interface APIUser {
 /**
  * https://discord.com/developers/docs/resources/user#user-object-user-flags
  */
-export const enum UserFlags {
+export enum UserFlags {
 	/**
 	 * None
 	 */
@@ -154,7 +154,7 @@ export const enum UserFlags {
 /**
  * https://discord.com/developers/docs/resources/user#user-object-premium-types
  */
-export const enum UserPremiumType {
+export enum UserPremiumType {
 	None,
 	NitroClassic,
 	Nitro,
@@ -206,7 +206,7 @@ export interface APIConnection {
 	visibility: ConnectionVisibility;
 }
 
-export const enum ConnectionVisibility {
+export enum ConnectionVisibility {
 	/**
 	 * Invisible to everyone except the user themselves
 	 */

--- a/payloads/v8/webhook.ts
+++ b/payloads/v8/webhook.ts
@@ -63,7 +63,7 @@ export interface APIWebhook {
 	url?: string;
 }
 
-export const enum WebhookType {
+export enum WebhookType {
 	/**
 	 * Incoming Webhooks can post messages to channels with a generated token
 	 */

--- a/payloads/v9/_interactions/_applicationCommands/_chatInput/shared.ts
+++ b/payloads/v9/_interactions/_applicationCommands/_chatInput/shared.ts
@@ -1,7 +1,7 @@
 /**
  * https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-type
  */
-export const enum ApplicationCommandOptionType {
+export enum ApplicationCommandOptionType {
 	Subcommand = 1,
 	SubcommandGroup,
 	String,

--- a/payloads/v9/_interactions/_applicationCommands/permissions.ts
+++ b/payloads/v9/_interactions/_applicationCommands/permissions.ts
@@ -43,7 +43,7 @@ export interface APIApplicationCommandPermission {
 /**
  * https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-application-command-permission-type
  */
-export const enum ApplicationCommandPermissionType {
+export enum ApplicationCommandPermissionType {
 	Role = 1,
 	User,
 }

--- a/payloads/v9/_interactions/applicationCommands.ts
+++ b/payloads/v9/_interactions/applicationCommands.ts
@@ -68,7 +68,7 @@ export interface APIApplicationCommand {
 /**
  * https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-types
  */
-export const enum ApplicationCommandType {
+export enum ApplicationCommandType {
 	ChatInput = 1,
 	User,
 	Message,

--- a/payloads/v9/_interactions/responses.ts
+++ b/payloads/v9/_interactions/responses.ts
@@ -5,7 +5,7 @@ import type { APIApplicationCommandOptionChoice } from './applicationCommands';
 /**
  * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-type
  */
-export const enum InteractionType {
+export enum InteractionType {
 	Ping = 1,
 	ApplicationCommand,
 	MessageComponent,
@@ -54,7 +54,7 @@ export interface APIInteractionResponseUpdateMessage {
 /**
  * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object-interaction-callback-type
  */
-export const enum InteractionResponseType {
+export enum InteractionResponseType {
 	/**
 	 * ACK a `Ping`
 	 */

--- a/payloads/v9/application.ts
+++ b/payloads/v9/application.ts
@@ -96,7 +96,7 @@ export interface APIApplication {
 /**
  * https://discord.com/developers/docs/resources/application#application-object-application-flags
  */
-export const enum ApplicationFlags {
+export enum ApplicationFlags {
 	EmbeddedReleased = 1 << 1,
 	ManagedEmoji = 1 << 2,
 	GroupDMCreate = 1 << 4,

--- a/payloads/v9/auditLog.ts
+++ b/payloads/v9/auditLog.ts
@@ -112,7 +112,7 @@ export interface APIAuditLogEntry {
 /**
  * https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events
  */
-export const enum AuditLogEvent {
+export enum AuditLogEvent {
 	GuildUpdate = 1,
 
 	ChannelCreate = 10,
@@ -261,7 +261,7 @@ export interface APIAuditLogOptions {
 	role_name?: string;
 }
 
-export const enum AuditLogOptionsType {
+export enum AuditLogOptionsType {
 	Role = '0',
 	Member = '1',
 }

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -241,7 +241,7 @@ export type APIChannel =
 /**
  * https://discord.com/developers/docs/resources/channel#channel-object-channel-types
  */
-export const enum ChannelType {
+export enum ChannelType {
 	/**
 	 * A text channel within a guild
 	 */
@@ -296,7 +296,7 @@ export const enum ChannelType {
 	GuildStageVoice,
 }
 
-export const enum VideoQualityMode {
+export enum VideoQualityMode {
 	/**
 	 * Discord chooses the quality for optimal performance
 	 */
@@ -502,7 +502,7 @@ export interface APIMessage {
 /**
  * https://discord.com/developers/docs/resources/channel#message-object-message-types
  */
-export const enum MessageType {
+export enum MessageType {
 	Default,
 	RecipientAdd,
 	RecipientRemove,
@@ -567,7 +567,7 @@ export interface APIMessageReference {
 /**
  * https://discord.com/developers/docs/resources/channel#message-object-message-activity-types
  */
-export const enum MessageActivityType {
+export enum MessageActivityType {
 	Join = 1,
 	Spectate,
 	Listen,
@@ -577,7 +577,7 @@ export const enum MessageActivityType {
 /**
  * https://discord.com/developers/docs/resources/channel#message-object-message-flags
  */
-export const enum MessageFlags {
+export enum MessageFlags {
 	/**
 	 * This message has been published to subscribed channels (via Channel Following)
 	 */
@@ -678,7 +678,7 @@ export interface APIOverwrite {
 	deny: Permissions;
 }
 
-export const enum OverwriteType {
+export enum OverwriteType {
 	Role,
 	Member,
 }
@@ -713,7 +713,7 @@ export interface APIThreadMetadata {
 	create_timestamp?: string;
 }
 
-export const enum ThreadAutoArchiveDuration {
+export enum ThreadAutoArchiveDuration {
 	OneHour = 60,
 	OneDay = 1440,
 	ThreeDays = 4320,
@@ -748,7 +748,7 @@ export interface APIThreadMember {
 	flags: ThreadMemberFlags;
 }
 
-export const enum ThreadMemberFlags {}
+export enum ThreadMemberFlags {}
 
 export interface APIThreadList {
 	/**
@@ -853,7 +853,7 @@ export interface APIEmbed {
  * https://discord.com/developers/docs/resources/channel#embed-object-embed-types
  * @deprecated *Embed types should be considered deprecated and might be removed in a future API version*
  */
-export const enum EmbedType {
+export enum EmbedType {
 	/**
 	 * Generic embed rendered from embed attributes
 	 */
@@ -1097,7 +1097,7 @@ export interface APIChannelMention {
 /**
  * https://discord.com/developers/docs/resources/channel#allowed-mentions-object-allowed-mention-types
  */
-export const enum AllowedMentionsTypes {
+export enum AllowedMentionsTypes {
 	/**
 	 * Controls @everyone and @here mentions
 	 */
@@ -1151,7 +1151,7 @@ export interface APIBaseMessageComponent<T extends ComponentType> {
 /**
  * https://discord.com/developers/docs/interactions/message-components#component-types
  */
-export const enum ComponentType {
+export enum ComponentType {
 	/**
 	 * Action Row component
 	 */
@@ -1235,7 +1235,7 @@ export type APIButtonComponent = APIButtonComponentWithCustomId | APIButtonCompo
 /**
  * https://discord.com/developers/docs/interactions/message-components#button-object-button-styles
  */
-export const enum ButtonStyle {
+export enum ButtonStyle {
 	Primary = 1,
 	Secondary,
 	Success,

--- a/payloads/v9/gateway.ts
+++ b/payloads/v9/gateway.ts
@@ -92,7 +92,7 @@ export interface GatewayPresenceUpdate {
 	client_status?: GatewayPresenceClientStatus;
 }
 
-export const enum PresenceUpdateStatus {
+export enum PresenceUpdateStatus {
 	Online = 'online',
 	DoNotDisturb = 'dnd',
 	Idle = 'idle',
@@ -217,7 +217,7 @@ export enum ActivityPlatform {
 /**
  * https://discord.com/developers/docs/topics/gateway#activity-object-activity-types
  */
-export const enum ActivityType {
+export enum ActivityType {
 	/**
 	 * Playing {game}
 	 */
@@ -292,7 +292,7 @@ export type GatewayActivitySecrets = Partial<Record<'join' | 'spectate' | 'match
 /**
  * https://discord.com/developers/docs/topics/gateway#activity-object-activity-flags
  */
-export const enum ActivityFlags {
+export enum ActivityFlags {
 	Instance = 1 << 0,
 	Join = 1 << 1,
 	Spectate = 1 << 2,

--- a/payloads/v9/guild.ts
+++ b/payloads/v9/guild.ts
@@ -351,7 +351,7 @@ export interface APIGuild extends APIPartialGuild {
 /**
  * https://discord.com/developers/docs/resources/guild#guild-object-default-message-notification-level
  */
-export const enum GuildDefaultMessageNotifications {
+export enum GuildDefaultMessageNotifications {
 	AllMessages,
 	OnlyMentions,
 }
@@ -359,7 +359,7 @@ export const enum GuildDefaultMessageNotifications {
 /**
  * https://discord.com/developers/docs/resources/guild#guild-object-explicit-content-filter-level
  */
-export const enum GuildExplicitContentFilter {
+export enum GuildExplicitContentFilter {
 	Disabled,
 	MembersWithoutRoles,
 	AllMembers,
@@ -368,7 +368,7 @@ export const enum GuildExplicitContentFilter {
 /**
  * https://discord.com/developers/docs/resources/guild#guild-object-mfa-level
  */
-export const enum GuildMFALevel {
+export enum GuildMFALevel {
 	None,
 	Elevated,
 }
@@ -376,7 +376,7 @@ export const enum GuildMFALevel {
 /**
  * https://discord.com/developers/docs/resources/guild#guild-object-guild-nsfw-level
  */
-export const enum GuildNSFWLevel {
+export enum GuildNSFWLevel {
 	Default,
 	Explicit,
 	Safe,
@@ -386,7 +386,7 @@ export const enum GuildNSFWLevel {
 /**
  * https://discord.com/developers/docs/resources/guild#guild-object-verification-level
  */
-export const enum GuildVerificationLevel {
+export enum GuildVerificationLevel {
 	/**
 	 * Unrestricted
 	 */
@@ -412,7 +412,7 @@ export const enum GuildVerificationLevel {
 /**
  * https://discord.com/developers/docs/resources/guild#guild-object-premium-tier
  */
-export const enum GuildPremiumTier {
+export enum GuildPremiumTier {
 	None,
 	Tier1,
 	Tier2,
@@ -422,7 +422,7 @@ export const enum GuildPremiumTier {
 /**
  * https://discord.com/developers/docs/resources/guild#guild-object-system-channel-flags
  */
-export const enum GuildSystemChannelFlags {
+export enum GuildSystemChannelFlags {
 	/**
 	 * Suppress member join notifications
 	 */
@@ -444,7 +444,7 @@ export const enum GuildSystemChannelFlags {
 /**
  * https://discord.com/developers/docs/resources/guild#guild-object-guild-features
  */
-export const enum GuildFeature {
+export enum GuildFeature {
 	/**
 	 * Guild has access to set an animated guild icon
 	 */
@@ -765,7 +765,7 @@ export type APIGuildInteractionType = 'twitch' | 'youtube' | 'discord';
 /**
  * https://discord.com/developers/docs/resources/guild#integration-object-integration-expire-behaviors
  */
-export const enum IntegrationExpireBehavior {
+export enum IntegrationExpireBehavior {
 	RemoveRole,
 	Kick,
 }
@@ -869,7 +869,7 @@ export interface APIGuildWidgetMember {
 /**
  * https://discord.com/developers/docs/resources/guild#get-guild-widget-image-widget-style-options
  */
-export const enum GuildWidgetStyle {
+export enum GuildWidgetStyle {
 	/**
 	 * Shield style widget with Discord icon and guild members online count
 	 */
@@ -959,7 +959,7 @@ export interface APIGuildMembershipScreeningField {
 	required: boolean;
 }
 
-export const enum MembershipScreeningFieldType {
+export enum MembershipScreeningFieldType {
 	/**
 	 * Server Rules
 	 */

--- a/payloads/v9/guildScheduledEvent.ts
+++ b/payloads/v9/guildScheduledEvent.ts
@@ -103,7 +103,7 @@ export interface APIGuildScheduledEventEntityMetadata {
 /**
  * https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-entity-types
  */
-export const enum GuildScheduledEventEntityType {
+export enum GuildScheduledEventEntityType {
 	StageInstance = 1,
 	Voice,
 	External,
@@ -112,7 +112,7 @@ export const enum GuildScheduledEventEntityType {
 /**
  * https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-status
  */
-export const enum GuildScheduledEventStatus {
+export enum GuildScheduledEventStatus {
 	Scheduled = 1,
 	Active,
 	Completed,
@@ -122,7 +122,7 @@ export const enum GuildScheduledEventStatus {
 /**
  * https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-privacy-level
  */
-export const enum GuildScheduledEventPrivacyLevel {
+export enum GuildScheduledEventPrivacyLevel {
 	/**
 	 * The scheduled event is only accessible to guild members
 	 */

--- a/payloads/v9/invite.ts
+++ b/payloads/v9/invite.ts
@@ -78,7 +78,7 @@ export interface APIInvite {
 /**
  * https://discord.com/developers/docs/resources/invite#invite-object-invite-target-types
  */
-export const enum InviteTargetType {
+export enum InviteTargetType {
 	Stream = 1,
 	EmbeddedApplication,
 }

--- a/payloads/v9/oauth2.ts
+++ b/payloads/v9/oauth2.ts
@@ -2,7 +2,7 @@
  * Types extracted from https://discord.com/developers/docs/topics/oauth2
  */
 
-export const enum OAuth2Scopes {
+export enum OAuth2Scopes {
 	/**
 	 * For oauth2 bots, this puts the bot in the user's selected guild by default
 	 */

--- a/payloads/v9/stageInstance.ts
+++ b/payloads/v9/stageInstance.ts
@@ -36,7 +36,7 @@ export interface APIStageInstance {
 /**
  * https://discord.com/developers/docs/resources/stage-instance#stage-instance-object-privacy-level
  */
-export const enum StageInstancePrivacyLevel {
+export enum StageInstancePrivacyLevel {
 	/**
 	 * The stage instance is visible publicly, such as on stage discovery
 	 */

--- a/payloads/v9/sticker.ts
+++ b/payloads/v9/sticker.ts
@@ -67,7 +67,7 @@ export interface APISticker {
 /**
  * https://discord.com/developers/docs/resources/sticker#sticker-object-sticker-types
  */
-export const enum StickerType {
+export enum StickerType {
 	/**
 	 * An official sticker in a pack, part of Nitro or in a removed purchasable pack
 	 */
@@ -81,7 +81,7 @@ export const enum StickerType {
 /**
  * https://discord.com/developers/docs/resources/sticker#sticker-object-sticker-format-types
  */
-export const enum StickerFormatType {
+export enum StickerFormatType {
 	PNG = 1,
 	APNG,
 	Lottie,

--- a/payloads/v9/teams.ts
+++ b/payloads/v9/teams.ts
@@ -60,7 +60,7 @@ export interface APITeamMember {
 /**
  * https://discord.com/developers/docs/topics/teams#data-models-membership-state-enum
  */
-export const enum TeamMemberMembershipState {
+export enum TeamMemberMembershipState {
 	Invited = 1,
 	Accepted,
 }

--- a/payloads/v9/user.ts
+++ b/payloads/v9/user.ts
@@ -84,7 +84,7 @@ export interface APIUser {
 /**
  * https://discord.com/developers/docs/resources/user#user-object-user-flags
  */
-export const enum UserFlags {
+export enum UserFlags {
 	/**
 	 * None
 	 */
@@ -154,7 +154,7 @@ export const enum UserFlags {
 /**
  * https://discord.com/developers/docs/resources/user#user-object-premium-types
  */
-export const enum UserPremiumType {
+export enum UserPremiumType {
 	None,
 	NitroClassic,
 	Nitro,
@@ -206,7 +206,7 @@ export interface APIConnection {
 	visibility: ConnectionVisibility;
 }
 
-export const enum ConnectionVisibility {
+export enum ConnectionVisibility {
 	/**
 	 * Invisible to everyone except the user themselves
 	 */

--- a/payloads/v9/webhook.ts
+++ b/payloads/v9/webhook.ts
@@ -63,7 +63,7 @@ export interface APIWebhook {
 	url?: string;
 }
 
-export const enum WebhookType {
+export enum WebhookType {
 	/**
 	 * Incoming Webhooks can post messages to channels with a generated token
 	 */

--- a/rest/common.ts
+++ b/rest/common.ts
@@ -1,7 +1,7 @@
 /**
  * https://discord.com/developers/docs/topics/opcodes-and-status-codes#json-json-error-codes
  */
-export const enum RESTJSONErrorCodes {
+export enum RESTJSONErrorCodes {
 	GeneralError,
 
 	UnknownAccount = 10001,
@@ -214,7 +214,7 @@ export const enum RESTJSONErrorCodes {
 	FailedToCreateStageNeededForStageEvent = 180002,
 }
 
-export const enum Locale {
+export enum Locale {
 	EnglishUS = 'en-US',
 	EnglishGB = 'en-GB',
 	Bulgarian = 'bg',

--- a/rpc/v8.ts
+++ b/rpc/v8.ts
@@ -1,7 +1,7 @@
 /**
  * https://discord.com/developers/docs/topics/opcodes-and-status-codes#rpc-rpc-error-codes
  */
-export const enum RPCErrorCodes {
+export enum RPCErrorCodes {
 	UnknownError = 1000,
 	InvalidPayload = 4000,
 	InvalidCommand = 4002,
@@ -23,7 +23,7 @@ export const enum RPCErrorCodes {
 /**
  * https://discord.com/developers/docs/topics/opcodes-and-status-codes#rpc-rpc-close-event-codes
  */
-export const enum RPCCloseEventCodes {
+export enum RPCCloseEventCodes {
 	InvalidClientId = 4000,
 	InvalidOrigin,
 	RateLimited,

--- a/rpc/v9.ts
+++ b/rpc/v9.ts
@@ -1,7 +1,7 @@
 /**
  * https://discord.com/developers/docs/topics/opcodes-and-status-codes#rpc-rpc-error-codes
  */
-export const enum RPCErrorCodes {
+export enum RPCErrorCodes {
 	UnknownError = 1000,
 	InvalidPayload = 4000,
 	InvalidCommand = 4002,
@@ -23,7 +23,7 @@ export const enum RPCErrorCodes {
 /**
  * https://discord.com/developers/docs/topics/opcodes-and-status-codes#rpc-rpc-close-event-codes
  */
-export const enum RPCCloseEventCodes {
+export enum RPCCloseEventCodes {
 	InvalidClientId = 4000,
 	InvalidOrigin,
 	RateLimited,

--- a/scripts/deno.mjs
+++ b/scripts/deno.mjs
@@ -30,14 +30,7 @@ function convertImports(source) {
 	);
 }
 
-/**
- * @param {string} source The raw source
- */
-function convertConstEnums(source) {
-	return source.replace(/const enum/gi, 'enum');
-}
-
-const transformers = [convertImports, convertConstEnums];
+const transformers = [convertImports];
 
 async function convertFile(fullFilePath, finalDenoPath) {
 	const originalFile = await readFile(fullFilePath, { encoding: 'utf8' });

--- a/voice/v4.ts
+++ b/voice/v4.ts
@@ -3,7 +3,7 @@ export const VoiceGatewayVersion = '4';
 /**
  * https://discord.com/developers/docs/topics/opcodes-and-status-codes#voice-voice-opcodes
  */
-export const enum VoiceOpcodes {
+export enum VoiceOpcodes {
 	/**
 	 * Begin a voice websocket connection
 	 */
@@ -57,7 +57,7 @@ export const enum VoiceOpcodes {
 /**
  * https://discord.com/developers/docs/topics/opcodes-and-status-codes#voice-voice-close-event-codes
  */
-export const enum VoiceCloseCodes {
+export enum VoiceCloseCodes {
 	/**
 	 * You sent an invalid opcode
 	 */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Changes all regular enums in v8 and v9 to const enums. `PermissionFlagBits` is still an object since it contains `bigint` values. The other `*Flags` enums are also still objects because the docs state they are still of the `integer` data type.

Closes #295 

**Reference Discord API Docs PRs or commits:**
