### PR TITLE
docs(FormattingPatterns): mark `UserWithNickname` and `UserWithOptionalNickname` as deprecated

### DIFF
--- a/deno/globals.ts
+++ b/deno/globals.ts
@@ -20,6 +20,20 @@ export const FormattingPatterns = {
 	 */
 	User: /<@(?<id>\d{17,20})>/,
 	/**
+	 * Regular expression for matching a user mention, strictly with a nickname
+	 *
+	 * The `id` group property is present on the `exec` result of this expression
+	 * @deprecated `!` is no longer supported in mentions
+	 */
+	UserWithNickname: /<@!(?<id>\d{17,20})>/,
+	/**
+	 * Regular expression for matching a user mention, with or without a nickname
+	 *
+	 * The `id` group property is present on the `exec` result of this expression
+	 * @deprecated `!` is no longer supported in mentions
+	 */
+	UserWithOptionalNickname: /<@!?(?<id>\d{17,20})>/,
+	/**
 	 * Regular expression for matching a channel mention
 	 *
 	 * The `id` group property is present on the `exec` result of this expression

--- a/deno/globals.ts
+++ b/deno/globals.ts
@@ -20,12 +20,6 @@ export const FormattingPatterns = {
 	 */
 	User: /<@(?<id>\d{17,20})>/,
 	/**
-	 * Regular expression for matching a user mention, strictly with a nickname
-	 *
-	 * The `id` group property is present on the `exec` result of this expression
-	 */
-	UserWithNickname: /<@!(?<id>\d{17,20})>/,
-	/**
 	 * Regular expression for matching a user mention, with or without a nickname
 	 *
 	 * The `id` group property is present on the `exec` result of this expression

--- a/deno/globals.ts
+++ b/deno/globals.ts
@@ -20,12 +20,6 @@ export const FormattingPatterns = {
 	 */
 	User: /<@(?<id>\d{17,20})>/,
 	/**
-	 * Regular expression for matching a user mention, with or without a nickname
-	 *
-	 * The `id` group property is present on the `exec` result of this expression
-	 */
-	UserWithOptionalNickname: /<@!?(?<id>\d{17,20})>/,
-	/**
 	 * Regular expression for matching a channel mention
 	 *
 	 * The `id` group property is present on the `exec` result of this expression

--- a/deno/globals.ts
+++ b/deno/globals.ts
@@ -23,14 +23,14 @@ export const FormattingPatterns = {
 	 * Regular expression for matching a user mention, strictly with a nickname
 	 *
 	 * The `id` group property is present on the `exec` result of this expression
-	 * @deprecated `!` is no longer supported in mentions
+	 * @deprecated Passing `!` in user mentions is no longer necessary / supported, and future message contents won't have it
 	 */
 	UserWithNickname: /<@!(?<id>\d{17,20})>/,
 	/**
 	 * Regular expression for matching a user mention, with or without a nickname
 	 *
 	 * The `id` group property is present on the `exec` result of this expression
-	 * @deprecated `!` is no longer supported in mentions
+	 * @deprecated Passing `!` in user mentions is no longer necessary / supported, and future message contents won't have it
 	 */
 	UserWithOptionalNickname: /<@!?(?<id>\d{17,20})>/,
 	/**

--- a/globals.ts
+++ b/globals.ts
@@ -20,6 +20,20 @@ export const FormattingPatterns = {
 	 */
 	User: /<@(?<id>\d{17,20})>/,
 	/**
+	 * Regular expression for matching a user mention, strictly with a nickname
+	 *
+	 * The `id` group property is present on the `exec` result of this expression
+	 * @deprecated `!` is no longer supported in mentions
+	 */
+	UserWithNickname: /<@!(?<id>\d{17,20})>/,
+	/**
+	 * Regular expression for matching a user mention, with or without a nickname
+	 *
+	 * The `id` group property is present on the `exec` result of this expression
+	 * @deprecated `!` is no longer supported in mentions
+	 */
+	UserWithOptionalNickname: /<@!?(?<id>\d{17,20})>/,
+	/**
 	 * Regular expression for matching a channel mention
 	 *
 	 * The `id` group property is present on the `exec` result of this expression

--- a/globals.ts
+++ b/globals.ts
@@ -20,12 +20,6 @@ export const FormattingPatterns = {
 	 */
 	User: /<@(?<id>\d{17,20})>/,
 	/**
-	 * Regular expression for matching a user mention, strictly with a nickname
-	 *
-	 * The `id` group property is present on the `exec` result of this expression
-	 */
-	UserWithNickname: /<@!(?<id>\d{17,20})>/,
-	/**
 	 * Regular expression for matching a user mention, with or without a nickname
 	 *
 	 * The `id` group property is present on the `exec` result of this expression

--- a/globals.ts
+++ b/globals.ts
@@ -20,12 +20,6 @@ export const FormattingPatterns = {
 	 */
 	User: /<@(?<id>\d{17,20})>/,
 	/**
-	 * Regular expression for matching a user mention, with or without a nickname
-	 *
-	 * The `id` group property is present on the `exec` result of this expression
-	 */
-	UserWithOptionalNickname: /<@!?(?<id>\d{17,20})>/,
-	/**
 	 * Regular expression for matching a channel mention
 	 *
 	 * The `id` group property is present on the `exec` result of this expression

--- a/globals.ts
+++ b/globals.ts
@@ -23,14 +23,14 @@ export const FormattingPatterns = {
 	 * Regular expression for matching a user mention, strictly with a nickname
 	 *
 	 * The `id` group property is present on the `exec` result of this expression
-	 * @deprecated `!` is no longer supported in mentions
+	 * @deprecated Passing `!` in user mentions is no longer necessary / supported, and future message contents won't have it
 	 */
 	UserWithNickname: /<@!(?<id>\d{17,20})>/,
 	/**
 	 * Regular expression for matching a user mention, with or without a nickname
 	 *
 	 * The `id` group property is present on the `exec` result of this expression
-	 * @deprecated `!` is no longer supported in mentions
+	 * @deprecated Passing `!` in user mentions is no longer necessary / supported, and future message contents won't have it
 	 */
 	UserWithOptionalNickname: /<@!?(?<id>\d{17,20})>/,
 	/**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Marks `UserWithNickname` and `UserWithOptionalNickname` as deprecated.

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
- https://github.com/discord/discord-api-docs/commit/a8f7638e79391bb70e15996d1d88488a3b6364b2
- https://github.com/discord/discord-api-docs/commit/e3921e168aa167503ae193439abe70106b58d914