### PR TITLE
fix:(localization): add missing props

### DIFF
--- a/deno/payloads/common.ts
+++ b/deno/payloads/common.ts
@@ -57,4 +57,4 @@ export const PermissionFlagsBits = {
  */
 Object.freeze(PermissionFlagsBits);
 
-export type LocalizationMap = Partial<Record<LocaleString, string>>;
+export type LocalizationMap = Partial<Record<LocaleString, string | null>>;

--- a/deno/payloads/v10/_interactions/applicationCommands.ts
+++ b/deno/payloads/v10/_interactions/applicationCommands.ts
@@ -51,6 +51,10 @@ export interface APIApplicationCommand {
 	 */
 	name_localizations?: LocalizationMap;
 	/**
+	 * The localized description
+	 */
+	name_localized?: string;
+	/**
 	 * 1-100 character description for `CHAT_INPUT` commands, empty string for `USER` and `MESSAGE` commands
 	 */
 	description: string;
@@ -58,6 +62,10 @@ export interface APIApplicationCommand {
 	 * Localization dictionary for the description field. Values follow the same restrictions as description
 	 */
 	description_localizations?: LocalizationMap;
+	/**
+	 * The localized description
+	 */
+	description_localized?: string;
 	/**
 	 * The parameters for the `CHAT_INPUT` command, max 25
 	 */

--- a/deno/payloads/v9/_interactions/applicationCommands.ts
+++ b/deno/payloads/v9/_interactions/applicationCommands.ts
@@ -51,6 +51,10 @@ export interface APIApplicationCommand {
 	 */
 	name_localizations?: LocalizationMap;
 	/**
+	 * The localized description
+	 */
+	name_localized?: string;
+	/**
 	 * 1-100 character description for `CHAT_INPUT` commands, empty string for `USER` and `MESSAGE` commands
 	 */
 	description: string;
@@ -58,6 +62,10 @@ export interface APIApplicationCommand {
 	 * Localization dictionary for the description field. Values follow the same restrictions as description
 	 */
 	description_localizations?: LocalizationMap;
+	/**
+	 * The localized description
+	 */
+	description_localized?: string;
 	/**
 	 * The parameters for the `CHAT_INPUT` command, max 25
 	 */

--- a/deno/rest/v10/interactions.ts
+++ b/deno/rest/v10/interactions.ts
@@ -27,7 +27,17 @@ export type RESTGetAPIApplicationCommandsResult = APIApplicationCommand[];
 export type RESTGetAPIApplicationCommandResult = APIApplicationCommand;
 
 type RESTPostAPIBaseApplicationCommandsJSONBody = AddUndefinedToPossiblyUndefinedPropertiesOfInterface<
-	Omit<APIApplicationCommand, 'id' | 'application_id' | 'description' | 'type' | 'version' | 'guild_id'>
+	Omit<
+		APIApplicationCommand,
+		| 'id'
+		| 'application_id'
+		| 'description'
+		| 'type'
+		| 'version'
+		| 'guild_id'
+		| 'name_localized'
+		| 'description_localized'
+	>
 >;
 
 /**

--- a/deno/rest/v9/interactions.ts
+++ b/deno/rest/v9/interactions.ts
@@ -27,7 +27,17 @@ export type RESTGetAPIApplicationCommandsResult = APIApplicationCommand[];
 export type RESTGetAPIApplicationCommandResult = APIApplicationCommand;
 
 type RESTPostAPIBaseApplicationCommandsJSONBody = AddUndefinedToPossiblyUndefinedPropertiesOfInterface<
-	Omit<APIApplicationCommand, 'id' | 'application_id' | 'description' | 'type' | 'version' | 'guild_id'>
+	Omit<
+		APIApplicationCommand,
+		| 'id'
+		| 'application_id'
+		| 'description'
+		| 'type'
+		| 'version'
+		| 'guild_id'
+		| 'name_localized'
+		| 'description_localized'
+	>
 >;
 
 /**

--- a/payloads/common.ts
+++ b/payloads/common.ts
@@ -57,4 +57,4 @@ export const PermissionFlagsBits = {
  */
 Object.freeze(PermissionFlagsBits);
 
-export type LocalizationMap = Partial<Record<LocaleString, string>>;
+export type LocalizationMap = Partial<Record<LocaleString, string | null>>;

--- a/payloads/v10/_interactions/applicationCommands.ts
+++ b/payloads/v10/_interactions/applicationCommands.ts
@@ -51,6 +51,10 @@ export interface APIApplicationCommand {
 	 */
 	name_localizations?: LocalizationMap;
 	/**
+	 * The localized description
+	 */
+	name_localized?: string;
+	/**
 	 * 1-100 character description for `CHAT_INPUT` commands, empty string for `USER` and `MESSAGE` commands
 	 */
 	description: string;
@@ -58,6 +62,10 @@ export interface APIApplicationCommand {
 	 * Localization dictionary for the description field. Values follow the same restrictions as description
 	 */
 	description_localizations?: LocalizationMap;
+	/**
+	 * The localized description
+	 */
+	description_localized?: string;
 	/**
 	 * The parameters for the `CHAT_INPUT` command, max 25
 	 */

--- a/payloads/v9/_interactions/applicationCommands.ts
+++ b/payloads/v9/_interactions/applicationCommands.ts
@@ -51,6 +51,10 @@ export interface APIApplicationCommand {
 	 */
 	name_localizations?: LocalizationMap;
 	/**
+	 * The localized description
+	 */
+	name_localized?: string;
+	/**
 	 * 1-100 character description for `CHAT_INPUT` commands, empty string for `USER` and `MESSAGE` commands
 	 */
 	description: string;
@@ -58,6 +62,10 @@ export interface APIApplicationCommand {
 	 * Localization dictionary for the description field. Values follow the same restrictions as description
 	 */
 	description_localizations?: LocalizationMap;
+	/**
+	 * The localized description
+	 */
+	description_localized?: string;
 	/**
 	 * The parameters for the `CHAT_INPUT` command, max 25
 	 */

--- a/rest/v10/interactions.ts
+++ b/rest/v10/interactions.ts
@@ -27,7 +27,17 @@ export type RESTGetAPIApplicationCommandsResult = APIApplicationCommand[];
 export type RESTGetAPIApplicationCommandResult = APIApplicationCommand;
 
 type RESTPostAPIBaseApplicationCommandsJSONBody = AddUndefinedToPossiblyUndefinedPropertiesOfInterface<
-	Omit<APIApplicationCommand, 'id' | 'application_id' | 'description' | 'type' | 'version' | 'guild_id'>
+	Omit<
+		APIApplicationCommand,
+		| 'id'
+		| 'application_id'
+		| 'description'
+		| 'type'
+		| 'version'
+		| 'guild_id'
+		| 'name_localized'
+		| 'description_localized'
+	>
 >;
 
 /**

--- a/rest/v9/interactions.ts
+++ b/rest/v9/interactions.ts
@@ -27,7 +27,17 @@ export type RESTGetAPIApplicationCommandsResult = APIApplicationCommand[];
 export type RESTGetAPIApplicationCommandResult = APIApplicationCommand;
 
 type RESTPostAPIBaseApplicationCommandsJSONBody = AddUndefinedToPossiblyUndefinedPropertiesOfInterface<
-	Omit<APIApplicationCommand, 'id' | 'application_id' | 'description' | 'type' | 'version' | 'guild_id'>
+	Omit<
+		APIApplicationCommand,
+		| 'id'
+		| 'application_id'
+		| 'description'
+		| 'type'
+		| 'version'
+		| 'guild_id'
+		| 'name_localized'
+		| 'description_localized'
+	>
 >;
 
 /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Adds missing props `name_localized` and `description_localized` which can be returned on specific endpoints. 

Also fixed the `LocalizationMap` type to allow null values for localization entries.

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
