### PR TITLE
fix(APIApplicationCommandAutocompleteInteraction): make `options` field required

### DIFF
--- a/deno/payloads/v8/_interactions/autocomplete.ts
+++ b/deno/payloads/v8/_interactions/autocomplete.ts
@@ -12,7 +12,10 @@ export type APIApplicationCommandAutocompleteInteraction = APIBaseInteraction<
 > &
 	Required<
 		Pick<
-			APIBaseInteraction<InteractionType.ApplicationCommandAutocomplete, APIChatInputApplicationCommandInteractionData>,
+			APIBaseInteraction<
+				InteractionType.ApplicationCommandAutocomplete,
+				Required<Pick<APIChatInputApplicationCommandInteractionData, 'options'>>
+			>,
 			'data'
 		>
 	>;

--- a/deno/payloads/v9/_interactions/autocomplete.ts
+++ b/deno/payloads/v9/_interactions/autocomplete.ts
@@ -12,7 +12,10 @@ export type APIApplicationCommandAutocompleteInteraction = APIBaseInteraction<
 > &
 	Required<
 		Pick<
-			APIBaseInteraction<InteractionType.ApplicationCommandAutocomplete, APIChatInputApplicationCommandInteractionData>,
+			APIBaseInteraction<
+				InteractionType.ApplicationCommandAutocomplete,
+				Required<Pick<APIChatInputApplicationCommandInteractionData, 'options'>>
+			>,
 			'data'
 		>
 	>;

--- a/payloads/v8/_interactions/autocomplete.ts
+++ b/payloads/v8/_interactions/autocomplete.ts
@@ -12,7 +12,10 @@ export type APIApplicationCommandAutocompleteInteraction = APIBaseInteraction<
 > &
 	Required<
 		Pick<
-			APIBaseInteraction<InteractionType.ApplicationCommandAutocomplete, APIChatInputApplicationCommandInteractionData>,
+			APIBaseInteraction<
+				InteractionType.ApplicationCommandAutocomplete,
+				Required<Pick<APIChatInputApplicationCommandInteractionData, 'options'>>
+			>,
 			'data'
 		>
 	>;

--- a/payloads/v9/_interactions/autocomplete.ts
+++ b/payloads/v9/_interactions/autocomplete.ts
@@ -12,7 +12,10 @@ export type APIApplicationCommandAutocompleteInteraction = APIBaseInteraction<
 > &
 	Required<
 		Pick<
-			APIBaseInteraction<InteractionType.ApplicationCommandAutocomplete, APIChatInputApplicationCommandInteractionData>,
+			APIBaseInteraction<
+				InteractionType.ApplicationCommandAutocomplete,
+				Required<Pick<APIChatInputApplicationCommandInteractionData, 'options'>>
+			>,
 			'data'
 		>
 	>;

--- a/tests/v9/interactions.test-d.ts
+++ b/tests/v9/interactions.test-d.ts
@@ -40,7 +40,10 @@ if (interaction.type === InteractionType.MessageComponent) {
 }
 
 if (interaction.type === InteractionType.ApplicationCommandAutocomplete) {
-	expectType<APIChatInputApplicationCommandInteractionData>(interaction.data);
+	expectType<
+		APIChatInputApplicationCommandInteractionData &
+			Required<Pick<APIChatInputApplicationCommandInteractionData, 'options'>>
+	>(interaction.data);
 }
 
 if (interaction.type === InteractionType.ModalSubmit) {

--- a/tests/v9/interactions.test-d.ts
+++ b/tests/v9/interactions.test-d.ts
@@ -2,7 +2,7 @@ import { expectType } from 'tsd';
 import {
 	APIApplicationCommandInteraction,
 	APIApplicationCommandInteractionData,
-	APIChatInputApplicationCommandInteractionData,
+	APIApplicationCommandAutocompleteInteraction,
 	APIDMInteraction,
 	APIGuildInteraction,
 	APIInteraction,
@@ -40,10 +40,7 @@ if (interaction.type === InteractionType.MessageComponent) {
 }
 
 if (interaction.type === InteractionType.ApplicationCommandAutocomplete) {
-	expectType<
-		APIChatInputApplicationCommandInteractionData &
-			Required<Pick<APIChatInputApplicationCommandInteractionData, 'options'>>
-	>(interaction.data);
+	expectType<APIApplicationCommandAutocompleteInteraction['data']>(interaction.data);
 }
 
 if (interaction.type === InteractionType.ModalSubmit) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
- Makes the `options` field required for autocomplete interactions
- Even though it is technically "optional" in the docs, in practice it will always be there when receiving an interaction
- The whole point of an autocomplete interaction is that a user is typing out an option. Therefore autocomplete interaction cannot be sent without options.

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
- [Interaction Object Data Structure](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data-structure)