### PR TITLE
ci: remove deprecate regular versions

### DIFF
--- a/.github/workflows/create-pr-for-release-and-publish.yml
+++ b/.github/workflows/create-pr-for-release-and-publish.yml
@@ -77,11 +77,6 @@ jobs:
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
-      - name: Deprecate old versions
-        run: npx npm-deprecate --name "*" --package discord-api-types --message "No longer supported. Install the latest release!" || true
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
-
       - name: Publish release to npm
         run: npm publish
         env:


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

@vladfrangu asked me to make this PR in Discord DMs

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**

N.A.

Sidenote that you should manually un-deprecate 0.26.1 after merging this @vladfrangu `npm deprecate discord-api-types@0.26.1 ""`
> To un-deprecate a package, specify an empty string (`""`) for the message argument. Note that you must use double quotes with no space between them to format an empty string.