### PR TITLE
fix(APIApplicationCommandAutocompleteInteraction): make `options` field required for v10 (PR #332 redo)

### DIFF
--- a/deno/payloads/v10/_interactions/autocomplete.ts
+++ b/deno/payloads/v10/_interactions/autocomplete.ts
@@ -12,7 +12,10 @@ export type APIApplicationCommandAutocompleteInteraction = APIBaseInteraction<
 > &
 	Required<
 		Pick<
-			APIBaseInteraction<InteractionType.ApplicationCommandAutocomplete, APIChatInputApplicationCommandInteractionData>,
+			APIBaseInteraction<
+				InteractionType.ApplicationCommandAutocomplete,
+				Required<Pick<APIChatInputApplicationCommandInteractionData, 'options'>>
+			>,
 			'data'
 		>
 	>;

--- a/payloads/v10/_interactions/autocomplete.ts
+++ b/payloads/v10/_interactions/autocomplete.ts
@@ -12,7 +12,10 @@ export type APIApplicationCommandAutocompleteInteraction = APIBaseInteraction<
 > &
 	Required<
 		Pick<
-			APIBaseInteraction<InteractionType.ApplicationCommandAutocomplete, APIChatInputApplicationCommandInteractionData>,
+			APIBaseInteraction<
+				InteractionType.ApplicationCommandAutocomplete,
+				Required<Pick<APIChatInputApplicationCommandInteractionData, 'options'>>
+			>,
 			'data'
 		>
 	>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
- Same changes as #332 but for v10 (since that PR was merged before 332)

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
- [Interaction Object Data Structure](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data-structure)