### PR TITLE
refactor(APIApplication): mark `flags` as optional

### DIFF
--- a/deno/payloads/v10/application.ts
+++ b/deno/payloads/v10/application.ts
@@ -86,7 +86,7 @@ export interface APIApplication {
 	 *
 	 * See https://discord.com/developers/docs/resources/application#application-object-application-flags
 	 */
-	flags: ApplicationFlags;
+	flags?: ApplicationFlags;
 	/**
 	 * Up to 5 tags describing the content and functionality of the application
 	 */

--- a/deno/payloads/v9/application.ts
+++ b/deno/payloads/v9/application.ts
@@ -86,7 +86,7 @@ export interface APIApplication {
 	 *
 	 * See https://discord.com/developers/docs/resources/application#application-object-application-flags
 	 */
-	flags: ApplicationFlags;
+	flags?: ApplicationFlags;
 	/**
 	 * Up to 5 tags describing the content and functionality of the application
 	 */

--- a/payloads/v10/application.ts
+++ b/payloads/v10/application.ts
@@ -86,7 +86,7 @@ export interface APIApplication {
 	 *
 	 * See https://discord.com/developers/docs/resources/application#application-object-application-flags
 	 */
-	flags: ApplicationFlags;
+	flags?: ApplicationFlags;
 	/**
 	 * Up to 5 tags describing the content and functionality of the application
 	 */

--- a/payloads/v9/application.ts
+++ b/payloads/v9/application.ts
@@ -86,7 +86,7 @@ export interface APIApplication {
 	 *
 	 * See https://discord.com/developers/docs/resources/application#application-object-application-flags
 	 */
-	flags: ApplicationFlags;
+	flags?: ApplicationFlags;
 	/**
 	 * Up to 5 tags describing the content and functionality of the application
 	 */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Makes `flags` in `APIApplication` as optional.

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
- https://github.com/discord/discord-api-docs/pull/3100
