### PR TITLE
fix(OAuth2Scopes): update ApplicationsCommandsUpdate

### DIFF
--- a/deno/payloads/v10/oauth2.ts
+++ b/deno/payloads/v10/oauth2.ts
@@ -110,5 +110,5 @@ export enum OAuth2Scopes {
 	 *
 	 * See https://discord.com/developers/docs/interactions/application-commands
 	 */
-	ApplicationsCommandsUpdate = 'applications.commands.update',
+	ApplicationsCommandsUpdate = 'applications.commands.permissions.update',
 }

--- a/payloads/v10/oauth2.ts
+++ b/payloads/v10/oauth2.ts
@@ -110,5 +110,5 @@ export enum OAuth2Scopes {
 	 *
 	 * See https://discord.com/developers/docs/interactions/application-commands
 	 */
-	ApplicationsCommandsUpdate = 'applications.commands.update',
+	ApplicationsCommandsUpdate = 'applications.commands.permissions.update',
 }


### PR DESCRIPTION
The OAuth2 scope that allows an integration to update it's command permissions recently changed from `applications.commands.update` to `applications.commands.permissions.update` : https://discord.com/developers/docs/topics/oauth2#shared-resources-oauth2-scopes