### PR TITLE
chore: export APIButtonComponentBase<T> interface

### DIFF
--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -1188,7 +1188,7 @@ export interface APIActionRowComponent<T extends APIActionRowComponentTypes>
 /**
  * https://discord.com/developers/docs/interactions/message-components#buttons
  */
-interface APIButtonComponentBase<Style extends ButtonStyle> extends APIBaseComponent<ComponentType.Button> {
+export interface APIButtonComponentBase<Style extends ButtonStyle> extends APIBaseComponent<ComponentType.Button> {
 	/**
 	 * The label to be displayed on the button
 	 */

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -1188,7 +1188,7 @@ export interface APIActionRowComponent<T extends APIActionRowComponentTypes>
 /**
  * https://discord.com/developers/docs/interactions/message-components#buttons
  */
-interface APIButtonComponentBase<Style extends ButtonStyle> extends APIBaseComponent<ComponentType.Button> {
+export interface APIButtonComponentBase<Style extends ButtonStyle> extends APIBaseComponent<ComponentType.Button> {
 	/**
 	 * The label to be displayed on the button
 	 */

--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -1188,7 +1188,7 @@ export interface APIActionRowComponent<T extends APIActionRowComponentTypes>
 /**
  * https://discord.com/developers/docs/interactions/message-components#buttons
  */
-interface APIButtonComponentBase<Style extends ButtonStyle> extends APIBaseComponent<ComponentType.Button> {
+export interface APIButtonComponentBase<Style extends ButtonStyle> extends APIBaseComponent<ComponentType.Button> {
 	/**
 	 * The label to be displayed on the button
 	 */

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -1188,7 +1188,7 @@ export interface APIActionRowComponent<T extends APIActionRowComponentTypes>
 /**
  * https://discord.com/developers/docs/interactions/message-components#buttons
  */
-interface APIButtonComponentBase<Style extends ButtonStyle> extends APIBaseComponent<ComponentType.Button> {
+export interface APIButtonComponentBase<Style extends ButtonStyle> extends APIBaseComponent<ComponentType.Button> {
 	/**
 	 * The label to be displayed on the button
 	 */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This exports the APIButtonComponentBase interface. This is necessary for libraries or other projects that are defining abstracted button logic that is then extended into custom id or link buttons. 

You can see a [concrete usage of this type here](https://github.com/IanMitchell/interaction-kit/pull/108/commits/1d8437b260d2be6412185b6dacbaf7c3835d7feb).