### PR TITLE
feat(OAuth2Scopes): add new OAuth2 scopes

### DIFF
--- a/deno/payloads/v10/oauth2.ts
+++ b/deno/payloads/v10/oauth2.ts
@@ -15,7 +15,7 @@ export enum OAuth2Scopes {
 	 */
 	Connections = 'connections',
 	/**
-	 * Allows your app to see information about the user's DMs and group DMs
+	 * Allows your app to see information about the user's DMs and group DMs - requires Discord approval
 	 */
 	DMChannelsRead = 'dm_channels.read',
 	/**
@@ -74,7 +74,7 @@ export enum OAuth2Scopes {
 	 */
 	WebhookIncoming = 'webhook.incoming',
 	/**
-	 * Allows your app to connect to voice on user's behalf and see all the voice members
+	 * Allows your app to connect to voice on user's behalf and see all the voice members - requires Discord approval
 	 */
 	Voice = 'voice',
 	/**

--- a/deno/payloads/v10/oauth2.ts
+++ b/deno/payloads/v10/oauth2.ts
@@ -15,6 +15,10 @@ export enum OAuth2Scopes {
 	 */
 	Connections = 'connections',
 	/**
+	 * Allows your app to see information about the user's DMs and group DMs
+	 */
+	DMChannelsRead = 'dm_channels.read',
+	/**
 	 * Enables [/users/@me](https://discord.com/developers/docs/resources/user#get-current-user) to return an `email`
 	 *
 	 * See https://discord.com/developers/docs/resources/user#get-current-user
@@ -69,6 +73,10 @@ export enum OAuth2Scopes {
 	 * This generates a webhook that is returned in the oauth token response for authorization code grants
 	 */
 	WebhookIncoming = 'webhook.incoming',
+	/**
+	 * Allows your app to connect to voice on user's behalf and see all the voice members
+	 */
+	Voice = 'voice',
 	/**
 	 * Allows your app to upload/update builds for a user's applications - requires Discord approval
 	 */

--- a/deno/payloads/v9/oauth2.ts
+++ b/deno/payloads/v9/oauth2.ts
@@ -15,7 +15,7 @@ export enum OAuth2Scopes {
 	 */
 	Connections = 'connections',
 	/**
-	 * Allows your app to see information about the user's DMs and group DMs
+	 * Allows your app to see information about the user's DMs and group DMs - requires Discord approval
 	 */
 	DMChannelsRead = 'dm_channels.read',
 	/**
@@ -74,7 +74,7 @@ export enum OAuth2Scopes {
 	 */
 	WebhookIncoming = 'webhook.incoming',
 	/**
-	 * Allows your app to connect to voice on user's behalf and see all the voice members
+	 * Allows your app to connect to voice on user's behalf and see all the voice members - requires Discord approval
 	 */
 	Voice = 'voice',
 	/**

--- a/deno/payloads/v9/oauth2.ts
+++ b/deno/payloads/v9/oauth2.ts
@@ -15,6 +15,10 @@ export enum OAuth2Scopes {
 	 */
 	Connections = 'connections',
 	/**
+	 * Allows your app to see information about the user's DMs and group DMs
+	 */
+	DMChannelsRead = 'dm_channels.read',
+	/**
 	 * Enables [/users/@me](https://discord.com/developers/docs/resources/user#get-current-user) to return an `email`
 	 *
 	 * See https://discord.com/developers/docs/resources/user#get-current-user
@@ -69,6 +73,10 @@ export enum OAuth2Scopes {
 	 * This generates a webhook that is returned in the oauth token response for authorization code grants
 	 */
 	WebhookIncoming = 'webhook.incoming',
+	/**
+	 * Allows your app to connect to voice on user's behalf and see all the voice members
+	 */
+	Voice = 'voice',
 	/**
 	 * Allows your app to upload/update builds for a user's applications - requires Discord approval
 	 */

--- a/payloads/v10/oauth2.ts
+++ b/payloads/v10/oauth2.ts
@@ -15,7 +15,7 @@ export enum OAuth2Scopes {
 	 */
 	Connections = 'connections',
 	/**
-	 * Allows your app to see information about the user's DMs and group DMs
+	 * Allows your app to see information about the user's DMs and group DMs - requires Discord approval
 	 */
 	DMChannelsRead = 'dm_channels.read',
 	/**
@@ -74,7 +74,7 @@ export enum OAuth2Scopes {
 	 */
 	WebhookIncoming = 'webhook.incoming',
 	/**
-	 * Allows your app to connect to voice on user's behalf and see all the voice members
+	 * Allows your app to connect to voice on user's behalf and see all the voice members - requires Discord approval
 	 */
 	Voice = 'voice',
 	/**

--- a/payloads/v10/oauth2.ts
+++ b/payloads/v10/oauth2.ts
@@ -15,6 +15,10 @@ export enum OAuth2Scopes {
 	 */
 	Connections = 'connections',
 	/**
+	 * Allows your app to see information about the user's DMs and group DMs
+	 */
+	DMChannelsRead = 'dm_channels.read',
+	/**
 	 * Enables [/users/@me](https://discord.com/developers/docs/resources/user#get-current-user) to return an `email`
 	 *
 	 * See https://discord.com/developers/docs/resources/user#get-current-user
@@ -69,6 +73,10 @@ export enum OAuth2Scopes {
 	 * This generates a webhook that is returned in the oauth token response for authorization code grants
 	 */
 	WebhookIncoming = 'webhook.incoming',
+	/**
+	 * Allows your app to connect to voice on user's behalf and see all the voice members
+	 */
+	Voice = 'voice',
 	/**
 	 * Allows your app to upload/update builds for a user's applications - requires Discord approval
 	 */

--- a/payloads/v9/oauth2.ts
+++ b/payloads/v9/oauth2.ts
@@ -15,7 +15,7 @@ export enum OAuth2Scopes {
 	 */
 	Connections = 'connections',
 	/**
-	 * Allows your app to see information about the user's DMs and group DMs
+	 * Allows your app to see information about the user's DMs and group DMs - requires Discord approval
 	 */
 	DMChannelsRead = 'dm_channels.read',
 	/**
@@ -74,7 +74,7 @@ export enum OAuth2Scopes {
 	 */
 	WebhookIncoming = 'webhook.incoming',
 	/**
-	 * Allows your app to connect to voice on user's behalf and see all the voice members
+	 * Allows your app to connect to voice on user's behalf and see all the voice members - requires Discord approval
 	 */
 	Voice = 'voice',
 	/**

--- a/payloads/v9/oauth2.ts
+++ b/payloads/v9/oauth2.ts
@@ -15,6 +15,10 @@ export enum OAuth2Scopes {
 	 */
 	Connections = 'connections',
 	/**
+	 * Allows your app to see information about the user's DMs and group DMs
+	 */
+	DMChannelsRead = 'dm_channels.read',
+	/**
 	 * Enables [/users/@me](https://discord.com/developers/docs/resources/user#get-current-user) to return an `email`
 	 *
 	 * See https://discord.com/developers/docs/resources/user#get-current-user
@@ -69,6 +73,10 @@ export enum OAuth2Scopes {
 	 * This generates a webhook that is returned in the oauth token response for authorization code grants
 	 */
 	WebhookIncoming = 'webhook.incoming',
+	/**
+	 * Allows your app to connect to voice on user's behalf and see all the voice members
+	 */
+	Voice = 'voice',
 	/**
 	 * Allows your app to upload/update builds for a user's applications - requires Discord approval
 	 */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Adds `DMChannelsRead` and `Voice` scopes to `OAuth2Scopes`.

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
- https://github.com/discord/discord-api-docs/pull/4917
