### PR TITLE
fix(APIApplicationCommand): `dm_permission` is not nullable and `default_member_permissions` is required

### DIFF
--- a/deno/payloads/v10/_interactions/applicationCommands.ts
+++ b/deno/payloads/v10/_interactions/applicationCommands.ts
@@ -73,11 +73,11 @@ export interface APIApplicationCommand {
 	/**
 	 * Set of permissions represented as a bitset
 	 */
-	default_member_permissions?: Permissions | null;
+	default_member_permissions: Permissions | null;
 	/**
 	 * Indicates whether the command is available in DMs with the app, only for globally-scoped commands. By default, commands are visible
 	 */
-	dm_permission?: boolean | null;
+	dm_permission?: boolean;
 	/**
 	 * Whether the command is enabled by default when the app is added to a guild
 	 *

--- a/deno/payloads/v9/_interactions/applicationCommands.ts
+++ b/deno/payloads/v9/_interactions/applicationCommands.ts
@@ -73,11 +73,11 @@ export interface APIApplicationCommand {
 	/**
 	 * Set of permissions represented as a bitset
 	 */
-	default_member_permissions?: Permissions | null;
+	default_member_permissions: Permissions | null;
 	/**
 	 * Indicates whether the command is available in DMs with the app, only for globally-scoped commands. By default, commands are visible
 	 */
-	dm_permission?: boolean | null;
+	dm_permission?: boolean;
 	/**
 	 * Whether the command is enabled by default when the app is added to a guild
 	 *

--- a/payloads/v10/_interactions/applicationCommands.ts
+++ b/payloads/v10/_interactions/applicationCommands.ts
@@ -73,11 +73,11 @@ export interface APIApplicationCommand {
 	/**
 	 * Set of permissions represented as a bitset
 	 */
-	default_member_permissions?: Permissions | null;
+	default_member_permissions: Permissions | null;
 	/**
 	 * Indicates whether the command is available in DMs with the app, only for globally-scoped commands. By default, commands are visible
 	 */
-	dm_permission?: boolean | null;
+	dm_permission?: boolean;
 	/**
 	 * Whether the command is enabled by default when the app is added to a guild
 	 *

--- a/payloads/v9/_interactions/applicationCommands.ts
+++ b/payloads/v9/_interactions/applicationCommands.ts
@@ -73,11 +73,11 @@ export interface APIApplicationCommand {
 	/**
 	 * Set of permissions represented as a bitset
 	 */
-	default_member_permissions?: Permissions | null;
+	default_member_permissions: Permissions | null;
 	/**
 	 * Indicates whether the command is available in DMs with the app, only for globally-scoped commands. By default, commands are visible
 	 */
-	dm_permission?: boolean | null;
+	dm_permission?: boolean;
 	/**
 	 * Whether the command is enabled by default when the app is added to a guild
 	 *


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
- discord/discord-api-docs#4991