### PR TITLE
Fix(.gitignore): Capitalization error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,4 +47,4 @@ voice/**/*.d.ts
 voice/**/*.mjs
 
 # macOS files
-.DS_store
+.DS_Store


### PR DESCRIPTION
The correct capitalization used by macOS is `.DS_Store`
`.DS_Store` is a file used exclusively by macOS for meta data and other custom attributes.[^1] While this file may be useful for macOS, it does not have any value nor usefulness in the code base. Therefore, this PR should be merged in order to properly prevent contributors using macOS from accidentally committing this file.

[^1]: https://en.wikipedia.org/wiki/.DS_Store