### PR TITLE
refactor(GuildFeature): thread archive durations are no longer boost locked

### DIFF
--- a/deno/payloads/v10/guild.ts
+++ b/deno/payloads/v10/guild.ts
@@ -537,14 +537,6 @@ export enum GuildFeature {
 	 */
 	RoleIcons = 'ROLE_ICONS',
 	/**
-	 * Guild has access to the seven day archive time for threads
-	 */
-	SevenDayThreadArchive = 'SEVEN_DAY_THREAD_ARCHIVE',
-	/**
-	 * Guild has access to the three day archive time for threads
-	 */
-	ThreeDayThreadArchive = 'THREE_DAY_THREAD_ARCHIVE',
-	/**
 	 * Guild has enabled ticketed events
 	 */
 	TicketedEventsEnabled = 'TICKETED_EVENTS_ENABLED',

--- a/deno/payloads/v9/guild.ts
+++ b/deno/payloads/v9/guild.ts
@@ -537,14 +537,6 @@ export enum GuildFeature {
 	 */
 	RoleIcons = 'ROLE_ICONS',
 	/**
-	 * Guild has access to the seven day archive time for threads
-	 */
-	SevenDayThreadArchive = 'SEVEN_DAY_THREAD_ARCHIVE',
-	/**
-	 * Guild has access to the three day archive time for threads
-	 */
-	ThreeDayThreadArchive = 'THREE_DAY_THREAD_ARCHIVE',
-	/**
 	 * Guild has enabled ticketed events
 	 */
 	TicketedEventsEnabled = 'TICKETED_EVENTS_ENABLED',

--- a/payloads/v10/guild.ts
+++ b/payloads/v10/guild.ts
@@ -537,14 +537,6 @@ export enum GuildFeature {
 	 */
 	RoleIcons = 'ROLE_ICONS',
 	/**
-	 * Guild has access to the seven day archive time for threads
-	 */
-	SevenDayThreadArchive = 'SEVEN_DAY_THREAD_ARCHIVE',
-	/**
-	 * Guild has access to the three day archive time for threads
-	 */
-	ThreeDayThreadArchive = 'THREE_DAY_THREAD_ARCHIVE',
-	/**
 	 * Guild has enabled ticketed events
 	 */
 	TicketedEventsEnabled = 'TICKETED_EVENTS_ENABLED',

--- a/payloads/v9/guild.ts
+++ b/payloads/v9/guild.ts
@@ -537,14 +537,6 @@ export enum GuildFeature {
 	 */
 	RoleIcons = 'ROLE_ICONS',
 	/**
-	 * Guild has access to the seven day archive time for threads
-	 */
-	SevenDayThreadArchive = 'SEVEN_DAY_THREAD_ARCHIVE',
-	/**
-	 * Guild has access to the three day archive time for threads
-	 */
-	ThreeDayThreadArchive = 'THREE_DAY_THREAD_ARCHIVE',
-	/**
 	 * Guild has enabled ticketed events
 	 */
 	TicketedEventsEnabled = 'TICKETED_EVENTS_ENABLED',


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
- https://github.com/discord/discord-api-docs/pull/4825
