### PR TITLE
fix: website link colors

### DIFF
--- a/website/src/css/custom.scss
+++ b/website/src/css/custom.scss
@@ -19,8 +19,6 @@
 	--ifm-menu-link-sublist-icon-filter: invert(100%) sepia(94%) saturate(17%) hue-rotate(223deg) brightness(104%) contrast(98%);
 	--ifm-navbar-height: 64px;
 	--ifm-navbar-link-color: #e5e7eb;
-	--ifm-link-hover-color: #e5e7eb;
-	--ifm-link-color: #e5e7eb;
 	--ifm-navbar-link-active-color: #e5e7eb;
 	--ifm-navbar-link-hover-color: #e5e7eb;
 	--ifm-font-weight-semibold: 700;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes *all* link colors accidentally being overridden instead of just navbar link colors. 😅 

Before:
<img width="500" alt="Screen Shot 2022-05-29 at 7 11 50 PM" src="https://user-images.githubusercontent.com/77477100/170895050-7a11eb15-42da-4a13-a14d-71502618d34b.png">

After:
<img width="500" alt="Screen Shot 2022-05-29 at 7 11 58 PM" src="https://user-images.githubusercontent.com/77477100/170895048-ed212c6d-0afd-4b66-858b-8a614ac5d353.png">
