### PR TITLE
refactor(APIComponents): simplify action row types

### DIFF
--- a/deno/payloads/v8/_interactions/modalSubmit.ts
+++ b/deno/payloads/v8/_interactions/modalSubmit.ts
@@ -1,4 +1,4 @@
-import type { APIActionRowComponent, APIModalComponent } from '../channel.ts';
+import type { APIActionRowComponent, APIModalActionRowComponent } from '../channel.ts';
 import type {
 	APIBaseInteraction,
 	InteractionType,
@@ -13,7 +13,8 @@ export interface ModalSubmitComponent {
 	value: string;
 }
 
-export interface ModalSubmitActionRowComponent extends Omit<APIActionRowComponent<APIModalComponent>, 'components'> {
+export interface ModalSubmitActionRowComponent
+	extends Omit<APIActionRowComponent<APIModalActionRowComponent>, 'components'> {
 	components: ModalSubmitComponent[];
 }
 

--- a/deno/payloads/v8/_interactions/responses.ts
+++ b/deno/payloads/v8/_interactions/responses.ts
@@ -1,7 +1,7 @@
 import type { MessageFlags } from '../mod.ts';
 import type { RESTPostAPIWebhookWithTokenJSONBody } from '../../../v8.ts';
 import type { APIApplicationCommandOptionChoice } from './applicationCommands.ts';
-import type { APIActionRowComponent, APIModalComponent } from '../channel.ts';
+import type { APIActionRowComponent, APIModalActionRowComponent } from '../channel.ts';
 
 /**
  * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-type
@@ -119,5 +119,5 @@ export interface APIModalInteractionResponseCallbackData {
 	/**
 	 * Between 1 and 5 (inclusive) components that make up the modal
 	 */
-	components: APIActionRowComponent<APIModalComponent>[];
+	components: APIActionRowComponent<APIModalActionRowComponent>[];
 }

--- a/deno/payloads/v8/channel.ts
+++ b/deno/payloads/v8/channel.ts
@@ -406,7 +406,7 @@ export interface APIMessage {
 	/**
 	 * Sent if the message contains components like buttons, action rows, or other interactive components
 	 */
-	components?: APIActionRowComponent<APIMessageComponent>[];
+	components?: APIActionRowComponent<APIMessageActionRowComponent>[];
 	/**
 	 * Sent if the message contains stickers
 	 *
@@ -1013,7 +1013,7 @@ export interface APIActionRowComponent<T extends APIActionRowComponentTypes>
 	/**
 	 * The components in the ActionRow
 	 */
-	components: Exclude<T, APIActionRowComponent<T>>[];
+	components: T[];
 }
 
 /**
@@ -1191,19 +1191,18 @@ export interface APITextInputComponent extends APIBaseComponent<ComponentType.Te
 	required?: boolean;
 }
 
-export type APIActionRowComponentTypes = APIMessageComponent | APIModalComponent;
+/**
+ * https://discord.com/developers/docs/interactions/message-components#message-components
+ */
+export type APIMessageComponent = APIMessageActionRowComponent | APIActionRowComponent<APIMessageActionRowComponent>;
+export type APIModalComponent = APIModalActionRowComponent | APIActionRowComponent<APIModalActionRowComponent>;
+
+export type APIActionRowComponentTypes = APIMessageActionRowComponent | APIModalActionRowComponent;
 
 /**
  * https://discord.com/developers/docs/interactions/message-components#message-components
  */
-export type APIMessageComponent =
-	| APIActionRowComponent<APIMessageComponent>
-	| APIButtonComponent
-	| APISelectMenuComponent;
-
-export type APIMessageActionRowComponent = APIActionRowComponent<APIMessageComponent>;
+export type APIMessageActionRowComponent = APIButtonComponent | APISelectMenuComponent;
 
 // Modal components
-export type APIModalComponent = APIActionRowComponent<APIModalComponent> | APITextInputComponent;
-
-export type APIModalActionRowComponent = APIActionRowComponent<APIModalComponent>;
+export type APIModalActionRowComponent = APITextInputComponent;

--- a/deno/payloads/v9/_interactions/modalSubmit.ts
+++ b/deno/payloads/v9/_interactions/modalSubmit.ts
@@ -1,4 +1,4 @@
-import type { APIActionRowComponent, APIModalComponent } from '../channel.ts';
+import type { APIActionRowComponent, APIModalActionRowComponent } from '../channel.ts';
 import type {
 	APIBaseInteraction,
 	InteractionType,
@@ -13,7 +13,8 @@ export interface ModalSubmitComponent {
 	value: string;
 }
 
-export interface ModalSubmitActionRowComponent extends Omit<APIActionRowComponent<APIModalComponent>, 'components'> {
+export interface ModalSubmitActionRowComponent
+	extends Omit<APIActionRowComponent<APIModalActionRowComponent>, 'components'> {
 	components: ModalSubmitComponent[];
 }
 

--- a/deno/payloads/v9/_interactions/responses.ts
+++ b/deno/payloads/v9/_interactions/responses.ts
@@ -1,7 +1,7 @@
 import type { MessageFlags } from '../mod.ts';
 import type { RESTPostAPIWebhookWithTokenJSONBody } from '../../../v9.ts';
 import type { APIApplicationCommandOptionChoice } from './applicationCommands.ts';
-import type { APIActionRowComponent, APIModalComponent } from '../channel.ts';
+import type { APIActionRowComponent, APIModalActionRowComponent } from '../channel.ts';
 
 /**
  * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-type
@@ -119,5 +119,5 @@ export interface APIModalInteractionResponseCallbackData {
 	/**
 	 * Between 1 and 5 (inclusive) components that make up the modal
 	 */
-	components: APIActionRowComponent<APIModalComponent>[];
+	components: APIActionRowComponent<APIModalActionRowComponent>[];
 }

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -483,7 +483,7 @@ export interface APIMessage {
 	/**
 	 * Sent if the message contains components like buttons, action rows, or other interactive components
 	 */
-	components?: APIActionRowComponent<APIMessageComponent>[];
+	components?: APIActionRowComponent<APIMessageActionRowComponent>[];
 	/**
 	 * Sent if the message contains stickers
 	 *
@@ -1182,7 +1182,7 @@ export interface APIActionRowComponent<T extends APIActionRowComponentTypes>
 	/**
 	 * The components in the ActionRow
 	 */
-	components: Exclude<T, APIActionRowComponent<T>>[];
+	components: T[];
 }
 
 /**
@@ -1360,19 +1360,18 @@ export interface APITextInputComponent extends APIBaseComponent<ComponentType.Te
 	required?: boolean;
 }
 
-export type APIActionRowComponentTypes = APIMessageComponent | APIModalComponent;
+/**
+ * https://discord.com/developers/docs/interactions/message-components#message-components
+ */
+export type APIMessageComponent = APIMessageActionRowComponent | APIActionRowComponent<APIMessageActionRowComponent>;
+export type APIModalComponent = APIModalActionRowComponent | APIActionRowComponent<APIModalActionRowComponent>;
+
+export type APIActionRowComponentTypes = APIMessageActionRowComponent | APIModalActionRowComponent;
 
 /**
  * https://discord.com/developers/docs/interactions/message-components#message-components
  */
-export type APIMessageComponent =
-	| APIActionRowComponent<APIMessageComponent>
-	| APIButtonComponent
-	| APISelectMenuComponent;
-
-export type APIMessageActionRowComponent = APIActionRowComponent<APIMessageComponent>;
+export type APIMessageActionRowComponent = APIButtonComponent | APISelectMenuComponent;
 
 // Modal components
-export type APIModalComponent = APIActionRowComponent<APIModalComponent> | APITextInputComponent;
-
-export type APIModalActionRowComponent = APIActionRowComponent<APIModalComponent>;
+export type APIModalActionRowComponent = APITextInputComponent;

--- a/deno/rest/v8/channel.ts
+++ b/deno/rest/v8/channel.ts
@@ -1,7 +1,6 @@
 import type { Permissions, Snowflake } from '../../globals.ts';
 import type {
 	APIActionRowComponent,
-	APIMessageComponent,
 	APIAllowedMentions,
 	APIAttachment,
 	APIChannel,
@@ -16,6 +15,7 @@ import type {
 	MessageFlags,
 	OverwriteType,
 	VideoQualityMode,
+	APIMessageActionRowComponent,
 } from '../../payloads/v8/mod.ts';
 import type { AddUndefinedToPossiblyUndefinedPropertiesOfInterface, StrictPartial } from '../../utils/internals.ts';
 
@@ -214,7 +214,7 @@ export type RESTPostAPIChannelMessageJSONBody = AddUndefinedToPossiblyUndefinedP
 	 *
 	 * See https://discord.com/developers/docs/interactions/message-components#component-object
 	 */
-	components?: APIActionRowComponent<APIMessageComponent>[];
+	components?: APIActionRowComponent<APIMessageActionRowComponent>[];
 	/**
 	 * IDs of up to 3 stickers in the server to send in the message
 	 *
@@ -348,7 +348,7 @@ export type RESTPatchAPIChannelMessageJSONBody = AddUndefinedToPossiblyUndefined
 	 *
 	 * See https://discord.com/developers/docs/interactions/message-components#component-object
 	 */
-	components?: APIActionRowComponent<APIMessageComponent>[] | null;
+	components?: APIActionRowComponent<APIMessageActionRowComponent>[] | null;
 }>;
 
 /**

--- a/deno/rest/v8/webhook.ts
+++ b/deno/rest/v8/webhook.ts
@@ -7,7 +7,7 @@ import type {
 	APIWebhook,
 	APIAttachment,
 	MessageFlags,
-	APIMessageComponent,
+	APIMessageActionRowComponent,
 } from '../../payloads/v8/mod.ts';
 import type { AddUndefinedToPossiblyUndefinedPropertiesOfInterface, Nullable } from '../../utils/internals.ts';
 
@@ -136,7 +136,7 @@ export type RESTPostAPIWebhookWithTokenJSONBody = AddUndefinedToPossiblyUndefine
 	 *
 	 * See https://discord.com/developers/docs/interactions/message-components#component-object
 	 */
-	components?: APIActionRowComponent<APIMessageComponent>[];
+	components?: APIActionRowComponent<APIMessageActionRowComponent>[];
 	/**
 	 * Attachment objects with filename and description
 	 */

--- a/deno/rest/v9/channel.ts
+++ b/deno/rest/v9/channel.ts
@@ -1,6 +1,5 @@
 import type { Permissions, Snowflake } from '../../globals.ts';
 import type {
-	APIMessageComponent,
 	APIActionRowComponent,
 	APIAllowedMentions,
 	APIAttachment,
@@ -21,6 +20,7 @@ import type {
 	VideoQualityMode,
 } from '../../payloads/v9/mod.ts';
 import type { AddUndefinedToPossiblyUndefinedPropertiesOfInterface, StrictPartial } from '../../utils/internals.ts';
+import type { APIMessageActionRowComponent } from '../../v8.ts';
 
 export interface APIChannelPatchOverwrite extends RESTPutAPIChannelPermissionJSONBody {
 	id: Snowflake;
@@ -247,7 +247,7 @@ export type RESTPostAPIChannelMessageJSONBody = AddUndefinedToPossiblyUndefinedP
 	 *
 	 * See https://discord.com/developers/docs/interactions/message-components#component-object
 	 */
-	components?: APIActionRowComponent<APIMessageComponent>[];
+	components?: APIActionRowComponent<APIMessageActionRowComponent>[];
 	/**
 	 * IDs of up to 3 stickers in the server to send in the message
 	 *
@@ -381,7 +381,7 @@ export type RESTPatchAPIChannelMessageJSONBody = AddUndefinedToPossiblyUndefined
 	 *
 	 * See https://discord.com/developers/docs/interactions/message-components#component-object
 	 */
-	components?: APIActionRowComponent<APIMessageComponent>[] | null;
+	components?: APIActionRowComponent<APIMessageActionRowComponent>[] | null;
 }>;
 
 /**

--- a/deno/rest/v9/channel.ts
+++ b/deno/rest/v9/channel.ts
@@ -18,9 +18,9 @@ import type {
 	OverwriteType,
 	ThreadAutoArchiveDuration,
 	VideoQualityMode,
+	APIMessageActionRowComponent,
 } from '../../payloads/v9/mod.ts';
 import type { AddUndefinedToPossiblyUndefinedPropertiesOfInterface, StrictPartial } from '../../utils/internals.ts';
-import type { APIMessageActionRowComponent } from '../../v8.ts';
 
 export interface APIChannelPatchOverwrite extends RESTPutAPIChannelPermissionJSONBody {
 	id: Snowflake;

--- a/deno/rest/v9/webhook.ts
+++ b/deno/rest/v9/webhook.ts
@@ -7,10 +7,9 @@ import type {
 	APIWebhook,
 	APIAttachment,
 	MessageFlags,
+	APIMessageActionRowComponent,
 } from '../../payloads/v9/mod.ts';
 import type { AddUndefinedToPossiblyUndefinedPropertiesOfInterface, Nullable } from '../../utils/internals.ts';
-import type { APIMessageActionRowComponent } from '../../v8.ts';
-
 /**
  * https://discord.com/developers/docs/resources/webhook#create-webhook
  */

--- a/deno/rest/v9/webhook.ts
+++ b/deno/rest/v9/webhook.ts
@@ -7,9 +7,9 @@ import type {
 	APIWebhook,
 	APIAttachment,
 	MessageFlags,
-	APIMessageComponent,
 } from '../../payloads/v9/mod.ts';
 import type { AddUndefinedToPossiblyUndefinedPropertiesOfInterface, Nullable } from '../../utils/internals.ts';
+import type { APIMessageActionRowComponent } from '../../v8.ts';
 
 /**
  * https://discord.com/developers/docs/resources/webhook#create-webhook
@@ -136,7 +136,7 @@ export type RESTPostAPIWebhookWithTokenJSONBody = AddUndefinedToPossiblyUndefine
 	 *
 	 * See https://discord.com/developers/docs/interactions/message-components#component-object
 	 */
-	components?: APIActionRowComponent<APIMessageComponent>[];
+	components?: APIActionRowComponent<APIMessageActionRowComponent>[];
 	/**
 	 * Attachment objects with filename and description
 	 */

--- a/payloads/v8/_interactions/modalSubmit.ts
+++ b/payloads/v8/_interactions/modalSubmit.ts
@@ -1,4 +1,4 @@
-import type { APIActionRowComponent, APIModalComponent } from '../channel';
+import type { APIActionRowComponent, APIModalActionRowComponent } from '../channel';
 import type {
 	APIBaseInteraction,
 	InteractionType,
@@ -13,7 +13,8 @@ export interface ModalSubmitComponent {
 	value: string;
 }
 
-export interface ModalSubmitActionRowComponent extends Omit<APIActionRowComponent<APIModalComponent>, 'components'> {
+export interface ModalSubmitActionRowComponent
+	extends Omit<APIActionRowComponent<APIModalActionRowComponent>, 'components'> {
 	components: ModalSubmitComponent[];
 }
 

--- a/payloads/v8/_interactions/responses.ts
+++ b/payloads/v8/_interactions/responses.ts
@@ -1,7 +1,7 @@
 import type { MessageFlags } from '../index';
 import type { RESTPostAPIWebhookWithTokenJSONBody } from '../../../v8';
 import type { APIApplicationCommandOptionChoice } from './applicationCommands';
-import type { APIActionRowComponent, APIModalComponent } from '../channel';
+import type { APIActionRowComponent, APIModalActionRowComponent } from '../channel';
 
 /**
  * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-type
@@ -119,5 +119,5 @@ export interface APIModalInteractionResponseCallbackData {
 	/**
 	 * Between 1 and 5 (inclusive) components that make up the modal
 	 */
-	components: APIActionRowComponent<APIModalComponent>[];
+	components: APIActionRowComponent<APIModalActionRowComponent>[];
 }

--- a/payloads/v8/channel.ts
+++ b/payloads/v8/channel.ts
@@ -406,7 +406,7 @@ export interface APIMessage {
 	/**
 	 * Sent if the message contains components like buttons, action rows, or other interactive components
 	 */
-	components?: APIActionRowComponent<APIMessageComponent>[];
+	components?: APIActionRowComponent<APIMessageActionRowComponent>[];
 	/**
 	 * Sent if the message contains stickers
 	 *
@@ -1013,7 +1013,7 @@ export interface APIActionRowComponent<T extends APIActionRowComponentTypes>
 	/**
 	 * The components in the ActionRow
 	 */
-	components: Exclude<T, APIActionRowComponent<T>>[];
+	components: T[];
 }
 
 /**
@@ -1191,19 +1191,18 @@ export interface APITextInputComponent extends APIBaseComponent<ComponentType.Te
 	required?: boolean;
 }
 
-export type APIActionRowComponentTypes = APIMessageComponent | APIModalComponent;
+/**
+ * https://discord.com/developers/docs/interactions/message-components#message-components
+ */
+export type APIMessageComponent = APIMessageActionRowComponent | APIActionRowComponent<APIMessageActionRowComponent>;
+export type APIModalComponent = APIModalActionRowComponent | APIActionRowComponent<APIModalActionRowComponent>;
+
+export type APIActionRowComponentTypes = APIMessageActionRowComponent | APIModalActionRowComponent;
 
 /**
  * https://discord.com/developers/docs/interactions/message-components#message-components
  */
-export type APIMessageComponent =
-	| APIActionRowComponent<APIMessageComponent>
-	| APIButtonComponent
-	| APISelectMenuComponent;
-
-export type APIMessageActionRowComponent = APIActionRowComponent<APIMessageComponent>;
+export type APIMessageActionRowComponent = APIButtonComponent | APISelectMenuComponent;
 
 // Modal components
-export type APIModalComponent = APIActionRowComponent<APIModalComponent> | APITextInputComponent;
-
-export type APIModalActionRowComponent = APIActionRowComponent<APIModalComponent>;
+export type APIModalActionRowComponent = APITextInputComponent;

--- a/payloads/v9/_interactions/modalSubmit.ts
+++ b/payloads/v9/_interactions/modalSubmit.ts
@@ -1,4 +1,4 @@
-import type { APIActionRowComponent, APIModalComponent } from '../channel';
+import type { APIActionRowComponent, APIModalActionRowComponent } from '../channel';
 import type {
 	APIBaseInteraction,
 	InteractionType,
@@ -13,7 +13,8 @@ export interface ModalSubmitComponent {
 	value: string;
 }
 
-export interface ModalSubmitActionRowComponent extends Omit<APIActionRowComponent<APIModalComponent>, 'components'> {
+export interface ModalSubmitActionRowComponent
+	extends Omit<APIActionRowComponent<APIModalActionRowComponent>, 'components'> {
 	components: ModalSubmitComponent[];
 }
 

--- a/payloads/v9/_interactions/responses.ts
+++ b/payloads/v9/_interactions/responses.ts
@@ -1,7 +1,7 @@
 import type { MessageFlags } from '../index';
 import type { RESTPostAPIWebhookWithTokenJSONBody } from '../../../v9';
 import type { APIApplicationCommandOptionChoice } from './applicationCommands';
-import type { APIActionRowComponent, APIModalComponent } from '../channel';
+import type { APIActionRowComponent, APIModalActionRowComponent } from '../channel';
 
 /**
  * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-type
@@ -119,5 +119,5 @@ export interface APIModalInteractionResponseCallbackData {
 	/**
 	 * Between 1 and 5 (inclusive) components that make up the modal
 	 */
-	components: APIActionRowComponent<APIModalComponent>[];
+	components: APIActionRowComponent<APIModalActionRowComponent>[];
 }

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -483,7 +483,7 @@ export interface APIMessage {
 	/**
 	 * Sent if the message contains components like buttons, action rows, or other interactive components
 	 */
-	components?: APIActionRowComponent<APIMessageComponent>[];
+	components?: APIActionRowComponent<APIMessageActionRowComponent>[];
 	/**
 	 * Sent if the message contains stickers
 	 *
@@ -1182,7 +1182,7 @@ export interface APIActionRowComponent<T extends APIActionRowComponentTypes>
 	/**
 	 * The components in the ActionRow
 	 */
-	components: Exclude<T, APIActionRowComponent<T>>[];
+	components: T[];
 }
 
 /**
@@ -1360,19 +1360,18 @@ export interface APITextInputComponent extends APIBaseComponent<ComponentType.Te
 	required?: boolean;
 }
 
-export type APIActionRowComponentTypes = APIMessageComponent | APIModalComponent;
+/**
+ * https://discord.com/developers/docs/interactions/message-components#message-components
+ */
+export type APIMessageComponent = APIMessageActionRowComponent | APIActionRowComponent<APIMessageActionRowComponent>;
+export type APIModalComponent = APIModalActionRowComponent | APIActionRowComponent<APIModalActionRowComponent>;
+
+export type APIActionRowComponentTypes = APIMessageActionRowComponent | APIModalActionRowComponent;
 
 /**
  * https://discord.com/developers/docs/interactions/message-components#message-components
  */
-export type APIMessageComponent =
-	| APIActionRowComponent<APIMessageComponent>
-	| APIButtonComponent
-	| APISelectMenuComponent;
-
-export type APIMessageActionRowComponent = APIActionRowComponent<APIMessageComponent>;
+export type APIMessageActionRowComponent = APIButtonComponent | APISelectMenuComponent;
 
 // Modal components
-export type APIModalComponent = APIActionRowComponent<APIModalComponent> | APITextInputComponent;
-
-export type APIModalActionRowComponent = APIActionRowComponent<APIModalComponent>;
+export type APIModalActionRowComponent = APITextInputComponent;

--- a/rest/v8/channel.ts
+++ b/rest/v8/channel.ts
@@ -1,7 +1,6 @@
 import type { Permissions, Snowflake } from '../../globals';
 import type {
 	APIActionRowComponent,
-	APIMessageComponent,
 	APIAllowedMentions,
 	APIAttachment,
 	APIChannel,
@@ -16,6 +15,7 @@ import type {
 	MessageFlags,
 	OverwriteType,
 	VideoQualityMode,
+	APIMessageActionRowComponent,
 } from '../../payloads/v8/index';
 import type { AddUndefinedToPossiblyUndefinedPropertiesOfInterface, StrictPartial } from '../../utils/internals';
 
@@ -214,7 +214,7 @@ export type RESTPostAPIChannelMessageJSONBody = AddUndefinedToPossiblyUndefinedP
 	 *
 	 * See https://discord.com/developers/docs/interactions/message-components#component-object
 	 */
-	components?: APIActionRowComponent<APIMessageComponent>[];
+	components?: APIActionRowComponent<APIMessageActionRowComponent>[];
 	/**
 	 * IDs of up to 3 stickers in the server to send in the message
 	 *
@@ -348,7 +348,7 @@ export type RESTPatchAPIChannelMessageJSONBody = AddUndefinedToPossiblyUndefined
 	 *
 	 * See https://discord.com/developers/docs/interactions/message-components#component-object
 	 */
-	components?: APIActionRowComponent<APIMessageComponent>[] | null;
+	components?: APIActionRowComponent<APIMessageActionRowComponent>[] | null;
 }>;
 
 /**

--- a/rest/v8/webhook.ts
+++ b/rest/v8/webhook.ts
@@ -7,7 +7,7 @@ import type {
 	APIWebhook,
 	APIAttachment,
 	MessageFlags,
-	APIMessageComponent,
+	APIMessageActionRowComponent,
 } from '../../payloads/v8/index';
 import type { AddUndefinedToPossiblyUndefinedPropertiesOfInterface, Nullable } from '../../utils/internals';
 
@@ -136,7 +136,7 @@ export type RESTPostAPIWebhookWithTokenJSONBody = AddUndefinedToPossiblyUndefine
 	 *
 	 * See https://discord.com/developers/docs/interactions/message-components#component-object
 	 */
-	components?: APIActionRowComponent<APIMessageComponent>[];
+	components?: APIActionRowComponent<APIMessageActionRowComponent>[];
 	/**
 	 * Attachment objects with filename and description
 	 */

--- a/rest/v9/channel.ts
+++ b/rest/v9/channel.ts
@@ -18,9 +18,9 @@ import type {
 	OverwriteType,
 	ThreadAutoArchiveDuration,
 	VideoQualityMode,
+	APIMessageActionRowComponent,
 } from '../../payloads/v9/index';
 import type { AddUndefinedToPossiblyUndefinedPropertiesOfInterface, StrictPartial } from '../../utils/internals';
-import type { APIMessageActionRowComponent } from '../../v8';
 
 export interface APIChannelPatchOverwrite extends RESTPutAPIChannelPermissionJSONBody {
 	id: Snowflake;

--- a/rest/v9/channel.ts
+++ b/rest/v9/channel.ts
@@ -1,6 +1,5 @@
 import type { Permissions, Snowflake } from '../../globals';
 import type {
-	APIMessageComponent,
 	APIActionRowComponent,
 	APIAllowedMentions,
 	APIAttachment,
@@ -21,6 +20,7 @@ import type {
 	VideoQualityMode,
 } from '../../payloads/v9/index';
 import type { AddUndefinedToPossiblyUndefinedPropertiesOfInterface, StrictPartial } from '../../utils/internals';
+import type { APIMessageActionRowComponent } from '../../v8';
 
 export interface APIChannelPatchOverwrite extends RESTPutAPIChannelPermissionJSONBody {
 	id: Snowflake;
@@ -247,7 +247,7 @@ export type RESTPostAPIChannelMessageJSONBody = AddUndefinedToPossiblyUndefinedP
 	 *
 	 * See https://discord.com/developers/docs/interactions/message-components#component-object
 	 */
-	components?: APIActionRowComponent<APIMessageComponent>[];
+	components?: APIActionRowComponent<APIMessageActionRowComponent>[];
 	/**
 	 * IDs of up to 3 stickers in the server to send in the message
 	 *
@@ -381,7 +381,7 @@ export type RESTPatchAPIChannelMessageJSONBody = AddUndefinedToPossiblyUndefined
 	 *
 	 * See https://discord.com/developers/docs/interactions/message-components#component-object
 	 */
-	components?: APIActionRowComponent<APIMessageComponent>[] | null;
+	components?: APIActionRowComponent<APIMessageActionRowComponent>[] | null;
 }>;
 
 /**

--- a/rest/v9/webhook.ts
+++ b/rest/v9/webhook.ts
@@ -7,10 +7,9 @@ import type {
 	APIWebhook,
 	APIAttachment,
 	MessageFlags,
+	APIMessageActionRowComponent,
 } from '../../payloads/v9/index';
 import type { AddUndefinedToPossiblyUndefinedPropertiesOfInterface, Nullable } from '../../utils/internals';
-import type { APIMessageActionRowComponent } from '../../v8';
-
 /**
  * https://discord.com/developers/docs/resources/webhook#create-webhook
  */

--- a/rest/v9/webhook.ts
+++ b/rest/v9/webhook.ts
@@ -7,9 +7,9 @@ import type {
 	APIWebhook,
 	APIAttachment,
 	MessageFlags,
-	APIMessageComponent,
 } from '../../payloads/v9/index';
 import type { AddUndefinedToPossiblyUndefinedPropertiesOfInterface, Nullable } from '../../utils/internals';
+import type { APIMessageActionRowComponent } from '../../v8';
 
 /**
  * https://discord.com/developers/docs/resources/webhook#create-webhook
@@ -136,7 +136,7 @@ export type RESTPostAPIWebhookWithTokenJSONBody = AddUndefinedToPossiblyUndefine
 	 *
 	 * See https://discord.com/developers/docs/interactions/message-components#component-object
 	 */
-	components?: APIActionRowComponent<APIMessageComponent>[];
+	components?: APIActionRowComponent<APIMessageActionRowComponent>[];
 	/**
 	 * Attachment objects with filename and description
 	 */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Doing `Exclude` within the `APIActionRow` caused a lot of type issues. So now `APIActionRow<T>` only accepts generic types that aren't action rows themselves. (Which is more intuitive IMO)

