### PR TITLE
fix(RestPostAPIBaseApplicationJSONBody): make `default_member_permissions` optional

### DIFF
--- a/deno/rest/v10/interactions.ts
+++ b/deno/rest/v10/interactions.ts
@@ -15,7 +15,6 @@ import type {
 	ApplicationCommandType,
 } from '../../payloads/v10/mod.ts';
 import type { AddUndefinedToPossiblyUndefinedPropertiesOfInterface, StrictPartial } from '../../utils/internals.ts';
-import type { Permissions } from '../../globals.ts';
 
 /**
  * https://discord.com/developers/docs/interactions/application-commands#get-global-application-commands
@@ -39,10 +38,9 @@ type RESTPostAPIBaseApplicationCommandsJSONBody = AddUndefinedToPossiblyUndefine
 		| 'name_localized'
 		| 'description_localized'
 		| 'default_member_permissions'
-	>
-> & {
-	defaultMemberPermissions?: Permissions | null;
-};
+	> &
+		Partial<Pick<APIApplicationCommand, 'default_member_permissions'>>
+>;
 
 /**
  * https://discord.com/developers/docs/interactions/application-commands#create-global-application-command

--- a/deno/rest/v10/interactions.ts
+++ b/deno/rest/v10/interactions.ts
@@ -15,6 +15,7 @@ import type {
 	ApplicationCommandType,
 } from '../../payloads/v10/mod.ts';
 import type { AddUndefinedToPossiblyUndefinedPropertiesOfInterface, StrictPartial } from '../../utils/internals.ts';
+import type { Permissions } from '../../globals.ts';
 
 /**
  * https://discord.com/developers/docs/interactions/application-commands#get-global-application-commands
@@ -37,8 +38,11 @@ type RESTPostAPIBaseApplicationCommandsJSONBody = AddUndefinedToPossiblyUndefine
 		| 'guild_id'
 		| 'name_localized'
 		| 'description_localized'
+		| 'default_member_permissions'
 	>
->;
+> & {
+	defaultMemberPermissions?: Permissions | null;
+};
 
 /**
  * https://discord.com/developers/docs/interactions/application-commands#create-global-application-command

--- a/deno/rest/v9/interactions.ts
+++ b/deno/rest/v9/interactions.ts
@@ -15,7 +15,6 @@ import type {
 	ApplicationCommandType,
 } from '../../payloads/v9/mod.ts';
 import type { AddUndefinedToPossiblyUndefinedPropertiesOfInterface, StrictPartial } from '../../utils/internals.ts';
-import type { Permissions } from '../../globals.ts';
 
 /**
  * https://discord.com/developers/docs/interactions/application-commands#get-global-application-commands
@@ -39,10 +38,9 @@ type RESTPostAPIBaseApplicationCommandsJSONBody = AddUndefinedToPossiblyUndefine
 		| 'name_localized'
 		| 'description_localized'
 		| 'default_member_permissions'
-	>
-> & {
-	defaultMemberPermissions?: Permissions | null;
-};
+	> &
+		Partial<Pick<APIApplicationCommand, 'default_member_permissions'>>
+>;
 
 /**
  * https://discord.com/developers/docs/interactions/application-commands#create-global-application-command

--- a/deno/rest/v9/interactions.ts
+++ b/deno/rest/v9/interactions.ts
@@ -15,6 +15,7 @@ import type {
 	ApplicationCommandType,
 } from '../../payloads/v9/mod.ts';
 import type { AddUndefinedToPossiblyUndefinedPropertiesOfInterface, StrictPartial } from '../../utils/internals.ts';
+import type { Permissions } from '../../globals.ts';
 
 /**
  * https://discord.com/developers/docs/interactions/application-commands#get-global-application-commands
@@ -37,8 +38,11 @@ type RESTPostAPIBaseApplicationCommandsJSONBody = AddUndefinedToPossiblyUndefine
 		| 'guild_id'
 		| 'name_localized'
 		| 'description_localized'
+		| 'default_member_permissions'
 	>
->;
+> & {
+	defaultMemberPermissions?: Permissions | null;
+};
 
 /**
  * https://discord.com/developers/docs/interactions/application-commands#create-global-application-command

--- a/rest/v10/interactions.ts
+++ b/rest/v10/interactions.ts
@@ -6,6 +6,7 @@ import type {
 	RESTPatchAPIWebhookWithTokenMessageResult,
 	RESTPostAPIWebhookWithTokenWaitResult,
 } from './webhook';
+import type { Permissions } from '../../globals';
 import type {
 	APIApplicationCommand,
 	APIApplicationCommandPermission,
@@ -37,8 +38,11 @@ type RESTPostAPIBaseApplicationCommandsJSONBody = AddUndefinedToPossiblyUndefine
 		| 'guild_id'
 		| 'name_localized'
 		| 'description_localized'
+		| 'default_member_permissions'
 	>
->;
+> & {
+	defaultMemberPermissions?: Permissions | null;
+};
 
 /**
  * https://discord.com/developers/docs/interactions/application-commands#create-global-application-command

--- a/rest/v10/interactions.ts
+++ b/rest/v10/interactions.ts
@@ -6,7 +6,6 @@ import type {
 	RESTPatchAPIWebhookWithTokenMessageResult,
 	RESTPostAPIWebhookWithTokenWaitResult,
 } from './webhook';
-import type { Permissions } from '../../globals';
 import type {
 	APIApplicationCommand,
 	APIApplicationCommandPermission,
@@ -39,10 +38,9 @@ type RESTPostAPIBaseApplicationCommandsJSONBody = AddUndefinedToPossiblyUndefine
 		| 'name_localized'
 		| 'description_localized'
 		| 'default_member_permissions'
-	>
-> & {
-	defaultMemberPermissions?: Permissions | null;
-};
+	> &
+		Partial<Pick<APIApplicationCommand, 'default_member_permissions'>>
+>;
 
 /**
  * https://discord.com/developers/docs/interactions/application-commands#create-global-application-command

--- a/rest/v9/interactions.ts
+++ b/rest/v9/interactions.ts
@@ -6,6 +6,7 @@ import type {
 	RESTPatchAPIWebhookWithTokenMessageResult,
 	RESTPostAPIWebhookWithTokenWaitResult,
 } from './webhook';
+import type { Permissions } from '../../globals';
 import type {
 	APIApplicationCommand,
 	APIApplicationCommandPermission,
@@ -37,8 +38,11 @@ type RESTPostAPIBaseApplicationCommandsJSONBody = AddUndefinedToPossiblyUndefine
 		| 'guild_id'
 		| 'name_localized'
 		| 'description_localized'
+		| 'default_member_permissions'
 	>
->;
+> & {
+	defaultMemberPermissions?: Permissions | null;
+};
 
 /**
  * https://discord.com/developers/docs/interactions/application-commands#create-global-application-command

--- a/rest/v9/interactions.ts
+++ b/rest/v9/interactions.ts
@@ -6,7 +6,6 @@ import type {
 	RESTPatchAPIWebhookWithTokenMessageResult,
 	RESTPostAPIWebhookWithTokenWaitResult,
 } from './webhook';
-import type { Permissions } from '../../globals';
 import type {
 	APIApplicationCommand,
 	APIApplicationCommandPermission,
@@ -39,10 +38,9 @@ type RESTPostAPIBaseApplicationCommandsJSONBody = AddUndefinedToPossiblyUndefine
 		| 'name_localized'
 		| 'description_localized'
 		| 'default_member_permissions'
-	>
-> & {
-	defaultMemberPermissions?: Permissions | null;
-};
+	> &
+		Partial<Pick<APIApplicationCommand, 'default_member_permissions'>>
+>;
 
 /**
  * https://discord.com/developers/docs/interactions/application-commands#create-global-application-command


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Makes the post json `default_member permissions` optional.
