### PR TITLE
feat(APIAuditLogChange): add `APIAuditLogChangeKeyImageHash`

### DIFF
--- a/deno/payloads/v10/auditLog.ts
+++ b/deno/payloads/v10/auditLog.ts
@@ -273,6 +273,7 @@ export type APIAuditLogChange =
 	| APIAuditLogChangeKeyName
 	| APIAuditLogChangeKeyDescription
 	| APIAuditLogChangeKeyIconHash
+	| APIAuditLogChangeKeyImageHash
 	| APIAuditLogChangeKeySplashHash
 	| APIAuditLogChangeKeyDiscoverySplashHash
 	| APIAuditLogChangeKeyBannerHash
@@ -353,6 +354,11 @@ export type APIAuditLogChangeKeyDescription = AuditLogChangeData<'description', 
  * Returned when a guild's icon is changed
  */
 export type APIAuditLogChangeKeyIconHash = AuditLogChangeData<'icon_hash', string>;
+
+/**
+ * Returned when a guild's scheduled event cover image changed
+ */
+export type APIAuditLogChangeKeyImageHash = AuditLogChangeData<'image_hash', string>;
 
 /**
  * Returned when a guild's splash is changed

--- a/deno/payloads/v10/auditLog.ts
+++ b/deno/payloads/v10/auditLog.ts
@@ -356,7 +356,7 @@ export type APIAuditLogChangeKeyDescription = AuditLogChangeData<'description', 
 export type APIAuditLogChangeKeyIconHash = AuditLogChangeData<'icon_hash', string>;
 
 /**
- * Returned when a guild's scheduled event cover image changed
+ * Returned when a guild's scheduled event's cover image is changed
  */
 export type APIAuditLogChangeKeyImageHash = AuditLogChangeData<'image_hash', string>;
 

--- a/deno/payloads/v9/auditLog.ts
+++ b/deno/payloads/v9/auditLog.ts
@@ -273,6 +273,7 @@ export type APIAuditLogChange =
 	| APIAuditLogChangeKeyName
 	| APIAuditLogChangeKeyDescription
 	| APIAuditLogChangeKeyIconHash
+	| APIAuditLogChangeKeyImageHash
 	| APIAuditLogChangeKeySplashHash
 	| APIAuditLogChangeKeyDiscoverySplashHash
 	| APIAuditLogChangeKeyBannerHash
@@ -353,6 +354,11 @@ export type APIAuditLogChangeKeyDescription = AuditLogChangeData<'description', 
  * Returned when a guild's icon is changed
  */
 export type APIAuditLogChangeKeyIconHash = AuditLogChangeData<'icon_hash', string>;
+
+/**
+ * Returned when a guild's scheduled event cover image changed
+ */
+export type APIAuditLogChangeKeyImageHash = AuditLogChangeData<'image_hash', string>;
 
 /**
  * Returned when a guild's splash is changed

--- a/deno/payloads/v9/auditLog.ts
+++ b/deno/payloads/v9/auditLog.ts
@@ -356,7 +356,7 @@ export type APIAuditLogChangeKeyDescription = AuditLogChangeData<'description', 
 export type APIAuditLogChangeKeyIconHash = AuditLogChangeData<'icon_hash', string>;
 
 /**
- * Returned when a guild's scheduled event cover image changed
+ * Returned when a guild's scheduled event's cover image is changed
  */
 export type APIAuditLogChangeKeyImageHash = AuditLogChangeData<'image_hash', string>;
 

--- a/payloads/v10/auditLog.ts
+++ b/payloads/v10/auditLog.ts
@@ -273,6 +273,7 @@ export type APIAuditLogChange =
 	| APIAuditLogChangeKeyName
 	| APIAuditLogChangeKeyDescription
 	| APIAuditLogChangeKeyIconHash
+	| APIAuditLogChangeKeyImageHash
 	| APIAuditLogChangeKeySplashHash
 	| APIAuditLogChangeKeyDiscoverySplashHash
 	| APIAuditLogChangeKeyBannerHash
@@ -353,6 +354,11 @@ export type APIAuditLogChangeKeyDescription = AuditLogChangeData<'description', 
  * Returned when a guild's icon is changed
  */
 export type APIAuditLogChangeKeyIconHash = AuditLogChangeData<'icon_hash', string>;
+
+/**
+ * Returned when a guild's scheduled event cover image changed
+ */
+export type APIAuditLogChangeKeyImageHash = AuditLogChangeData<'image_hash', string>;
 
 /**
  * Returned when a guild's splash is changed

--- a/payloads/v10/auditLog.ts
+++ b/payloads/v10/auditLog.ts
@@ -356,7 +356,7 @@ export type APIAuditLogChangeKeyDescription = AuditLogChangeData<'description', 
 export type APIAuditLogChangeKeyIconHash = AuditLogChangeData<'icon_hash', string>;
 
 /**
- * Returned when a guild's scheduled event cover image changed
+ * Returned when a guild's scheduled event's cover image is changed
  */
 export type APIAuditLogChangeKeyImageHash = AuditLogChangeData<'image_hash', string>;
 

--- a/payloads/v9/auditLog.ts
+++ b/payloads/v9/auditLog.ts
@@ -273,6 +273,7 @@ export type APIAuditLogChange =
 	| APIAuditLogChangeKeyName
 	| APIAuditLogChangeKeyDescription
 	| APIAuditLogChangeKeyIconHash
+	| APIAuditLogChangeKeyImageHash
 	| APIAuditLogChangeKeySplashHash
 	| APIAuditLogChangeKeyDiscoverySplashHash
 	| APIAuditLogChangeKeyBannerHash
@@ -353,6 +354,11 @@ export type APIAuditLogChangeKeyDescription = AuditLogChangeData<'description', 
  * Returned when a guild's icon is changed
  */
 export type APIAuditLogChangeKeyIconHash = AuditLogChangeData<'icon_hash', string>;
+
+/**
+ * Returned when a guild's scheduled event cover image changed
+ */
+export type APIAuditLogChangeKeyImageHash = AuditLogChangeData<'image_hash', string>;
 
 /**
  * Returned when a guild's splash is changed

--- a/payloads/v9/auditLog.ts
+++ b/payloads/v9/auditLog.ts
@@ -356,7 +356,7 @@ export type APIAuditLogChangeKeyDescription = AuditLogChangeData<'description', 
 export type APIAuditLogChangeKeyIconHash = AuditLogChangeData<'icon_hash', string>;
 
 /**
- * Returned when a guild's scheduled event cover image changed
+ * Returned when a guild's scheduled event's cover image is changed
  */
 export type APIAuditLogChangeKeyImageHash = AuditLogChangeData<'image_hash', string>;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Adds `image_hash`.

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
- https://github.com/discord/discord-api-docs/pull/4707
