### PR TITLE
refactor: separate `GUILD_CREATE` fields from `APIGuild` object

### DIFF
--- a/deno/gateway/v10.ts
+++ b/deno/gateway/v10.ts
@@ -509,10 +509,20 @@ export type GatewayGuildModifyDispatch = DataPayload<
 >;
 
 /**
- * https://discord.com/developers/docs/topics/gateway#guild-create
  * https://discord.com/developers/docs/topics/gateway#guild-update
  */
-export type GatewayGuildModifyDispatchData = APIGuild & {
+export type GatewayGuildModifyDispatchData = APIGuild;
+
+/**
+ * https://discord.com/developers/docs/topics/gateway#guild-create
+ */
+export type GatewayGuildCreateDispatch = GatewayGuildModifyDispatch;
+
+/**
+ * https://discord.com/developers/docs/topics/gateway#guild-create
+ * https://discord.com/developers/docs/topics/gateway#guild-create-guild-create-extra-fields
+ */
+export type GatewayGuildCreateDispatchData = APIGuild & {
 	/**
 	 * When this guild was joined at
 	 *
@@ -588,16 +598,6 @@ export type GatewayGuildModifyDispatchData = APIGuild & {
 	 */
 	guild_scheduled_events: APIGuildScheduledEvent[];
 };
-
-/**
- * https://discord.com/developers/docs/topics/gateway#guild-create
- */
-export type GatewayGuildCreateDispatch = GatewayGuildModifyDispatch;
-
-/**
- * https://discord.com/developers/docs/topics/gateway#guild-create
- */
-export type GatewayGuildCreateDispatchData = GatewayGuildModifyDispatchData;
 
 /**
  * https://discord.com/developers/docs/topics/gateway#guild-update

--- a/deno/gateway/v10.ts
+++ b/deno/gateway/v10.ts
@@ -512,22 +512,7 @@ export type GatewayGuildModifyDispatch = DataPayload<
  * https://discord.com/developers/docs/topics/gateway#guild-create
  * https://discord.com/developers/docs/topics/gateway#guild-update
  */
-export type GatewayGuildModifyDispatchData = APIGuild;
-
-/**
- * https://discord.com/developers/docs/topics/gateway#guild-create
- */
-export type GatewayGuildCreateDispatch = GatewayGuildModifyDispatch;
-
-/**
- * https://discord.com/developers/docs/topics/gateway#guild-create
- */
-export type GatewayGuildCreateDispatchData = GatewayGuildModifyDispatchData;
-
-/**
- * https://discord.com/developers/docs/topics/gateway#guild-create-extra-fields
- */
-export type GatewayGuildCreateExtraFields = APIGuild & {
+export type GatewayGuildModifyDispatchData = APIGuild & {
 	/**
 	 * When this guild was joined at
 	 *
@@ -603,6 +588,16 @@ export type GatewayGuildCreateExtraFields = APIGuild & {
 	 */
 	guild_scheduled_events: APIGuildScheduledEvent[];
 };
+
+/**
+ * https://discord.com/developers/docs/topics/gateway#guild-create
+ */
+export type GatewayGuildCreateDispatch = GatewayGuildModifyDispatch;
+
+/**
+ * https://discord.com/developers/docs/topics/gateway#guild-create
+ */
+export type GatewayGuildCreateDispatchData = GatewayGuildModifyDispatchData;
 
 /**
  * https://discord.com/developers/docs/topics/gateway#guild-update

--- a/deno/gateway/v10.ts
+++ b/deno/gateway/v10.ts
@@ -3,6 +3,7 @@
  */
 
 import type { Snowflake } from '../globals.ts';
+import type { GatewayPresenceUpdate } from '../payloads/v10/gateway.ts';
 import type {
 	APIApplication,
 	APIChannel,
@@ -522,6 +523,86 @@ export type GatewayGuildCreateDispatch = GatewayGuildModifyDispatch;
  * https://discord.com/developers/docs/topics/gateway#guild-create
  */
 export type GatewayGuildCreateDispatchData = GatewayGuildModifyDispatchData;
+
+/**
+ * https://discord.com/developers/docs/topics/gateway#guild-create-extra-fields
+ */
+export type GatewayGuildCreateExtraFields = APIGuild & {
+	/**
+	 * When this guild was joined at
+	 *
+	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
+	 */
+	joined_at: string;
+	/**
+	 * `true` if this is considered a large guild
+	 *
+	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
+	 */
+	large: boolean;
+	/**
+	 * Total number of members in this guild
+	 *
+	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
+	 */
+	member_count: number;
+	/**
+	 * States of members currently in voice channels; lacks the `guild_id` key
+	 *
+	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
+	 *
+	 * See https://discord.com/developers/docs/resources/voice#voice-state-object
+	 */
+	voice_states: Omit<GatewayVoiceState, 'guild_id'>[];
+	/**
+	 * Users in the guild
+	 *
+	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
+	 *
+	 * See https://discord.com/developers/docs/resources/guild#guild-member-object
+	 */
+	members: APIGuildMember[];
+	/**
+	 * Channels in the guild
+	 *
+	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
+	 *
+	 * See https://discord.com/developers/docs/resources/channel#channel-object
+	 */
+	channels: APIChannel[];
+	/**
+	 * Threads in the guild
+	 *
+	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
+	 *
+	 * See https://discord.com/developers/docs/resources/channel#channel-object
+	 */
+	threads: APIChannel[];
+	/**
+	 * Presences of the members in the guild, will only include non-offline members if the size is greater than `large_threshold`
+	 *
+	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
+	 *
+	 * See https://discord.com/developers/docs/topics/gateway#presence-update
+	 */
+	presences: GatewayPresenceUpdate[];
+	/**
+	 * The stage instances in the guild
+	 *
+	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
+	 *
+	 * See https://discord.com/developers/docs/resources/stage-instance#stage-instance-object-stage-instance-structure
+	 */
+	stage_instances: APIStageInstance[];
+	/**
+	 * The scheduled events in the guild
+	 *
+	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
+	 *
+	 * https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object
+	 */
+	guild_scheduled_events: APIGuildScheduledEvent[];
+};
 
 /**
  * https://discord.com/developers/docs/topics/gateway#guild-update

--- a/deno/gateway/v9.ts
+++ b/deno/gateway/v9.ts
@@ -511,22 +511,7 @@ export type GatewayGuildModifyDispatch = DataPayload<
  * https://discord.com/developers/docs/topics/gateway#guild-create
  * https://discord.com/developers/docs/topics/gateway#guild-update
  */
-export type GatewayGuildModifyDispatchData = APIGuild;
-
-/**
- * https://discord.com/developers/docs/topics/gateway#guild-create
- */
-export type GatewayGuildCreateDispatch = GatewayGuildModifyDispatch;
-
-/**
- * https://discord.com/developers/docs/topics/gateway#guild-create
- */
-export type GatewayGuildCreateDispatchData = GatewayGuildModifyDispatchData;
-
-/**
- * https://discord.com/developers/docs/topics/gateway#guild-create-extra-fields
- */
-export type GatewayGuildCreateExtraFields = APIGuild & {
+export type GatewayGuildModifyDispatchData = APIGuild & {
 	/**
 	 * When this guild was joined at
 	 *
@@ -602,6 +587,16 @@ export type GatewayGuildCreateExtraFields = APIGuild & {
 	 */
 	guild_scheduled_events: APIGuildScheduledEvent[];
 };
+
+/**
+ * https://discord.com/developers/docs/topics/gateway#guild-create
+ */
+export type GatewayGuildCreateDispatch = GatewayGuildModifyDispatch;
+
+/**
+ * https://discord.com/developers/docs/topics/gateway#guild-create
+ */
+export type GatewayGuildCreateDispatchData = GatewayGuildModifyDispatchData;
 
 /**
  * https://discord.com/developers/docs/topics/gateway#guild-update

--- a/deno/gateway/v9.ts
+++ b/deno/gateway/v9.ts
@@ -3,6 +3,7 @@
  */
 
 import type { Snowflake } from '../globals.ts';
+import type { GatewayPresenceUpdate } from '../payloads/v9/gateway.ts';
 import type {
 	APIApplication,
 	APIChannel,
@@ -521,6 +522,86 @@ export type GatewayGuildCreateDispatch = GatewayGuildModifyDispatch;
  * https://discord.com/developers/docs/topics/gateway#guild-create
  */
 export type GatewayGuildCreateDispatchData = GatewayGuildModifyDispatchData;
+
+/**
+ * https://discord.com/developers/docs/topics/gateway#guild-create-extra-fields
+ */
+export type GatewayGuildCreateExtraFields = APIGuild & {
+	/**
+	 * When this guild was joined at
+	 *
+	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
+	 */
+	joined_at: string;
+	/**
+	 * `true` if this is considered a large guild
+	 *
+	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
+	 */
+	large: boolean;
+	/**
+	 * Total number of members in this guild
+	 *
+	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
+	 */
+	member_count: number;
+	/**
+	 * States of members currently in voice channels; lacks the `guild_id` key
+	 *
+	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
+	 *
+	 * See https://discord.com/developers/docs/resources/voice#voice-state-object
+	 */
+	voice_states: Omit<GatewayVoiceState, 'guild_id'>[];
+	/**
+	 * Users in the guild
+	 *
+	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
+	 *
+	 * See https://discord.com/developers/docs/resources/guild#guild-member-object
+	 */
+	members: APIGuildMember[];
+	/**
+	 * Channels in the guild
+	 *
+	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
+	 *
+	 * See https://discord.com/developers/docs/resources/channel#channel-object
+	 */
+	channels: APIChannel[];
+	/**
+	 * Threads in the guild
+	 *
+	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
+	 *
+	 * See https://discord.com/developers/docs/resources/channel#channel-object
+	 */
+	threads: APIChannel[];
+	/**
+	 * Presences of the members in the guild, will only include non-offline members if the size is greater than `large_threshold`
+	 *
+	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
+	 *
+	 * See https://discord.com/developers/docs/topics/gateway#presence-update
+	 */
+	presences: GatewayPresenceUpdate[];
+	/**
+	 * The stage instances in the guild
+	 *
+	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
+	 *
+	 * See https://discord.com/developers/docs/resources/stage-instance#stage-instance-object-stage-instance-structure
+	 */
+	stage_instances: APIStageInstance[];
+	/**
+	 * The scheduled events in the guild
+	 *
+	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
+	 *
+	 * https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object
+	 */
+	guild_scheduled_events: APIGuildScheduledEvent[];
+};
 
 /**
  * https://discord.com/developers/docs/topics/gateway#guild-update

--- a/deno/gateway/v9.ts
+++ b/deno/gateway/v9.ts
@@ -508,10 +508,20 @@ export type GatewayGuildModifyDispatch = DataPayload<
 >;
 
 /**
- * https://discord.com/developers/docs/topics/gateway#guild-create
  * https://discord.com/developers/docs/topics/gateway#guild-update
  */
-export type GatewayGuildModifyDispatchData = APIGuild & {
+export type GatewayGuildModifyDispatchData = APIGuild;
+
+/**
+ * https://discord.com/developers/docs/topics/gateway#guild-create
+ */
+export type GatewayGuildCreateDispatch = GatewayGuildModifyDispatch;
+
+/**
+ * https://discord.com/developers/docs/topics/gateway#guild-create
+ * https://discord.com/developers/docs/topics/gateway#guild-create-guild-create-extra-fields
+ */
+export type GatewayGuildCreateDispatchData = APIGuild & {
 	/**
 	 * When this guild was joined at
 	 *
@@ -587,16 +597,6 @@ export type GatewayGuildModifyDispatchData = APIGuild & {
 	 */
 	guild_scheduled_events: APIGuildScheduledEvent[];
 };
-
-/**
- * https://discord.com/developers/docs/topics/gateway#guild-create
- */
-export type GatewayGuildCreateDispatch = GatewayGuildModifyDispatch;
-
-/**
- * https://discord.com/developers/docs/topics/gateway#guild-create
- */
-export type GatewayGuildCreateDispatchData = GatewayGuildModifyDispatchData;
 
 /**
  * https://discord.com/developers/docs/topics/gateway#guild-update

--- a/deno/payloads/v10/guild.ts
+++ b/deno/payloads/v10/guild.ts
@@ -2,15 +2,11 @@
  * Types extracted from https://discord.com/developers/docs/resources/guild
  */
 
-import type { APIChannel } from './channel.ts';
 import type { APIEmoji } from './emoji.ts';
-import type { GatewayPresenceUpdate, PresenceUpdateStatus } from './gateway.ts';
-import type { APIGuildScheduledEvent } from './guildScheduledEvent.ts';
+import type { PresenceUpdateStatus } from './gateway.ts';
 import type { APIRole } from './permissions.ts';
-import type { APIStageInstance } from './stageInstance.ts';
 import type { APISticker } from './sticker.ts';
 import type { APIUser } from './user.ts';
-import type { GatewayVoiceState } from './voice.ts';
 import type { Permissions, Snowflake } from '../../globals.ts';
 
 /**
@@ -197,64 +193,6 @@ export interface APIGuild extends APIPartialGuild {
 	 */
 	rules_channel_id: Snowflake | null;
 	/**
-	 * When this guild was joined at
-	 *
-	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
-	 */
-	joined_at?: string;
-	/**
-	 * `true` if this is considered a large guild
-	 *
-	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
-	 */
-	large?: boolean;
-	/**
-	 * Total number of members in this guild
-	 *
-	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
-	 */
-	member_count?: number;
-	/**
-	 * States of members currently in voice channels; lacks the `guild_id` key
-	 *
-	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
-	 *
-	 * See https://discord.com/developers/docs/resources/voice#voice-state-object
-	 */
-	voice_states?: Omit<GatewayVoiceState, 'guild_id'>[];
-	/**
-	 * Users in the guild
-	 *
-	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
-	 *
-	 * See https://discord.com/developers/docs/resources/guild#guild-member-object
-	 */
-	members?: APIGuildMember[];
-	/**
-	 * Channels in the guild
-	 *
-	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
-	 *
-	 * See https://discord.com/developers/docs/resources/channel#channel-object
-	 */
-	channels?: APIChannel[];
-	/**
-	 * Threads in the guild
-	 *
-	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
-	 *
-	 * See https://discord.com/developers/docs/resources/channel#channel-object
-	 */
-	threads?: APIChannel[];
-	/**
-	 * Presences of the members in the guild, will only include non-offline members if the size is greater than `large_threshold`
-	 *
-	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
-	 *
-	 * See https://discord.com/developers/docs/topics/gateway#presence-update
-	 */
-	presences?: GatewayPresenceUpdate[];
-	/**
 	 * The maximum number of presences for the guild (`null` is always returned, apart from the largest of guilds)
 	 */
 	max_presences?: number | null;
@@ -321,14 +259,6 @@ export interface APIGuild extends APIPartialGuild {
 	 */
 	nsfw_level: GuildNSFWLevel;
 	/**
-	 * The stage instances in the guild
-	 *
-	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
-	 *
-	 * See https://discord.com/developers/docs/resources/stage-instance#stage-instance-object-stage-instance-structure
-	 */
-	stage_instances?: APIStageInstance[];
-	/**
 	 * Custom guild stickers
 	 *
 	 * See https://discord.com/developers/docs/resources/sticker#sticker-object
@@ -338,14 +268,6 @@ export interface APIGuild extends APIPartialGuild {
 	 * Whether the guild has the boost progress bar enabled.
 	 */
 	premium_progress_bar_enabled: boolean;
-	/**
-	 * The scheduled events in the guild
-	 *
-	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
-	 *
-	 * https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object
-	 */
-	guild_scheduled_events?: APIGuildScheduledEvent[];
 	/**
 	 * The type of Student Hub the guild is
 	 */

--- a/deno/payloads/v9/guild.ts
+++ b/deno/payloads/v9/guild.ts
@@ -2,15 +2,11 @@
  * Types extracted from https://discord.com/developers/docs/resources/guild
  */
 
-import type { APIChannel } from './channel.ts';
 import type { APIEmoji } from './emoji.ts';
-import type { GatewayPresenceUpdate, PresenceUpdateStatus } from './gateway.ts';
-import type { APIGuildScheduledEvent } from './guildScheduledEvent.ts';
+import type { PresenceUpdateStatus } from './gateway.ts';
 import type { APIRole } from './permissions.ts';
-import type { APIStageInstance } from './stageInstance.ts';
 import type { APISticker } from './sticker.ts';
 import type { APIUser } from './user.ts';
-import type { GatewayVoiceState } from './voice.ts';
 import type { Permissions, Snowflake } from '../../globals.ts';
 
 /**
@@ -197,64 +193,6 @@ export interface APIGuild extends APIPartialGuild {
 	 */
 	rules_channel_id: Snowflake | null;
 	/**
-	 * When this guild was joined at
-	 *
-	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
-	 */
-	joined_at?: string;
-	/**
-	 * `true` if this is considered a large guild
-	 *
-	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
-	 */
-	large?: boolean;
-	/**
-	 * Total number of members in this guild
-	 *
-	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
-	 */
-	member_count?: number;
-	/**
-	 * States of members currently in voice channels; lacks the `guild_id` key
-	 *
-	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
-	 *
-	 * See https://discord.com/developers/docs/resources/voice#voice-state-object
-	 */
-	voice_states?: Omit<GatewayVoiceState, 'guild_id'>[];
-	/**
-	 * Users in the guild
-	 *
-	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
-	 *
-	 * See https://discord.com/developers/docs/resources/guild#guild-member-object
-	 */
-	members?: APIGuildMember[];
-	/**
-	 * Channels in the guild
-	 *
-	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
-	 *
-	 * See https://discord.com/developers/docs/resources/channel#channel-object
-	 */
-	channels?: APIChannel[];
-	/**
-	 * Threads in the guild
-	 *
-	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
-	 *
-	 * See https://discord.com/developers/docs/resources/channel#channel-object
-	 */
-	threads?: APIChannel[];
-	/**
-	 * Presences of the members in the guild, will only include non-offline members if the size is greater than `large_threshold`
-	 *
-	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
-	 *
-	 * See https://discord.com/developers/docs/topics/gateway#presence-update
-	 */
-	presences?: GatewayPresenceUpdate[];
-	/**
 	 * The maximum number of presences for the guild (`null` is always returned, apart from the largest of guilds)
 	 */
 	max_presences?: number | null;
@@ -321,14 +259,6 @@ export interface APIGuild extends APIPartialGuild {
 	 */
 	nsfw_level: GuildNSFWLevel;
 	/**
-	 * The stage instances in the guild
-	 *
-	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
-	 *
-	 * See https://discord.com/developers/docs/resources/stage-instance#stage-instance-object-stage-instance-structure
-	 */
-	stage_instances?: APIStageInstance[];
-	/**
 	 * Custom guild stickers
 	 *
 	 * See https://discord.com/developers/docs/resources/sticker#sticker-object
@@ -338,14 +268,6 @@ export interface APIGuild extends APIPartialGuild {
 	 * Whether the guild has the boost progress bar enabled.
 	 */
 	premium_progress_bar_enabled: boolean;
-	/**
-	 * The scheduled events in the guild
-	 *
-	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
-	 *
-	 * https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object
-	 */
-	guild_scheduled_events?: APIGuildScheduledEvent[];
 	/**
 	 * The type of Student Hub the guild is
 	 */

--- a/gateway/v10.ts
+++ b/gateway/v10.ts
@@ -509,10 +509,20 @@ export type GatewayGuildModifyDispatch = DataPayload<
 >;
 
 /**
- * https://discord.com/developers/docs/topics/gateway#guild-create
  * https://discord.com/developers/docs/topics/gateway#guild-update
  */
-export type GatewayGuildModifyDispatchData = APIGuild & {
+export type GatewayGuildModifyDispatchData = APIGuild;
+
+/**
+ * https://discord.com/developers/docs/topics/gateway#guild-create
+ */
+export type GatewayGuildCreateDispatch = GatewayGuildModifyDispatch;
+
+/**
+ * https://discord.com/developers/docs/topics/gateway#guild-create
+ * https://discord.com/developers/docs/topics/gateway#guild-create-guild-create-extra-fields
+ */
+export type GatewayGuildCreateDispatchData = APIGuild & {
 	/**
 	 * When this guild was joined at
 	 *
@@ -588,16 +598,6 @@ export type GatewayGuildModifyDispatchData = APIGuild & {
 	 */
 	guild_scheduled_events: APIGuildScheduledEvent[];
 };
-
-/**
- * https://discord.com/developers/docs/topics/gateway#guild-create
- */
-export type GatewayGuildCreateDispatch = GatewayGuildModifyDispatch;
-
-/**
- * https://discord.com/developers/docs/topics/gateway#guild-create
- */
-export type GatewayGuildCreateDispatchData = GatewayGuildModifyDispatchData;
 
 /**
  * https://discord.com/developers/docs/topics/gateway#guild-update

--- a/gateway/v10.ts
+++ b/gateway/v10.ts
@@ -512,22 +512,7 @@ export type GatewayGuildModifyDispatch = DataPayload<
  * https://discord.com/developers/docs/topics/gateway#guild-create
  * https://discord.com/developers/docs/topics/gateway#guild-update
  */
-export type GatewayGuildModifyDispatchData = APIGuild;
-
-/**
- * https://discord.com/developers/docs/topics/gateway#guild-create
- */
-export type GatewayGuildCreateDispatch = GatewayGuildModifyDispatch;
-
-/**
- * https://discord.com/developers/docs/topics/gateway#guild-create
- */
-export type GatewayGuildCreateDispatchData = GatewayGuildModifyDispatchData;
-
-/**
- * https://discord.com/developers/docs/topics/gateway#guild-create-extra-fields
- */
-export type GatewayGuildCreateExtraFields = APIGuild & {
+export type GatewayGuildModifyDispatchData = APIGuild & {
 	/**
 	 * When this guild was joined at
 	 *
@@ -603,6 +588,16 @@ export type GatewayGuildCreateExtraFields = APIGuild & {
 	 */
 	guild_scheduled_events: APIGuildScheduledEvent[];
 };
+
+/**
+ * https://discord.com/developers/docs/topics/gateway#guild-create
+ */
+export type GatewayGuildCreateDispatch = GatewayGuildModifyDispatch;
+
+/**
+ * https://discord.com/developers/docs/topics/gateway#guild-create
+ */
+export type GatewayGuildCreateDispatchData = GatewayGuildModifyDispatchData;
 
 /**
  * https://discord.com/developers/docs/topics/gateway#guild-update

--- a/gateway/v10.ts
+++ b/gateway/v10.ts
@@ -3,6 +3,7 @@
  */
 
 import type { Snowflake } from '../globals';
+import type { GatewayPresenceUpdate } from '../payloads/v10/gateway';
 import type {
 	APIApplication,
 	APIChannel,
@@ -522,6 +523,86 @@ export type GatewayGuildCreateDispatch = GatewayGuildModifyDispatch;
  * https://discord.com/developers/docs/topics/gateway#guild-create
  */
 export type GatewayGuildCreateDispatchData = GatewayGuildModifyDispatchData;
+
+/**
+ * https://discord.com/developers/docs/topics/gateway#guild-create-extra-fields
+ */
+export type GatewayGuildCreateExtraFields = APIGuild & {
+	/**
+	 * When this guild was joined at
+	 *
+	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
+	 */
+	joined_at: string;
+	/**
+	 * `true` if this is considered a large guild
+	 *
+	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
+	 */
+	large: boolean;
+	/**
+	 * Total number of members in this guild
+	 *
+	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
+	 */
+	member_count: number;
+	/**
+	 * States of members currently in voice channels; lacks the `guild_id` key
+	 *
+	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
+	 *
+	 * See https://discord.com/developers/docs/resources/voice#voice-state-object
+	 */
+	voice_states: Omit<GatewayVoiceState, 'guild_id'>[];
+	/**
+	 * Users in the guild
+	 *
+	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
+	 *
+	 * See https://discord.com/developers/docs/resources/guild#guild-member-object
+	 */
+	members: APIGuildMember[];
+	/**
+	 * Channels in the guild
+	 *
+	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
+	 *
+	 * See https://discord.com/developers/docs/resources/channel#channel-object
+	 */
+	channels: APIChannel[];
+	/**
+	 * Threads in the guild
+	 *
+	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
+	 *
+	 * See https://discord.com/developers/docs/resources/channel#channel-object
+	 */
+	threads: APIChannel[];
+	/**
+	 * Presences of the members in the guild, will only include non-offline members if the size is greater than `large_threshold`
+	 *
+	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
+	 *
+	 * See https://discord.com/developers/docs/topics/gateway#presence-update
+	 */
+	presences: GatewayPresenceUpdate[];
+	/**
+	 * The stage instances in the guild
+	 *
+	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
+	 *
+	 * See https://discord.com/developers/docs/resources/stage-instance#stage-instance-object-stage-instance-structure
+	 */
+	stage_instances: APIStageInstance[];
+	/**
+	 * The scheduled events in the guild
+	 *
+	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
+	 *
+	 * https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object
+	 */
+	guild_scheduled_events: APIGuildScheduledEvent[];
+};
 
 /**
  * https://discord.com/developers/docs/topics/gateway#guild-update

--- a/gateway/v9.ts
+++ b/gateway/v9.ts
@@ -3,6 +3,7 @@
  */
 
 import type { Snowflake } from '../globals';
+import type { GatewayPresenceUpdate } from '../payloads/v9/gateway';
 import type {
 	APIApplication,
 	APIChannel,
@@ -521,6 +522,86 @@ export type GatewayGuildCreateDispatch = GatewayGuildModifyDispatch;
  * https://discord.com/developers/docs/topics/gateway#guild-create
  */
 export type GatewayGuildCreateDispatchData = GatewayGuildModifyDispatchData;
+
+/**
+ * https://discord.com/developers/docs/topics/gateway#guild-create-extra-fields
+ */
+export type GatewayGuildCreateExtraFields = APIGuild & {
+	/**
+	 * When this guild was joined at
+	 *
+	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
+	 */
+	joined_at: string;
+	/**
+	 * `true` if this is considered a large guild
+	 *
+	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
+	 */
+	large: boolean;
+	/**
+	 * Total number of members in this guild
+	 *
+	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
+	 */
+	member_count: number;
+	/**
+	 * States of members currently in voice channels; lacks the `guild_id` key
+	 *
+	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
+	 *
+	 * See https://discord.com/developers/docs/resources/voice#voice-state-object
+	 */
+	voice_states: Omit<GatewayVoiceState, 'guild_id'>[];
+	/**
+	 * Users in the guild
+	 *
+	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
+	 *
+	 * See https://discord.com/developers/docs/resources/guild#guild-member-object
+	 */
+	members: APIGuildMember[];
+	/**
+	 * Channels in the guild
+	 *
+	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
+	 *
+	 * See https://discord.com/developers/docs/resources/channel#channel-object
+	 */
+	channels: APIChannel[];
+	/**
+	 * Threads in the guild
+	 *
+	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
+	 *
+	 * See https://discord.com/developers/docs/resources/channel#channel-object
+	 */
+	threads: APIChannel[];
+	/**
+	 * Presences of the members in the guild, will only include non-offline members if the size is greater than `large_threshold`
+	 *
+	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
+	 *
+	 * See https://discord.com/developers/docs/topics/gateway#presence-update
+	 */
+	presences: GatewayPresenceUpdate[];
+	/**
+	 * The stage instances in the guild
+	 *
+	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
+	 *
+	 * See https://discord.com/developers/docs/resources/stage-instance#stage-instance-object-stage-instance-structure
+	 */
+	stage_instances: APIStageInstance[];
+	/**
+	 * The scheduled events in the guild
+	 *
+	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
+	 *
+	 * https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object
+	 */
+	guild_scheduled_events: APIGuildScheduledEvent[];
+};
 
 /**
  * https://discord.com/developers/docs/topics/gateway#guild-update

--- a/gateway/v9.ts
+++ b/gateway/v9.ts
@@ -511,22 +511,7 @@ export type GatewayGuildModifyDispatch = DataPayload<
  * https://discord.com/developers/docs/topics/gateway#guild-create
  * https://discord.com/developers/docs/topics/gateway#guild-update
  */
-export type GatewayGuildModifyDispatchData = APIGuild;
-
-/**
- * https://discord.com/developers/docs/topics/gateway#guild-create
- */
-export type GatewayGuildCreateDispatch = GatewayGuildModifyDispatch;
-
-/**
- * https://discord.com/developers/docs/topics/gateway#guild-create
- */
-export type GatewayGuildCreateDispatchData = GatewayGuildModifyDispatchData;
-
-/**
- * https://discord.com/developers/docs/topics/gateway#guild-create-extra-fields
- */
-export type GatewayGuildCreateExtraFields = APIGuild & {
+export type GatewayGuildModifyDispatchData = APIGuild & {
 	/**
 	 * When this guild was joined at
 	 *
@@ -602,6 +587,16 @@ export type GatewayGuildCreateExtraFields = APIGuild & {
 	 */
 	guild_scheduled_events: APIGuildScheduledEvent[];
 };
+
+/**
+ * https://discord.com/developers/docs/topics/gateway#guild-create
+ */
+export type GatewayGuildCreateDispatch = GatewayGuildModifyDispatch;
+
+/**
+ * https://discord.com/developers/docs/topics/gateway#guild-create
+ */
+export type GatewayGuildCreateDispatchData = GatewayGuildModifyDispatchData;
 
 /**
  * https://discord.com/developers/docs/topics/gateway#guild-update

--- a/gateway/v9.ts
+++ b/gateway/v9.ts
@@ -508,10 +508,20 @@ export type GatewayGuildModifyDispatch = DataPayload<
 >;
 
 /**
- * https://discord.com/developers/docs/topics/gateway#guild-create
  * https://discord.com/developers/docs/topics/gateway#guild-update
  */
-export type GatewayGuildModifyDispatchData = APIGuild & {
+export type GatewayGuildModifyDispatchData = APIGuild;
+
+/**
+ * https://discord.com/developers/docs/topics/gateway#guild-create
+ */
+export type GatewayGuildCreateDispatch = GatewayGuildModifyDispatch;
+
+/**
+ * https://discord.com/developers/docs/topics/gateway#guild-create
+ * https://discord.com/developers/docs/topics/gateway#guild-create-guild-create-extra-fields
+ */
+export type GatewayGuildCreateDispatchData = APIGuild & {
 	/**
 	 * When this guild was joined at
 	 *
@@ -587,16 +597,6 @@ export type GatewayGuildModifyDispatchData = APIGuild & {
 	 */
 	guild_scheduled_events: APIGuildScheduledEvent[];
 };
-
-/**
- * https://discord.com/developers/docs/topics/gateway#guild-create
- */
-export type GatewayGuildCreateDispatch = GatewayGuildModifyDispatch;
-
-/**
- * https://discord.com/developers/docs/topics/gateway#guild-create
- */
-export type GatewayGuildCreateDispatchData = GatewayGuildModifyDispatchData;
 
 /**
  * https://discord.com/developers/docs/topics/gateway#guild-update

--- a/payloads/v10/guild.ts
+++ b/payloads/v10/guild.ts
@@ -2,15 +2,11 @@
  * Types extracted from https://discord.com/developers/docs/resources/guild
  */
 
-import type { APIChannel } from './channel';
 import type { APIEmoji } from './emoji';
-import type { GatewayPresenceUpdate, PresenceUpdateStatus } from './gateway';
-import type { APIGuildScheduledEvent } from './guildScheduledEvent';
+import type { PresenceUpdateStatus } from './gateway';
 import type { APIRole } from './permissions';
-import type { APIStageInstance } from './stageInstance';
 import type { APISticker } from './sticker';
 import type { APIUser } from './user';
-import type { GatewayVoiceState } from './voice';
 import type { Permissions, Snowflake } from '../../globals';
 
 /**
@@ -197,64 +193,6 @@ export interface APIGuild extends APIPartialGuild {
 	 */
 	rules_channel_id: Snowflake | null;
 	/**
-	 * When this guild was joined at
-	 *
-	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
-	 */
-	joined_at?: string;
-	/**
-	 * `true` if this is considered a large guild
-	 *
-	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
-	 */
-	large?: boolean;
-	/**
-	 * Total number of members in this guild
-	 *
-	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
-	 */
-	member_count?: number;
-	/**
-	 * States of members currently in voice channels; lacks the `guild_id` key
-	 *
-	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
-	 *
-	 * See https://discord.com/developers/docs/resources/voice#voice-state-object
-	 */
-	voice_states?: Omit<GatewayVoiceState, 'guild_id'>[];
-	/**
-	 * Users in the guild
-	 *
-	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
-	 *
-	 * See https://discord.com/developers/docs/resources/guild#guild-member-object
-	 */
-	members?: APIGuildMember[];
-	/**
-	 * Channels in the guild
-	 *
-	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
-	 *
-	 * See https://discord.com/developers/docs/resources/channel#channel-object
-	 */
-	channels?: APIChannel[];
-	/**
-	 * Threads in the guild
-	 *
-	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
-	 *
-	 * See https://discord.com/developers/docs/resources/channel#channel-object
-	 */
-	threads?: APIChannel[];
-	/**
-	 * Presences of the members in the guild, will only include non-offline members if the size is greater than `large_threshold`
-	 *
-	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
-	 *
-	 * See https://discord.com/developers/docs/topics/gateway#presence-update
-	 */
-	presences?: GatewayPresenceUpdate[];
-	/**
 	 * The maximum number of presences for the guild (`null` is always returned, apart from the largest of guilds)
 	 */
 	max_presences?: number | null;
@@ -321,14 +259,6 @@ export interface APIGuild extends APIPartialGuild {
 	 */
 	nsfw_level: GuildNSFWLevel;
 	/**
-	 * The stage instances in the guild
-	 *
-	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
-	 *
-	 * See https://discord.com/developers/docs/resources/stage-instance#stage-instance-object-stage-instance-structure
-	 */
-	stage_instances?: APIStageInstance[];
-	/**
 	 * Custom guild stickers
 	 *
 	 * See https://discord.com/developers/docs/resources/sticker#sticker-object
@@ -338,14 +268,6 @@ export interface APIGuild extends APIPartialGuild {
 	 * Whether the guild has the boost progress bar enabled.
 	 */
 	premium_progress_bar_enabled: boolean;
-	/**
-	 * The scheduled events in the guild
-	 *
-	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
-	 *
-	 * https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object
-	 */
-	guild_scheduled_events?: APIGuildScheduledEvent[];
 	/**
 	 * The type of Student Hub the guild is
 	 */

--- a/payloads/v9/guild.ts
+++ b/payloads/v9/guild.ts
@@ -2,15 +2,11 @@
  * Types extracted from https://discord.com/developers/docs/resources/guild
  */
 
-import type { APIChannel } from './channel';
 import type { APIEmoji } from './emoji';
-import type { GatewayPresenceUpdate, PresenceUpdateStatus } from './gateway';
-import type { APIGuildScheduledEvent } from './guildScheduledEvent';
+import type { PresenceUpdateStatus } from './gateway';
 import type { APIRole } from './permissions';
-import type { APIStageInstance } from './stageInstance';
 import type { APISticker } from './sticker';
 import type { APIUser } from './user';
-import type { GatewayVoiceState } from './voice';
 import type { Permissions, Snowflake } from '../../globals';
 
 /**
@@ -197,64 +193,6 @@ export interface APIGuild extends APIPartialGuild {
 	 */
 	rules_channel_id: Snowflake | null;
 	/**
-	 * When this guild was joined at
-	 *
-	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
-	 */
-	joined_at?: string;
-	/**
-	 * `true` if this is considered a large guild
-	 *
-	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
-	 */
-	large?: boolean;
-	/**
-	 * Total number of members in this guild
-	 *
-	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
-	 */
-	member_count?: number;
-	/**
-	 * States of members currently in voice channels; lacks the `guild_id` key
-	 *
-	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
-	 *
-	 * See https://discord.com/developers/docs/resources/voice#voice-state-object
-	 */
-	voice_states?: Omit<GatewayVoiceState, 'guild_id'>[];
-	/**
-	 * Users in the guild
-	 *
-	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
-	 *
-	 * See https://discord.com/developers/docs/resources/guild#guild-member-object
-	 */
-	members?: APIGuildMember[];
-	/**
-	 * Channels in the guild
-	 *
-	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
-	 *
-	 * See https://discord.com/developers/docs/resources/channel#channel-object
-	 */
-	channels?: APIChannel[];
-	/**
-	 * Threads in the guild
-	 *
-	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
-	 *
-	 * See https://discord.com/developers/docs/resources/channel#channel-object
-	 */
-	threads?: APIChannel[];
-	/**
-	 * Presences of the members in the guild, will only include non-offline members if the size is greater than `large_threshold`
-	 *
-	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
-	 *
-	 * See https://discord.com/developers/docs/topics/gateway#presence-update
-	 */
-	presences?: GatewayPresenceUpdate[];
-	/**
 	 * The maximum number of presences for the guild (`null` is always returned, apart from the largest of guilds)
 	 */
 	max_presences?: number | null;
@@ -321,14 +259,6 @@ export interface APIGuild extends APIPartialGuild {
 	 */
 	nsfw_level: GuildNSFWLevel;
 	/**
-	 * The stage instances in the guild
-	 *
-	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
-	 *
-	 * See https://discord.com/developers/docs/resources/stage-instance#stage-instance-object-stage-instance-structure
-	 */
-	stage_instances?: APIStageInstance[];
-	/**
 	 * Custom guild stickers
 	 *
 	 * See https://discord.com/developers/docs/resources/sticker#sticker-object
@@ -338,14 +268,6 @@ export interface APIGuild extends APIPartialGuild {
 	 * Whether the guild has the boost progress bar enabled.
 	 */
 	premium_progress_bar_enabled: boolean;
-	/**
-	 * The scheduled events in the guild
-	 *
-	 * **This field is only sent within the [GUILD_CREATE](https://discord.com/developers/docs/topics/gateway#guild-create) event**
-	 *
-	 * https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object
-	 */
-	guild_scheduled_events?: APIGuildScheduledEvent[];
 	/**
 	 * The type of Student Hub the guild is
 	 */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Separete `GUILD_CREATE` event fields from `APIGuild` object. Please let me know if something is wrong, it's a bit confusing to me. 

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
- https://github.com/discord/discord-api-docs/pull/4888
