### PR TITLE
refactor(APIGuildScheduledEventBase): make `description` nullable

### DIFF
--- a/deno/payloads/v10/guildScheduledEvent.ts
+++ b/deno/payloads/v10/guildScheduledEvent.ts
@@ -26,7 +26,7 @@ interface APIGuildScheduledEventBase<Type extends GuildScheduledEventEntityType>
 	/**
 	 * The description of the scheduled event
 	 */
-	description?: string;
+	description?: string | null;
 	/**
 	 * The time the scheduled event will start
 	 */

--- a/deno/payloads/v9/guildScheduledEvent.ts
+++ b/deno/payloads/v9/guildScheduledEvent.ts
@@ -26,7 +26,7 @@ interface APIGuildScheduledEventBase<Type extends GuildScheduledEventEntityType>
 	/**
 	 * The description of the scheduled event
 	 */
-	description?: string;
+	description?: string | null;
 	/**
 	 * The time the scheduled event will start
 	 */

--- a/payloads/v10/guildScheduledEvent.ts
+++ b/payloads/v10/guildScheduledEvent.ts
@@ -26,7 +26,7 @@ interface APIGuildScheduledEventBase<Type extends GuildScheduledEventEntityType>
 	/**
 	 * The description of the scheduled event
 	 */
-	description?: string;
+	description?: string | null;
 	/**
 	 * The time the scheduled event will start
 	 */

--- a/payloads/v9/guildScheduledEvent.ts
+++ b/payloads/v9/guildScheduledEvent.ts
@@ -26,7 +26,7 @@ interface APIGuildScheduledEventBase<Type extends GuildScheduledEventEntityType>
 	/**
 	 * The description of the scheduled event
 	 */
-	description?: string;
+	description?: string | null;
 	/**
 	 * The time the scheduled event will start
 	 */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
- https://github.com/discord/discord-api-docs/pull/4608