### PR TITLE
fix: add `position` property to create channel options

### DIFF
--- a/deno/rest/v10/guild.ts
+++ b/deno/rest/v10/guild.ts
@@ -41,7 +41,14 @@ export type APIGuildChannelResolvable = Exclude<APIChannel, APIDMChannel | APIGr
 export type APIGuildCreatePartialChannel = StrictPartial<
 	DistributivePick<
 		APIGuildChannelResolvable,
-		'type' | 'topic' | 'nsfw' | 'bitrate' | 'user_limit' | 'rate_limit_per_user' | 'default_auto_archive_duration'
+		| 'type'
+		| 'topic'
+		| 'nsfw'
+		| 'bitrate'
+		| 'user_limit'
+		| 'rate_limit_per_user'
+		| 'default_auto_archive_duration'
+		| 'position'
 	>
 > &
 	AddUndefinedToPossiblyUndefinedPropertiesOfInterface<{

--- a/deno/rest/v9/guild.ts
+++ b/deno/rest/v9/guild.ts
@@ -41,7 +41,14 @@ export type APIGuildChannelResolvable = Exclude<APIChannel, APIDMChannel | APIGr
 export type APIGuildCreatePartialChannel = StrictPartial<
 	DistributivePick<
 		APIGuildChannelResolvable,
-		'type' | 'topic' | 'nsfw' | 'bitrate' | 'user_limit' | 'rate_limit_per_user' | 'default_auto_archive_duration'
+		| 'type'
+		| 'topic'
+		| 'nsfw'
+		| 'bitrate'
+		| 'user_limit'
+		| 'rate_limit_per_user'
+		| 'default_auto_archive_duration'
+		| 'position'
 	>
 > &
 	AddUndefinedToPossiblyUndefinedPropertiesOfInterface<{

--- a/rest/v10/guild.ts
+++ b/rest/v10/guild.ts
@@ -41,7 +41,14 @@ export type APIGuildChannelResolvable = Exclude<APIChannel, APIDMChannel | APIGr
 export type APIGuildCreatePartialChannel = StrictPartial<
 	DistributivePick<
 		APIGuildChannelResolvable,
-		'type' | 'topic' | 'nsfw' | 'bitrate' | 'user_limit' | 'rate_limit_per_user' | 'default_auto_archive_duration'
+		| 'type'
+		| 'topic'
+		| 'nsfw'
+		| 'bitrate'
+		| 'user_limit'
+		| 'rate_limit_per_user'
+		| 'default_auto_archive_duration'
+		| 'position'
 	>
 > &
 	AddUndefinedToPossiblyUndefinedPropertiesOfInterface<{

--- a/rest/v9/guild.ts
+++ b/rest/v9/guild.ts
@@ -41,7 +41,14 @@ export type APIGuildChannelResolvable = Exclude<APIChannel, APIDMChannel | APIGr
 export type APIGuildCreatePartialChannel = StrictPartial<
 	DistributivePick<
 		APIGuildChannelResolvable,
-		'type' | 'topic' | 'nsfw' | 'bitrate' | 'user_limit' | 'rate_limit_per_user' | 'default_auto_archive_duration'
+		| 'type'
+		| 'topic'
+		| 'nsfw'
+		| 'bitrate'
+		| 'user_limit'
+		| 'rate_limit_per_user'
+		| 'default_auto_archive_duration'
+		| 'position'
 	>
 > &
 	AddUndefinedToPossiblyUndefinedPropertiesOfInterface<{


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

https://discord.com/channels/222078108977594368/941291502372552735/967583651535667250

This allows supplying a `position` property to the create channel options type (`RESTPostAPIGuildChannelJSONBody`).

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
https://discord.com/developers/docs/resources/guild#create-guild-channel-json-params