### PR TITLE
docs(APIGuild): any guild can have `description`

### DIFF
--- a/deno/payloads/v10/guild.ts
+++ b/deno/payloads/v10/guild.ts
@@ -54,7 +54,7 @@ export interface APIPartialGuild extends Omit<APIUnavailableGuild, 'unavailable'
 	 */
 	banner?: string | null;
 	/**
-	 * The description for the guild, if the guild is discoverable
+	 * The description for the guild
 	 */
 	description?: string | null;
 	/**
@@ -267,7 +267,7 @@ export interface APIGuild extends APIPartialGuild {
 	 */
 	vanity_url_code: string | null;
 	/**
-	 * The description for the guild, if the guild is discoverable
+	 * The description for the guild
 	 */
 	description: string | null;
 	/**

--- a/deno/payloads/v9/guild.ts
+++ b/deno/payloads/v9/guild.ts
@@ -54,7 +54,7 @@ export interface APIPartialGuild extends Omit<APIUnavailableGuild, 'unavailable'
 	 */
 	banner?: string | null;
 	/**
-	 * The description for the guild, if the guild is discoverable
+	 * The description for the guild
 	 */
 	description?: string | null;
 	/**
@@ -267,7 +267,7 @@ export interface APIGuild extends APIPartialGuild {
 	 */
 	vanity_url_code: string | null;
 	/**
-	 * The description for the guild, if the guild is discoverable
+	 * The description for the guild
 	 */
 	description: string | null;
 	/**

--- a/deno/rest/v10/guild.ts
+++ b/deno/rest/v10/guild.ts
@@ -264,7 +264,7 @@ export type RESTPatchAPIGuildJSONBody = AddUndefinedToPossiblyUndefinedPropertie
 	 */
 	features?: GuildFeature[];
 	/**
-	 * The description for the guild, if the guild is discoverable
+	 * The description for the guild
 	 */
 	description?: string | null;
 	/**

--- a/deno/rest/v9/guild.ts
+++ b/deno/rest/v9/guild.ts
@@ -264,7 +264,7 @@ export type RESTPatchAPIGuildJSONBody = AddUndefinedToPossiblyUndefinedPropertie
 	 */
 	features?: GuildFeature[];
 	/**
-	 * The description for the guild, if the guild is discoverable
+	 * The description for the guild
 	 */
 	description?: string | null;
 	/**

--- a/payloads/v10/guild.ts
+++ b/payloads/v10/guild.ts
@@ -54,7 +54,7 @@ export interface APIPartialGuild extends Omit<APIUnavailableGuild, 'unavailable'
 	 */
 	banner?: string | null;
 	/**
-	 * The description for the guild, if the guild is discoverable
+	 * The description for the guild
 	 */
 	description?: string | null;
 	/**
@@ -267,7 +267,7 @@ export interface APIGuild extends APIPartialGuild {
 	 */
 	vanity_url_code: string | null;
 	/**
-	 * The description for the guild, if the guild is discoverable
+	 * The description for the guild
 	 */
 	description: string | null;
 	/**

--- a/payloads/v9/guild.ts
+++ b/payloads/v9/guild.ts
@@ -54,7 +54,7 @@ export interface APIPartialGuild extends Omit<APIUnavailableGuild, 'unavailable'
 	 */
 	banner?: string | null;
 	/**
-	 * The description for the guild, if the guild is discoverable
+	 * The description for the guild
 	 */
 	description?: string | null;
 	/**
@@ -267,7 +267,7 @@ export interface APIGuild extends APIPartialGuild {
 	 */
 	vanity_url_code: string | null;
 	/**
-	 * The description for the guild, if the guild is discoverable
+	 * The description for the guild
 	 */
 	description: string | null;
 	/**

--- a/rest/v10/guild.ts
+++ b/rest/v10/guild.ts
@@ -264,7 +264,7 @@ export type RESTPatchAPIGuildJSONBody = AddUndefinedToPossiblyUndefinedPropertie
 	 */
 	features?: GuildFeature[];
 	/**
-	 * The description for the guild, if the guild is discoverable
+	 * The description for the guild
 	 */
 	description?: string | null;
 	/**

--- a/rest/v9/guild.ts
+++ b/rest/v9/guild.ts
@@ -264,7 +264,7 @@ export type RESTPatchAPIGuildJSONBody = AddUndefinedToPossiblyUndefinedPropertie
 	 */
 	features?: GuildFeature[];
 	/**
-	 * The description for the guild, if the guild is discoverable
+	 * The description for the guild
 	 */
 	description?: string | null;
 	/**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
- https://github.com/discord/discord-api-docs/pull/3469
