### PR TITLE
refactor(APIGuildScheduledEventBase): make `creator_id` optional

### DIFF
--- a/deno/payloads/v8/guildScheduledEvent.ts
+++ b/deno/payloads/v8/guildScheduledEvent.ts
@@ -18,7 +18,7 @@ interface APIGuildScheduledEventBase<Type extends GuildScheduledEventEntityType>
 	/**
 	 * The id of the user that created the scheduled event
 	 */
-	creator_id: Snowflake | null;
+	creator_id?: Snowflake | null;
 	/**
 	 * The name of the scheduled event
 	 */

--- a/deno/payloads/v9/guildScheduledEvent.ts
+++ b/deno/payloads/v9/guildScheduledEvent.ts
@@ -18,7 +18,7 @@ interface APIGuildScheduledEventBase<Type extends GuildScheduledEventEntityType>
 	/**
 	 * The id of the user that created the scheduled event
 	 */
-	creator_id: Snowflake | null;
+	creator_id?: Snowflake | null;
 	/**
 	 * The name of the scheduled event
 	 */

--- a/payloads/v8/guildScheduledEvent.ts
+++ b/payloads/v8/guildScheduledEvent.ts
@@ -18,7 +18,7 @@ interface APIGuildScheduledEventBase<Type extends GuildScheduledEventEntityType>
 	/**
 	 * The id of the user that created the scheduled event
 	 */
-	creator_id: Snowflake | null;
+	creator_id?: Snowflake | null;
 	/**
 	 * The name of the scheduled event
 	 */

--- a/payloads/v9/guildScheduledEvent.ts
+++ b/payloads/v9/guildScheduledEvent.ts
@@ -18,7 +18,7 @@ interface APIGuildScheduledEventBase<Type extends GuildScheduledEventEntityType>
 	/**
 	 * The id of the user that created the scheduled event
 	 */
-	creator_id: Snowflake | null;
+	creator_id?: Snowflake | null;
 	/**
 	 * The name of the scheduled event
 	 */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

**Reference Discord API Docs PRs or commits:**
- https://github.com/discord/discord-api-docs/pull/4454