### PR TITLE
fix(GatewayThreadCreateDispatchData): `newly_created` is optional, and `true` when present

### DIFF
--- a/deno/gateway/v9.ts
+++ b/deno/gateway/v9.ts
@@ -27,6 +27,7 @@ import type {
 	GatewayVoiceState,
 	InviteTargetType,
 	PresenceUpdateStatus,
+	APIThreadChannel,
 } from '../payloads/v9/mod.ts';
 import type { Nullable } from '../utils/internals.ts';
 
@@ -1280,12 +1281,12 @@ export type GatewayThreadCreateDispatch = GatewayChannelModifyDispatch;
 /**
  * https://discord.com/developers/docs/topics/gateway#thread-create
  */
-export type GatewayThreadCreateDispatchData = GatewayChannelModifyDispatchData & {
+export interface GatewayThreadCreateDispatchData extends APIThreadChannel {
 	/**
 	 * Whether the thread is newly created or not.
 	 */
 	newly_created: boolean;
-};
+}
 
 /**
  * https://discord.com/developers/docs/topics/gateway#thread-update

--- a/deno/gateway/v9.ts
+++ b/deno/gateway/v9.ts
@@ -1285,7 +1285,7 @@ export interface GatewayThreadCreateDispatchData extends APIThreadChannel {
 	/**
 	 * Whether the thread is newly created or not.
 	 */
-	newly_created: boolean;
+	newly_created?: boolean;
 }
 
 /**

--- a/deno/gateway/v9.ts
+++ b/deno/gateway/v9.ts
@@ -1280,7 +1280,12 @@ export type GatewayThreadCreateDispatch = GatewayChannelModifyDispatch;
 /**
  * https://discord.com/developers/docs/topics/gateway#thread-create
  */
-export type GatewayThreadCreateDispatchData = GatewayChannelModifyDispatchData;
+export type GatewayThreadCreateDispatchData = GatewayChannelModifyDispatchData & {
+	/**
+	 * Whether the thread is newly created or not.
+	 */
+	newly_created: boolean;
+};
 
 /**
  * https://discord.com/developers/docs/topics/gateway#thread-update

--- a/deno/gateway/v9.ts
+++ b/deno/gateway/v9.ts
@@ -1285,7 +1285,7 @@ export interface GatewayThreadCreateDispatchData extends APIThreadChannel {
 	/**
 	 * Whether the thread is newly created or not.
 	 */
-	newly_created?: boolean;
+	newly_created?: true;
 }
 
 /**

--- a/gateway/v9.ts
+++ b/gateway/v9.ts
@@ -27,6 +27,7 @@ import type {
 	GatewayVoiceState,
 	InviteTargetType,
 	PresenceUpdateStatus,
+	APIThreadChannel,
 } from '../payloads/v9/index';
 import type { Nullable } from '../utils/internals';
 
@@ -1280,12 +1281,12 @@ export type GatewayThreadCreateDispatch = GatewayChannelModifyDispatch;
 /**
  * https://discord.com/developers/docs/topics/gateway#thread-create
  */
-export type GatewayThreadCreateDispatchData = GatewayChannelModifyDispatchData & {
+export interface GatewayThreadCreateDispatchData extends APIThreadChannel {
 	/**
 	 * Whether the thread is newly created or not.
 	 */
 	newly_created: boolean;
-};
+}
 
 /**
  * https://discord.com/developers/docs/topics/gateway#thread-update

--- a/gateway/v9.ts
+++ b/gateway/v9.ts
@@ -1285,7 +1285,7 @@ export interface GatewayThreadCreateDispatchData extends APIThreadChannel {
 	/**
 	 * Whether the thread is newly created or not.
 	 */
-	newly_created: boolean;
+	newly_created?: boolean;
 }
 
 /**

--- a/gateway/v9.ts
+++ b/gateway/v9.ts
@@ -1280,7 +1280,12 @@ export type GatewayThreadCreateDispatch = GatewayChannelModifyDispatch;
 /**
  * https://discord.com/developers/docs/topics/gateway#thread-create
  */
-export type GatewayThreadCreateDispatchData = GatewayChannelModifyDispatchData;
+export type GatewayThreadCreateDispatchData = GatewayChannelModifyDispatchData & {
+	/**
+	 * Whether the thread is newly created or not.
+	 */
+	newly_created: boolean;
+};
 
 /**
  * https://discord.com/developers/docs/topics/gateway#thread-update

--- a/gateway/v9.ts
+++ b/gateway/v9.ts
@@ -1285,7 +1285,7 @@ export interface GatewayThreadCreateDispatchData extends APIThreadChannel {
 	/**
 	 * Whether the thread is newly created or not.
 	 */
-	newly_created?: boolean;
+	newly_created?: true;
 }
 
 /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

**Reference Discord API Docs PRs or commits:**
