### PR TITLE
feat(rest): add missing guild routes results

### DIFF
--- a/deno/rest/v10/guild.ts
+++ b/deno/rest/v10/guild.ts
@@ -828,6 +828,9 @@ export type RESTPatchAPIGuildMemberVerificationJSONBody = AddUndefinedToPossibly
 
 export type RESTPatchAPIGuildMemberVerificationResult = APIGuildMembershipScreening;
 
+/**
+ * https://discord.com/developers/docs/resources/guild#modify-current-user-voice-state
+ */
 export type RESTPatchAPIGuildVoiceStateCurrentMemberJSONBody = AddUndefinedToPossiblyUndefinedPropertiesOfInterface<{
 	/**
 	 * The id of the channel the user is currently in
@@ -843,6 +846,14 @@ export type RESTPatchAPIGuildVoiceStateCurrentMemberJSONBody = AddUndefinedToPos
 	request_to_speak_timestamp?: string | null;
 }>;
 
+/**
+ * https://discord.com/developers/docs/resources/guild#modify-current-user-voice-state
+ */
+export type RESTPatchAPIGuildVoiceStateCurrentMemberResult = never;
+
+/**
+ * https://discord.com/developers/docs/resources/guild#modify-user-voice-state
+ */
 export type RESTPatchAPIGuildVoiceStateUserJSONBody = AddUndefinedToPossiblyUndefinedPropertiesOfInterface<{
 	/**
 	 * The id of the channel the user is currently in
@@ -869,3 +880,8 @@ export type RESTPatchAPIGuildWelcomeScreenJSONBody = Nullable<StrictPartial<APIG
 		 */
 		enabled?: boolean | null;
 	}>;
+
+/**
+ * https://discord.com/developers/docs/resources/guild#modify-guild-welcome-screen
+ */
+export type RESTPatchAPIGuildWelcomeScreenResult = APIGuildWelcomeScreen;

--- a/deno/rest/v9/guild.ts
+++ b/deno/rest/v9/guild.ts
@@ -834,6 +834,9 @@ export type RESTPatchAPIGuildMemberVerificationJSONBody = AddUndefinedToPossibly
 
 export type RESTPatchAPIGuildMemberVerificationResult = APIGuildMembershipScreening;
 
+/**
+ * https://discord.com/developers/docs/resources/guild#modify-current-user-voice-state
+ */
 export type RESTPatchAPIGuildVoiceStateCurrentMemberJSONBody = AddUndefinedToPossiblyUndefinedPropertiesOfInterface<{
 	/**
 	 * The id of the channel the user is currently in
@@ -849,6 +852,14 @@ export type RESTPatchAPIGuildVoiceStateCurrentMemberJSONBody = AddUndefinedToPos
 	request_to_speak_timestamp?: string | null;
 }>;
 
+/**
+ * https://discord.com/developers/docs/resources/guild#modify-current-user-voice-state
+ */
+export type RESTPatchAPIGuildVoiceStateCurrentMemberResult = never;
+
+/**
+ * https://discord.com/developers/docs/resources/guild#modify-user-voice-state
+ */
 export type RESTPatchAPIGuildVoiceStateUserJSONBody = AddUndefinedToPossiblyUndefinedPropertiesOfInterface<{
 	/**
 	 * The id of the channel the user is currently in
@@ -875,3 +886,8 @@ export type RESTPatchAPIGuildWelcomeScreenJSONBody = Nullable<StrictPartial<APIG
 		 */
 		enabled?: boolean | null;
 	}>;
+
+/**
+ * https://discord.com/developers/docs/resources/guild#modify-guild-welcome-screen
+ */
+export type RESTPatchAPIGuildWelcomeScreenResult = APIGuildWelcomeScreen;

--- a/rest/v10/guild.ts
+++ b/rest/v10/guild.ts
@@ -828,6 +828,9 @@ export type RESTPatchAPIGuildMemberVerificationJSONBody = AddUndefinedToPossibly
 
 export type RESTPatchAPIGuildMemberVerificationResult = APIGuildMembershipScreening;
 
+/**
+ * https://discord.com/developers/docs/resources/guild#modify-current-user-voice-state
+ */
 export type RESTPatchAPIGuildVoiceStateCurrentMemberJSONBody = AddUndefinedToPossiblyUndefinedPropertiesOfInterface<{
 	/**
 	 * The id of the channel the user is currently in
@@ -843,6 +846,14 @@ export type RESTPatchAPIGuildVoiceStateCurrentMemberJSONBody = AddUndefinedToPos
 	request_to_speak_timestamp?: string | null;
 }>;
 
+/**
+ * https://discord.com/developers/docs/resources/guild#modify-current-user-voice-state
+ */
+export type RESTPatchAPIGuildVoiceStateCurrentMemberResult = never;
+
+/**
+ * https://discord.com/developers/docs/resources/guild#modify-user-voice-state
+ */
 export type RESTPatchAPIGuildVoiceStateUserJSONBody = AddUndefinedToPossiblyUndefinedPropertiesOfInterface<{
 	/**
 	 * The id of the channel the user is currently in
@@ -869,3 +880,8 @@ export type RESTPatchAPIGuildWelcomeScreenJSONBody = Nullable<StrictPartial<APIG
 		 */
 		enabled?: boolean | null;
 	}>;
+
+/**
+ * https://discord.com/developers/docs/resources/guild#modify-guild-welcome-screen
+ */
+export type RESTPatchAPIGuildWelcomeScreenResult = APIGuildWelcomeScreen;

--- a/rest/v9/guild.ts
+++ b/rest/v9/guild.ts
@@ -834,6 +834,9 @@ export type RESTPatchAPIGuildMemberVerificationJSONBody = AddUndefinedToPossibly
 
 export type RESTPatchAPIGuildMemberVerificationResult = APIGuildMembershipScreening;
 
+/**
+ * https://discord.com/developers/docs/resources/guild#modify-current-user-voice-state
+ */
 export type RESTPatchAPIGuildVoiceStateCurrentMemberJSONBody = AddUndefinedToPossiblyUndefinedPropertiesOfInterface<{
 	/**
 	 * The id of the channel the user is currently in
@@ -849,6 +852,14 @@ export type RESTPatchAPIGuildVoiceStateCurrentMemberJSONBody = AddUndefinedToPos
 	request_to_speak_timestamp?: string | null;
 }>;
 
+/**
+ * https://discord.com/developers/docs/resources/guild#modify-current-user-voice-state
+ */
+export type RESTPatchAPIGuildVoiceStateCurrentMemberResult = never;
+
+/**
+ * https://discord.com/developers/docs/resources/guild#modify-user-voice-state
+ */
 export type RESTPatchAPIGuildVoiceStateUserJSONBody = AddUndefinedToPossiblyUndefinedPropertiesOfInterface<{
 	/**
 	 * The id of the channel the user is currently in
@@ -875,3 +886,8 @@ export type RESTPatchAPIGuildWelcomeScreenJSONBody = Nullable<StrictPartial<APIG
 		 */
 		enabled?: boolean | null;
 	}>;
+
+/**
+ * https://discord.com/developers/docs/resources/guild#modify-guild-welcome-screen
+ */
+export type RESTPatchAPIGuildWelcomeScreenResult = APIGuildWelcomeScreen;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
It adds endpoint types that I noticed were missing from the guilds file.

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
