### PR TITLE
fix: make `data` required in autocomplete interaction and add separate dm/guild types

### DIFF
--- a/deno/payloads/v8/_interactions/autocomplete.ts
+++ b/deno/payloads/v8/_interactions/autocomplete.ts
@@ -1,6 +1,24 @@
-import type { APIBaseInteraction, APIChatInputApplicationCommandInteractionData, InteractionType } from '../mod.ts';
+import type {
+	APIBaseInteraction,
+	APIChatInputApplicationCommandInteractionData,
+	APIDMInteractionWrapper,
+	APIGuildInteractionWrapper,
+	InteractionType,
+} from '../mod.ts';
 
 export type APIApplicationCommandAutocompleteInteraction = APIBaseInteraction<
 	InteractionType.ApplicationCommandAutocomplete,
 	APIChatInputApplicationCommandInteractionData
 >;
+
+/**
+ * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object
+ */
+export type APIApplicationCommandAutocompleteDMInteraction =
+	APIDMInteractionWrapper<APIApplicationCommandAutocompleteInteraction>;
+
+/**
+ * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object
+ */
+export type APIApplicationCommandAutocompleteGuildInteraction =
+	APIGuildInteractionWrapper<APIApplicationCommandAutocompleteInteraction>;

--- a/deno/payloads/v8/_interactions/autocomplete.ts
+++ b/deno/payloads/v8/_interactions/autocomplete.ts
@@ -9,7 +9,13 @@ import type {
 export type APIApplicationCommandAutocompleteInteraction = APIBaseInteraction<
 	InteractionType.ApplicationCommandAutocomplete,
 	APIChatInputApplicationCommandInteractionData
->;
+> &
+	Required<
+		Pick<
+			APIBaseInteraction<InteractionType.ApplicationCommandAutocomplete, APIChatInputApplicationCommandInteractionData>,
+			'data'
+		>
+	>;
 
 /**
  * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object

--- a/deno/payloads/v8/interactions.ts
+++ b/deno/payloads/v8/interactions.ts
@@ -9,7 +9,11 @@ import type {
 	APIApplicationCommandGuildInteraction,
 	APIApplicationCommandInteraction,
 } from './_interactions/applicationCommands.ts';
-import type { APIApplicationCommandAutocompleteInteraction } from './_interactions/autocomplete.ts';
+import type {
+	APIApplicationCommandAutocompleteDMInteraction,
+	APIApplicationCommandAutocompleteGuildInteraction,
+	APIApplicationCommandAutocompleteInteraction,
+} from './_interactions/autocomplete.ts';
 import type {
 	APIModalSubmitDMInteraction,
 	APIModalSubmitGuildInteraction,
@@ -39,6 +43,7 @@ export type APIInteraction =
 export type APIDMInteraction =
 	| APIApplicationCommandDMInteraction
 	| APIMessageComponentDMInteraction
+	| APIApplicationCommandAutocompleteDMInteraction
 	| APIModalSubmitDMInteraction;
 
 /**
@@ -47,4 +52,5 @@ export type APIDMInteraction =
 export type APIGuildInteraction =
 	| APIApplicationCommandGuildInteraction
 	| APIMessageComponentGuildInteraction
+	| APIApplicationCommandAutocompleteGuildInteraction
 	| APIModalSubmitGuildInteraction;

--- a/deno/payloads/v9/_interactions/autocomplete.ts
+++ b/deno/payloads/v9/_interactions/autocomplete.ts
@@ -1,6 +1,24 @@
-import type { APIBaseInteraction, APIChatInputApplicationCommandInteractionData, InteractionType } from '../mod.ts';
+import type {
+	APIBaseInteraction,
+	APIChatInputApplicationCommandInteractionData,
+	APIDMInteractionWrapper,
+	APIGuildInteractionWrapper,
+	InteractionType,
+} from '../mod.ts';
 
 export type APIApplicationCommandAutocompleteInteraction = APIBaseInteraction<
 	InteractionType.ApplicationCommandAutocomplete,
 	APIChatInputApplicationCommandInteractionData
 >;
+
+/**
+ * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object
+ */
+export type APIApplicationCommandAutocompleteDMInteraction =
+	APIDMInteractionWrapper<APIApplicationCommandAutocompleteInteraction>;
+
+/**
+ * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object
+ */
+export type APIApplicationCommandAutocompleteGuildInteraction =
+	APIGuildInteractionWrapper<APIApplicationCommandAutocompleteInteraction>;

--- a/deno/payloads/v9/_interactions/autocomplete.ts
+++ b/deno/payloads/v9/_interactions/autocomplete.ts
@@ -9,7 +9,13 @@ import type {
 export type APIApplicationCommandAutocompleteInteraction = APIBaseInteraction<
 	InteractionType.ApplicationCommandAutocomplete,
 	APIChatInputApplicationCommandInteractionData
->;
+> &
+	Required<
+		Pick<
+			APIBaseInteraction<InteractionType.ApplicationCommandAutocomplete, APIChatInputApplicationCommandInteractionData>,
+			'data'
+		>
+	>;
 
 /**
  * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object

--- a/deno/payloads/v9/interactions.ts
+++ b/deno/payloads/v9/interactions.ts
@@ -9,7 +9,11 @@ import type {
 	APIApplicationCommandGuildInteraction,
 	APIApplicationCommandInteraction,
 } from './_interactions/applicationCommands.ts';
-import type { APIApplicationCommandAutocompleteInteraction } from './_interactions/autocomplete.ts';
+import type {
+	APIApplicationCommandAutocompleteDMInteraction,
+	APIApplicationCommandAutocompleteGuildInteraction,
+	APIApplicationCommandAutocompleteInteraction,
+} from './_interactions/autocomplete.ts';
 import type {
 	APIModalSubmitDMInteraction,
 	APIModalSubmitGuildInteraction,
@@ -39,6 +43,7 @@ export type APIInteraction =
 export type APIDMInteraction =
 	| APIApplicationCommandDMInteraction
 	| APIMessageComponentDMInteraction
+	| APIApplicationCommandAutocompleteDMInteraction
 	| APIModalSubmitDMInteraction;
 
 /**
@@ -47,4 +52,5 @@ export type APIDMInteraction =
 export type APIGuildInteraction =
 	| APIApplicationCommandGuildInteraction
 	| APIMessageComponentGuildInteraction
+	| APIApplicationCommandAutocompleteGuildInteraction
 	| APIModalSubmitGuildInteraction;

--- a/payloads/v8/_interactions/autocomplete.ts
+++ b/payloads/v8/_interactions/autocomplete.ts
@@ -1,6 +1,24 @@
-import type { APIBaseInteraction, APIChatInputApplicationCommandInteractionData, InteractionType } from '../index';
+import type {
+	APIBaseInteraction,
+	APIChatInputApplicationCommandInteractionData,
+	APIDMInteractionWrapper,
+	APIGuildInteractionWrapper,
+	InteractionType,
+} from '../index';
 
 export type APIApplicationCommandAutocompleteInteraction = APIBaseInteraction<
 	InteractionType.ApplicationCommandAutocomplete,
 	APIChatInputApplicationCommandInteractionData
 >;
+
+/**
+ * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object
+ */
+export type APIApplicationCommandAutocompleteDMInteraction =
+	APIDMInteractionWrapper<APIApplicationCommandAutocompleteInteraction>;
+
+/**
+ * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object
+ */
+export type APIApplicationCommandAutocompleteGuildInteraction =
+	APIGuildInteractionWrapper<APIApplicationCommandAutocompleteInteraction>;

--- a/payloads/v8/_interactions/autocomplete.ts
+++ b/payloads/v8/_interactions/autocomplete.ts
@@ -9,7 +9,13 @@ import type {
 export type APIApplicationCommandAutocompleteInteraction = APIBaseInteraction<
 	InteractionType.ApplicationCommandAutocomplete,
 	APIChatInputApplicationCommandInteractionData
->;
+> &
+	Required<
+		Pick<
+			APIBaseInteraction<InteractionType.ApplicationCommandAutocomplete, APIChatInputApplicationCommandInteractionData>,
+			'data'
+		>
+	>;
 
 /**
  * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object

--- a/payloads/v8/interactions.ts
+++ b/payloads/v8/interactions.ts
@@ -9,7 +9,11 @@ import type {
 	APIApplicationCommandGuildInteraction,
 	APIApplicationCommandInteraction,
 } from './_interactions/applicationCommands';
-import type { APIApplicationCommandAutocompleteInteraction } from './_interactions/autocomplete';
+import type {
+	APIApplicationCommandAutocompleteDMInteraction,
+	APIApplicationCommandAutocompleteGuildInteraction,
+	APIApplicationCommandAutocompleteInteraction,
+} from './_interactions/autocomplete';
 import type {
 	APIModalSubmitDMInteraction,
 	APIModalSubmitGuildInteraction,
@@ -39,6 +43,7 @@ export type APIInteraction =
 export type APIDMInteraction =
 	| APIApplicationCommandDMInteraction
 	| APIMessageComponentDMInteraction
+	| APIApplicationCommandAutocompleteDMInteraction
 	| APIModalSubmitDMInteraction;
 
 /**
@@ -47,4 +52,5 @@ export type APIDMInteraction =
 export type APIGuildInteraction =
 	| APIApplicationCommandGuildInteraction
 	| APIMessageComponentGuildInteraction
+	| APIApplicationCommandAutocompleteGuildInteraction
 	| APIModalSubmitGuildInteraction;

--- a/payloads/v9/_interactions/autocomplete.ts
+++ b/payloads/v9/_interactions/autocomplete.ts
@@ -1,6 +1,24 @@
-import type { APIBaseInteraction, APIChatInputApplicationCommandInteractionData, InteractionType } from '../index';
+import type {
+	APIBaseInteraction,
+	APIChatInputApplicationCommandInteractionData,
+	APIDMInteractionWrapper,
+	APIGuildInteractionWrapper,
+	InteractionType,
+} from '../index';
 
 export type APIApplicationCommandAutocompleteInteraction = APIBaseInteraction<
 	InteractionType.ApplicationCommandAutocomplete,
 	APIChatInputApplicationCommandInteractionData
 >;
+
+/**
+ * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object
+ */
+export type APIApplicationCommandAutocompleteDMInteraction =
+	APIDMInteractionWrapper<APIApplicationCommandAutocompleteInteraction>;
+
+/**
+ * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object
+ */
+export type APIApplicationCommandAutocompleteGuildInteraction =
+	APIGuildInteractionWrapper<APIApplicationCommandAutocompleteInteraction>;

--- a/payloads/v9/_interactions/autocomplete.ts
+++ b/payloads/v9/_interactions/autocomplete.ts
@@ -9,7 +9,13 @@ import type {
 export type APIApplicationCommandAutocompleteInteraction = APIBaseInteraction<
 	InteractionType.ApplicationCommandAutocomplete,
 	APIChatInputApplicationCommandInteractionData
->;
+> &
+	Required<
+		Pick<
+			APIBaseInteraction<InteractionType.ApplicationCommandAutocomplete, APIChatInputApplicationCommandInteractionData>,
+			'data'
+		>
+	>;
 
 /**
  * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object

--- a/payloads/v9/interactions.ts
+++ b/payloads/v9/interactions.ts
@@ -9,7 +9,11 @@ import type {
 	APIApplicationCommandGuildInteraction,
 	APIApplicationCommandInteraction,
 } from './_interactions/applicationCommands';
-import type { APIApplicationCommandAutocompleteInteraction } from './_interactions/autocomplete';
+import type {
+	APIApplicationCommandAutocompleteDMInteraction,
+	APIApplicationCommandAutocompleteGuildInteraction,
+	APIApplicationCommandAutocompleteInteraction,
+} from './_interactions/autocomplete';
 import type {
 	APIModalSubmitDMInteraction,
 	APIModalSubmitGuildInteraction,
@@ -39,6 +43,7 @@ export type APIInteraction =
 export type APIDMInteraction =
 	| APIApplicationCommandDMInteraction
 	| APIMessageComponentDMInteraction
+	| APIApplicationCommandAutocompleteDMInteraction
 	| APIModalSubmitDMInteraction;
 
 /**
@@ -47,4 +52,5 @@ export type APIDMInteraction =
 export type APIGuildInteraction =
 	| APIApplicationCommandGuildInteraction
 	| APIMessageComponentGuildInteraction
+	| APIApplicationCommandAutocompleteGuildInteraction
 	| APIModalSubmitGuildInteraction;

--- a/tests/v9/interactions.test-d.ts
+++ b/tests/v9/interactions.test-d.ts
@@ -2,6 +2,7 @@ import { expectType } from 'tsd';
 import {
 	APIApplicationCommandInteraction,
 	APIApplicationCommandInteractionData,
+	APIChatInputApplicationCommandInteractionData,
 	APIDMInteraction,
 	APIGuildInteraction,
 	APIInteraction,
@@ -36,6 +37,10 @@ if (interaction.type === InteractionType.MessageComponent) {
 		// expectType<APIMessageSelectMenuInteractionData>(data);
 		expectType<string[]>(data.values);
 	}
+}
+
+if (interaction.type === InteractionType.ApplicationCommandAutocomplete) {
+	expectType<APIChatInputApplicationCommandInteractionData>(interaction.data);
 }
 
 if (interaction.type === InteractionType.ModalSubmit) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
As I understand it, the `data` property cannot be missing in any of the current interaction types (except for ping) ([source](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-structure))

As per @vladfrangu's request (https://github.com/discordjs/discord-api-types/pull/321#issuecomment-1036494951), added separate dm/guild types of the `APIApplicationCommandAutocompleteInteraction`

**Reference Discord API Docs PRs or commits:**
