### PR TITLE
fix(APIGuildIntegrationType): correct name of type

### DIFF
--- a/deno/payloads/v10/guild.ts
+++ b/deno/payloads/v10/guild.ts
@@ -681,7 +681,7 @@ export interface APIGuildIntegration {
 	/**
 	 * Integration type
 	 */
-	type: APIGuildInteractionType;
+	type: APIGuildIntegrationType;
 	/**
 	 * Is this integration enabled
 	 */
@@ -760,7 +760,7 @@ export interface APIGuildIntegration {
 	application?: APIGuildIntegrationApplication;
 }
 
-export type APIGuildInteractionType = 'twitch' | 'youtube' | 'discord';
+export type APIGuildIntegrationType = 'twitch' | 'youtube' | 'discord';
 
 /**
  * https://discord.com/developers/docs/resources/guild#integration-object-integration-expire-behaviors

--- a/deno/payloads/v9/guild.ts
+++ b/deno/payloads/v9/guild.ts
@@ -681,7 +681,7 @@ export interface APIGuildIntegration {
 	/**
 	 * Integration type
 	 */
-	type: APIGuildInteractionType;
+	type: APIGuildIntegrationType;
 	/**
 	 * Is this integration enabled
 	 */
@@ -760,7 +760,7 @@ export interface APIGuildIntegration {
 	application?: APIGuildIntegrationApplication;
 }
 
-export type APIGuildInteractionType = 'twitch' | 'youtube' | 'discord';
+export type APIGuildIntegrationType = 'twitch' | 'youtube' | 'discord';
 
 /**
  * https://discord.com/developers/docs/resources/guild#integration-object-integration-expire-behaviors

--- a/payloads/v10/guild.ts
+++ b/payloads/v10/guild.ts
@@ -681,7 +681,7 @@ export interface APIGuildIntegration {
 	/**
 	 * Integration type
 	 */
-	type: APIGuildInteractionType;
+	type: APIGuildIntegrationType;
 	/**
 	 * Is this integration enabled
 	 */
@@ -760,7 +760,7 @@ export interface APIGuildIntegration {
 	application?: APIGuildIntegrationApplication;
 }
 
-export type APIGuildInteractionType = 'twitch' | 'youtube' | 'discord';
+export type APIGuildIntegrationType = 'twitch' | 'youtube' | 'discord';
 
 /**
  * https://discord.com/developers/docs/resources/guild#integration-object-integration-expire-behaviors

--- a/payloads/v9/guild.ts
+++ b/payloads/v9/guild.ts
@@ -681,7 +681,7 @@ export interface APIGuildIntegration {
 	/**
 	 * Integration type
 	 */
-	type: APIGuildInteractionType;
+	type: APIGuildIntegrationType;
 	/**
 	 * Is this integration enabled
 	 */
@@ -760,7 +760,7 @@ export interface APIGuildIntegration {
 	application?: APIGuildIntegrationApplication;
 }
 
-export type APIGuildInteractionType = 'twitch' | 'youtube' | 'discord';
+export type APIGuildIntegrationType = 'twitch' | 'youtube' | 'discord';
 
 /**
  * https://discord.com/developers/docs/resources/guild#integration-object-integration-expire-behaviors


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The type of an integration was exported as `APIGuildInteractionType`, but this is misnamed. It should be `APIGuildIntegrationType`. It's not an interaction.