### PR TITLE
feat(MessageComponentInteraction): export specific interaction aliases

### DIFF
--- a/deno/payloads/v10/_interactions/messageComponents.ts
+++ b/deno/payloads/v10/_interactions/messageComponents.ts
@@ -24,7 +24,7 @@ export type APIMessageComponentButtonInteraction = APIBaseInteraction<
 		>
 	>;
 
-export type APIMessageComponentSelectInteraction = APIBaseInteraction<
+export type APIMessageComponentSelectMenuInteraction = APIBaseInteraction<
 	InteractionType.MessageComponent,
 	APIMessageSelectMenuInteractionData
 > &

--- a/deno/payloads/v10/_interactions/messageComponents.ts
+++ b/deno/payloads/v10/_interactions/messageComponents.ts
@@ -13,6 +13,28 @@ export type APIMessageComponentInteraction = APIBaseInteraction<
 		>
 	>;
 
+export type APIMessageComponentButtonInteraction = APIBaseInteraction<
+	InteractionType.MessageComponent,
+	APIMessageButtonInteractionData
+> &
+	Required<
+		Pick<
+			APIBaseInteraction<InteractionType.MessageComponent, APIMessageButtonInteractionData>,
+			'channel_id' | 'data' | 'message'
+		>
+	>;
+
+export type APIMessageComponentSelectInteraction = APIBaseInteraction<
+	InteractionType.MessageComponent,
+	APIMessageSelectMenuInteractionData
+> &
+	Required<
+		Pick<
+			APIBaseInteraction<InteractionType.MessageComponent, APIMessageSelectMenuInteractionData>,
+			'channel_id' | 'data' | 'message'
+		>
+	>;
+
 export type APIMessageComponentInteractionData = APIMessageButtonInteractionData | APIMessageSelectMenuInteractionData;
 
 export interface APIMessageComponentBaseInteractionData<CType extends ComponentType> {

--- a/deno/payloads/v9/_interactions/messageComponents.ts
+++ b/deno/payloads/v9/_interactions/messageComponents.ts
@@ -24,7 +24,7 @@ export type APIMessageComponentButtonInteraction = APIBaseInteraction<
 		>
 	>;
 
-export type APIMessageComponentSelectInteraction = APIBaseInteraction<
+export type APIMessageComponentSelectMenuInteraction = APIBaseInteraction<
 	InteractionType.MessageComponent,
 	APIMessageSelectMenuInteractionData
 > &

--- a/deno/payloads/v9/_interactions/messageComponents.ts
+++ b/deno/payloads/v9/_interactions/messageComponents.ts
@@ -13,6 +13,28 @@ export type APIMessageComponentInteraction = APIBaseInteraction<
 		>
 	>;
 
+export type APIMessageComponentButtonInteraction = APIBaseInteraction<
+	InteractionType.MessageComponent,
+	APIMessageButtonInteractionData
+> &
+	Required<
+		Pick<
+			APIBaseInteraction<InteractionType.MessageComponent, APIMessageButtonInteractionData>,
+			'channel_id' | 'data' | 'message'
+		>
+	>;
+
+export type APIMessageComponentSelectInteraction = APIBaseInteraction<
+	InteractionType.MessageComponent,
+	APIMessageSelectMenuInteractionData
+> &
+	Required<
+		Pick<
+			APIBaseInteraction<InteractionType.MessageComponent, APIMessageSelectMenuInteractionData>,
+			'channel_id' | 'data' | 'message'
+		>
+	>;
+
 export type APIMessageComponentInteractionData = APIMessageButtonInteractionData | APIMessageSelectMenuInteractionData;
 
 export interface APIMessageComponentBaseInteractionData<CType extends ComponentType> {

--- a/payloads/v10/_interactions/messageComponents.ts
+++ b/payloads/v10/_interactions/messageComponents.ts
@@ -24,7 +24,7 @@ export type APIMessageComponentButtonInteraction = APIBaseInteraction<
 		>
 	>;
 
-export type APIMessageComponentSelectInteraction = APIBaseInteraction<
+export type APIMessageComponentSelectMenuInteraction = APIBaseInteraction<
 	InteractionType.MessageComponent,
 	APIMessageSelectMenuInteractionData
 > &

--- a/payloads/v10/_interactions/messageComponents.ts
+++ b/payloads/v10/_interactions/messageComponents.ts
@@ -13,6 +13,28 @@ export type APIMessageComponentInteraction = APIBaseInteraction<
 		>
 	>;
 
+export type APIMessageComponentButtonInteraction = APIBaseInteraction<
+	InteractionType.MessageComponent,
+	APIMessageButtonInteractionData
+> &
+	Required<
+		Pick<
+			APIBaseInteraction<InteractionType.MessageComponent, APIMessageButtonInteractionData>,
+			'channel_id' | 'data' | 'message'
+		>
+	>;
+
+export type APIMessageComponentSelectInteraction = APIBaseInteraction<
+	InteractionType.MessageComponent,
+	APIMessageSelectMenuInteractionData
+> &
+	Required<
+		Pick<
+			APIBaseInteraction<InteractionType.MessageComponent, APIMessageSelectMenuInteractionData>,
+			'channel_id' | 'data' | 'message'
+		>
+	>;
+
 export type APIMessageComponentInteractionData = APIMessageButtonInteractionData | APIMessageSelectMenuInteractionData;
 
 export interface APIMessageComponentBaseInteractionData<CType extends ComponentType> {

--- a/payloads/v9/_interactions/messageComponents.ts
+++ b/payloads/v9/_interactions/messageComponents.ts
@@ -24,7 +24,7 @@ export type APIMessageComponentButtonInteraction = APIBaseInteraction<
 		>
 	>;
 
-export type APIMessageComponentSelectInteraction = APIBaseInteraction<
+export type APIMessageComponentSelectMenuInteraction = APIBaseInteraction<
 	InteractionType.MessageComponent,
 	APIMessageSelectMenuInteractionData
 > &

--- a/payloads/v9/_interactions/messageComponents.ts
+++ b/payloads/v9/_interactions/messageComponents.ts
@@ -13,6 +13,28 @@ export type APIMessageComponentInteraction = APIBaseInteraction<
 		>
 	>;
 
+export type APIMessageComponentButtonInteraction = APIBaseInteraction<
+	InteractionType.MessageComponent,
+	APIMessageButtonInteractionData
+> &
+	Required<
+		Pick<
+			APIBaseInteraction<InteractionType.MessageComponent, APIMessageButtonInteractionData>,
+			'channel_id' | 'data' | 'message'
+		>
+	>;
+
+export type APIMessageComponentSelectInteraction = APIBaseInteraction<
+	InteractionType.MessageComponent,
+	APIMessageSelectMenuInteractionData
+> &
+	Required<
+		Pick<
+			APIBaseInteraction<InteractionType.MessageComponent, APIMessageSelectMenuInteractionData>,
+			'channel_id' | 'data' | 'message'
+		>
+	>;
+
 export type APIMessageComponentInteractionData = APIMessageButtonInteractionData | APIMessageSelectMenuInteractionData;
 
 export interface APIMessageComponentBaseInteractionData<CType extends ComponentType> {


### PR DESCRIPTION
I have no idea if this is right or not lol, but I _think_ it is.

**Please describe the changes this PR makes and why it should be merged:**
This adds types for specific Message Component Interactions. This is useful for when you know what type of component is sending an interaction

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
Vlad influenced me by asking me to export these
