### PR TITLE
fix(APIInteractions): export ApplicationCommandAutocomplete

### DIFF
--- a/deno/payloads/v8/interactions.ts
+++ b/deno/payloads/v8/interactions.ts
@@ -26,6 +26,7 @@ export * from './_interactions/ping.ts';
 export * from './_interactions/responses.ts';
 export * from './_interactions/applicationCommands.ts';
 export * from './_interactions/modalSubmit.ts';
+export * from './_interactions/autocomplete.ts';
 
 /**
  * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object

--- a/deno/payloads/v9/interactions.ts
+++ b/deno/payloads/v9/interactions.ts
@@ -26,6 +26,7 @@ export * from './_interactions/ping.ts';
 export * from './_interactions/responses.ts';
 export * from './_interactions/applicationCommands.ts';
 export * from './_interactions/modalSubmit.ts';
+export * from './_interactions/autocomplete.ts';
 
 /**
  * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object

--- a/payloads/v8/interactions.ts
+++ b/payloads/v8/interactions.ts
@@ -26,6 +26,7 @@ export * from './_interactions/ping';
 export * from './_interactions/responses';
 export * from './_interactions/applicationCommands';
 export * from './_interactions/modalSubmit';
+export * from './_interactions/autocomplete';
 
 /**
  * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object

--- a/payloads/v9/interactions.ts
+++ b/payloads/v9/interactions.ts
@@ -26,6 +26,7 @@ export * from './_interactions/ping';
 export * from './_interactions/responses';
 export * from './_interactions/applicationCommands';
 export * from './_interactions/modalSubmit';
+export * from './_interactions/autocomplete';
 
 /**
  * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
- Export autocomplete API interaction
- Every other API interaction is exported, why not autocomplete?
- This will allow people (like me) to use the autocomplete type specifically and not a generic interaction

**Reference Discord API Docs PRs or commits:**
- None