### PR TITLE
feat(RESTPostAPIGuildChannelJSONBody): add `default_auto_archive_duration` prop

### DIFF
--- a/deno/rest/v10/guild.ts
+++ b/deno/rest/v10/guild.ts
@@ -26,10 +26,11 @@ import type {
 } from '../../payloads/v10/mod.ts';
 import type {
 	AddUndefinedToPossiblyUndefinedPropertiesOfInterface,
+	DistributiveOmit,
+	DistributivePick,
 	Nullable,
 	StrictPartial,
 	StrictRequired,
-	UnionToIntersection,
 } from '../../utils/internals.ts';
 
 export interface APIGuildCreateOverwrite extends RESTPutAPIChannelPermissionJSONBody {
@@ -38,9 +39,9 @@ export interface APIGuildCreateOverwrite extends RESTPutAPIChannelPermissionJSON
 
 export type APIGuildChannelResolvable = Exclude<APIChannel, APIDMChannel | APIGroupDMChannel>;
 export type APIGuildCreatePartialChannel = StrictPartial<
-	Pick<
-		UnionToIntersection<APIGuildChannelResolvable>,
-		'type' | 'topic' | 'nsfw' | 'bitrate' | 'user_limit' | 'rate_limit_per_user'
+	DistributivePick<
+		APIGuildChannelResolvable,
+		'type' | 'topic' | 'nsfw' | 'bitrate' | 'user_limit' | 'rate_limit_per_user' | 'default_auto_archive_duration'
 	>
 > &
 	AddUndefinedToPossiblyUndefinedPropertiesOfInterface<{
@@ -291,7 +292,7 @@ export type RESTGetAPIGuildChannelsResult = APIChannel[];
 /**
  * https://discord.com/developers/docs/resources/guild#create-guild-channel
  */
-export type RESTPostAPIGuildChannelJSONBody = Omit<APIGuildCreatePartialChannel, 'id'>;
+export type RESTPostAPIGuildChannelJSONBody = DistributiveOmit<APIGuildCreatePartialChannel, 'id'>;
 
 /**
  * https://discord.com/developers/docs/resources/guild#create-guild-channel

--- a/deno/rest/v9/guild.ts
+++ b/deno/rest/v9/guild.ts
@@ -26,10 +26,11 @@ import type {
 } from '../../payloads/v9/mod.ts';
 import type {
 	AddUndefinedToPossiblyUndefinedPropertiesOfInterface,
+	DistributiveOmit,
+	DistributivePick,
 	Nullable,
 	StrictPartial,
 	StrictRequired,
-	UnionToIntersection,
 } from '../../utils/internals.ts';
 
 export interface APIGuildCreateOverwrite extends RESTPutAPIChannelPermissionJSONBody {
@@ -38,9 +39,9 @@ export interface APIGuildCreateOverwrite extends RESTPutAPIChannelPermissionJSON
 
 export type APIGuildChannelResolvable = Exclude<APIChannel, APIDMChannel | APIGroupDMChannel>;
 export type APIGuildCreatePartialChannel = StrictPartial<
-	Pick<
-		UnionToIntersection<APIGuildChannelResolvable>,
-		'type' | 'topic' | 'nsfw' | 'bitrate' | 'user_limit' | 'rate_limit_per_user'
+	DistributivePick<
+		APIGuildChannelResolvable,
+		'type' | 'topic' | 'nsfw' | 'bitrate' | 'user_limit' | 'rate_limit_per_user' | 'default_auto_archive_duration'
 	>
 > &
 	AddUndefinedToPossiblyUndefinedPropertiesOfInterface<{
@@ -291,7 +292,7 @@ export type RESTGetAPIGuildChannelsResult = APIChannel[];
 /**
  * https://discord.com/developers/docs/resources/guild#create-guild-channel
  */
-export type RESTPostAPIGuildChannelJSONBody = Omit<APIGuildCreatePartialChannel, 'id'>;
+export type RESTPostAPIGuildChannelJSONBody = DistributiveOmit<APIGuildCreatePartialChannel, 'id'>;
 
 /**
  * https://discord.com/developers/docs/resources/guild#create-guild-channel

--- a/deno/utils/internals.ts
+++ b/deno/utils/internals.ts
@@ -14,4 +14,26 @@ export type StrictPartial<Base> = AddUndefinedToPossiblyUndefinedPropertiesOfInt
 
 export type StrictRequired<Base> = Required<{ [K in keyof Base]: Exclude<Base[K], undefined> }>;
 
-export type UnionToIntersection<T> = (T extends any ? (x: T) => any : never) extends (x: infer R) => any ? R : never;
+export type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (k: infer I) => void ? I : never;
+
+type Keys<T> = keyof T;
+type DistributiveKeys<T> = T extends unknown ? Keys<T> : never;
+/**
+ * Allows picking of keys from unions that are disjoint
+ */
+export type DistributivePick<T, K extends DistributiveKeys<T>> = T extends unknown
+	? keyof Pick_<T, K> extends never
+		? never
+		: { [P in keyof Pick_<T, K>]: Pick_<T, K>[P] }
+	: never;
+
+type Pick_<T, K> = Pick<T, Extract<keyof T, K>>;
+
+/**
+ * Allows omitting of keys from unions that are disjoint
+ */
+export type DistributiveOmit<T, K extends DistributiveKeys<T>> = T extends unknown
+	? { [P in keyof Omit_<T, K>]: Omit_<T, K>[P] }
+	: never;
+
+type Omit_<T, K> = Omit<T, Extract<keyof T, K>>;

--- a/rest/v10/guild.ts
+++ b/rest/v10/guild.ts
@@ -26,10 +26,11 @@ import type {
 } from '../../payloads/v10/index';
 import type {
 	AddUndefinedToPossiblyUndefinedPropertiesOfInterface,
+	DistributiveOmit,
+	DistributivePick,
 	Nullable,
 	StrictPartial,
 	StrictRequired,
-	UnionToIntersection,
 } from '../../utils/internals';
 
 export interface APIGuildCreateOverwrite extends RESTPutAPIChannelPermissionJSONBody {
@@ -38,9 +39,9 @@ export interface APIGuildCreateOverwrite extends RESTPutAPIChannelPermissionJSON
 
 export type APIGuildChannelResolvable = Exclude<APIChannel, APIDMChannel | APIGroupDMChannel>;
 export type APIGuildCreatePartialChannel = StrictPartial<
-	Pick<
-		UnionToIntersection<APIGuildChannelResolvable>,
-		'type' | 'topic' | 'nsfw' | 'bitrate' | 'user_limit' | 'rate_limit_per_user'
+	DistributivePick<
+		APIGuildChannelResolvable,
+		'type' | 'topic' | 'nsfw' | 'bitrate' | 'user_limit' | 'rate_limit_per_user' | 'default_auto_archive_duration'
 	>
 > &
 	AddUndefinedToPossiblyUndefinedPropertiesOfInterface<{
@@ -291,7 +292,7 @@ export type RESTGetAPIGuildChannelsResult = APIChannel[];
 /**
  * https://discord.com/developers/docs/resources/guild#create-guild-channel
  */
-export type RESTPostAPIGuildChannelJSONBody = Omit<APIGuildCreatePartialChannel, 'id'>;
+export type RESTPostAPIGuildChannelJSONBody = DistributiveOmit<APIGuildCreatePartialChannel, 'id'>;
 
 /**
  * https://discord.com/developers/docs/resources/guild#create-guild-channel

--- a/rest/v9/guild.ts
+++ b/rest/v9/guild.ts
@@ -26,10 +26,11 @@ import type {
 } from '../../payloads/v9/index';
 import type {
 	AddUndefinedToPossiblyUndefinedPropertiesOfInterface,
+	DistributiveOmit,
+	DistributivePick,
 	Nullable,
 	StrictPartial,
 	StrictRequired,
-	UnionToIntersection,
 } from '../../utils/internals';
 
 export interface APIGuildCreateOverwrite extends RESTPutAPIChannelPermissionJSONBody {
@@ -38,9 +39,9 @@ export interface APIGuildCreateOverwrite extends RESTPutAPIChannelPermissionJSON
 
 export type APIGuildChannelResolvable = Exclude<APIChannel, APIDMChannel | APIGroupDMChannel>;
 export type APIGuildCreatePartialChannel = StrictPartial<
-	Pick<
-		UnionToIntersection<APIGuildChannelResolvable>,
-		'type' | 'topic' | 'nsfw' | 'bitrate' | 'user_limit' | 'rate_limit_per_user'
+	DistributivePick<
+		APIGuildChannelResolvable,
+		'type' | 'topic' | 'nsfw' | 'bitrate' | 'user_limit' | 'rate_limit_per_user' | 'default_auto_archive_duration'
 	>
 > &
 	AddUndefinedToPossiblyUndefinedPropertiesOfInterface<{
@@ -291,7 +292,7 @@ export type RESTGetAPIGuildChannelsResult = APIChannel[];
 /**
  * https://discord.com/developers/docs/resources/guild#create-guild-channel
  */
-export type RESTPostAPIGuildChannelJSONBody = Omit<APIGuildCreatePartialChannel, 'id'>;
+export type RESTPostAPIGuildChannelJSONBody = DistributiveOmit<APIGuildCreatePartialChannel, 'id'>;
 
 /**
  * https://discord.com/developers/docs/resources/guild#create-guild-channel

--- a/utils/internals.ts
+++ b/utils/internals.ts
@@ -14,4 +14,26 @@ export type StrictPartial<Base> = AddUndefinedToPossiblyUndefinedPropertiesOfInt
 
 export type StrictRequired<Base> = Required<{ [K in keyof Base]: Exclude<Base[K], undefined> }>;
 
-export type UnionToIntersection<T> = (T extends any ? (x: T) => any : never) extends (x: infer R) => any ? R : never;
+export type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (k: infer I) => void ? I : never;
+
+type Keys<T> = keyof T;
+type DistributiveKeys<T> = T extends unknown ? Keys<T> : never;
+/**
+ * Allows picking of keys from unions that are disjoint
+ */
+export type DistributivePick<T, K extends DistributiveKeys<T>> = T extends unknown
+	? keyof Pick_<T, K> extends never
+		? never
+		: { [P in keyof Pick_<T, K>]: Pick_<T, K>[P] }
+	: never;
+
+type Pick_<T, K> = Pick<T, Extract<keyof T, K>>;
+
+/**
+ * Allows omitting of keys from unions that are disjoint
+ */
+export type DistributiveOmit<T, K extends DistributiveKeys<T>> = T extends unknown
+	? { [P in keyof Omit_<T, K>]: Omit_<T, K>[P] }
+	: never;
+
+type Omit_<T, K> = Omit<T, Extract<keyof T, K>>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR also fixes a bug where `RESTPostAPIGuildChannelJSONBody` would resolve to `never` since `Pick` and `Omit` don't consider disjoint props.

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**

- https://github.com/discord/discord-api-docs/pull/4767
