### PR TITLE
feat(RESTPostAPIWebhookWithTokenJSONBody): add `thread_name`

### DIFF
--- a/deno/rest/v10/webhook.ts
+++ b/deno/rest/v10/webhook.ts
@@ -145,10 +145,9 @@ export type RESTPostAPIWebhookWithTokenJSONBody = AddUndefinedToPossiblyUndefine
 	 */
 	flags?: MessageFlags;
 	/**
-	 * Name of thread to create (only available if webhook is in a forum channel)
+	 * Name of thread to create
 	 *
-	 * If the webhook is in a thread channel, you must provide either `thread_id` in the query string params, or `thread_name` in the JSON/form params.
-	 * If `thread_id` is provided, the message will send in that thread. If `thread_name` is provided, a thread with that name will be created in the forum channel.
+	 * Available only if the webhook is in a forum channel and a thread is not specified in {@link RESTPostAPIWebhookWithTokenQuery.thread_id} query parameter
 	 */
 	thread_name: string;
 }>;
@@ -178,6 +177,8 @@ export interface RESTPostAPIWebhookWithTokenQuery {
 	wait?: boolean;
 	/**
 	 * Send a message to the specified thread within a webhook's channel. The thread will automatically be unarchived.
+	 *
+	 * Available only if the {@link RESTPostAPIWebhookWithTokenJSONBody.thread_name} JSON body property is not specified
 	 */
 	thread_id?: Snowflake;
 }

--- a/deno/rest/v10/webhook.ts
+++ b/deno/rest/v10/webhook.ts
@@ -144,6 +144,10 @@ export type RESTPostAPIWebhookWithTokenJSONBody = AddUndefinedToPossiblyUndefine
 	 * Message flags combined as a bitfield
 	 */
 	flags?: MessageFlags;
+	/**
+	 * Name of thread to create (only available if webhook is in a forum channel)
+	 */
+	thread_name: string;
 }>;
 
 /**

--- a/deno/rest/v10/webhook.ts
+++ b/deno/rest/v10/webhook.ts
@@ -146,6 +146,9 @@ export type RESTPostAPIWebhookWithTokenJSONBody = AddUndefinedToPossiblyUndefine
 	flags?: MessageFlags;
 	/**
 	 * Name of thread to create (only available if webhook is in a forum channel)
+	 *
+	 * If the webhook is in a thread channel, you must provide either `thread_id` in the query string params, or `thread_name` in the JSON/form params.
+	 * If `thread_id` is provided, the message will send in that thread. If `thread_name` is provided, a thread with that name will be created in the forum channel.
 	 */
 	thread_name: string;
 }>;

--- a/deno/rest/v9/webhook.ts
+++ b/deno/rest/v9/webhook.ts
@@ -145,10 +145,9 @@ export type RESTPostAPIWebhookWithTokenJSONBody = AddUndefinedToPossiblyUndefine
 	 */
 	flags?: MessageFlags;
 	/**
-	 * Name of thread to create (only available if webhook is in a forum channel)
+	 * Name of thread to create
 	 *
-	 * If the webhook is in a thread channel, you must provide either `thread_id` in the query string params, or `thread_name` in the JSON/form params.
-	 * If `thread_id` is provided, the message will send in that thread. If `thread_name` is provided, a thread with that name will be created in the forum channel.
+	 * Available only if the webhook is in a forum channel and a thread is not specified in {@link RESTPostAPIWebhookWithTokenQuery.thread_id} query parameter
 	 */
 	thread_name: string;
 }>;
@@ -178,6 +177,8 @@ export interface RESTPostAPIWebhookWithTokenQuery {
 	wait?: boolean;
 	/**
 	 * Send a message to the specified thread within a webhook's channel. The thread will automatically be unarchived.
+	 *
+	 * Available only if the {@link RESTPostAPIWebhookWithTokenJSONBody.thread_name} JSON body property is not specified
 	 */
 	thread_id?: Snowflake;
 }

--- a/deno/rest/v9/webhook.ts
+++ b/deno/rest/v9/webhook.ts
@@ -144,6 +144,10 @@ export type RESTPostAPIWebhookWithTokenJSONBody = AddUndefinedToPossiblyUndefine
 	 * Message flags combined as a bitfield
 	 */
 	flags?: MessageFlags;
+	/**
+	 * Name of thread to create (only available if webhook is in a forum channel)
+	 */
+	thread_name: string;
 }>;
 
 /**

--- a/deno/rest/v9/webhook.ts
+++ b/deno/rest/v9/webhook.ts
@@ -146,6 +146,9 @@ export type RESTPostAPIWebhookWithTokenJSONBody = AddUndefinedToPossiblyUndefine
 	flags?: MessageFlags;
 	/**
 	 * Name of thread to create (only available if webhook is in a forum channel)
+	 *
+	 * If the webhook is in a thread channel, you must provide either `thread_id` in the query string params, or `thread_name` in the JSON/form params.
+	 * If `thread_id` is provided, the message will send in that thread. If `thread_name` is provided, a thread with that name will be created in the forum channel.
 	 */
 	thread_name: string;
 }>;

--- a/rest/v10/webhook.ts
+++ b/rest/v10/webhook.ts
@@ -145,10 +145,9 @@ export type RESTPostAPIWebhookWithTokenJSONBody = AddUndefinedToPossiblyUndefine
 	 */
 	flags?: MessageFlags;
 	/**
-	 * Name of thread to create (only available if webhook is in a forum channel)
+	 * Name of thread to create
 	 *
-	 * If the webhook is in a thread channel, you must provide either `thread_id` in the query string params, or `thread_name` in the JSON/form params.
-	 * If `thread_id` is provided, the message will send in that thread. If `thread_name` is provided, a thread with that name will be created in the forum channel.
+	 * Available only if the webhook is in a forum channel and a thread is not specified in {@link RESTPostAPIWebhookWithTokenQuery.thread_id} query parameter
 	 */
 	thread_name: string;
 }>;
@@ -178,6 +177,8 @@ export interface RESTPostAPIWebhookWithTokenQuery {
 	wait?: boolean;
 	/**
 	 * Send a message to the specified thread within a webhook's channel. The thread will automatically be unarchived.
+	 *
+	 * Available only if the {@link RESTPostAPIWebhookWithTokenJSONBody.thread_name} JSON body property is not specified
 	 */
 	thread_id?: Snowflake;
 }

--- a/rest/v10/webhook.ts
+++ b/rest/v10/webhook.ts
@@ -144,6 +144,10 @@ export type RESTPostAPIWebhookWithTokenJSONBody = AddUndefinedToPossiblyUndefine
 	 * Message flags combined as a bitfield
 	 */
 	flags?: MessageFlags;
+	/**
+	 * Name of thread to create (only available if webhook is in a forum channel)
+	 */
+	thread_name: string;
 }>;
 
 /**

--- a/rest/v10/webhook.ts
+++ b/rest/v10/webhook.ts
@@ -146,6 +146,9 @@ export type RESTPostAPIWebhookWithTokenJSONBody = AddUndefinedToPossiblyUndefine
 	flags?: MessageFlags;
 	/**
 	 * Name of thread to create (only available if webhook is in a forum channel)
+	 *
+	 * If the webhook is in a thread channel, you must provide either `thread_id` in the query string params, or `thread_name` in the JSON/form params.
+	 * If `thread_id` is provided, the message will send in that thread. If `thread_name` is provided, a thread with that name will be created in the forum channel.
 	 */
 	thread_name: string;
 }>;

--- a/rest/v9/webhook.ts
+++ b/rest/v9/webhook.ts
@@ -145,10 +145,9 @@ export type RESTPostAPIWebhookWithTokenJSONBody = AddUndefinedToPossiblyUndefine
 	 */
 	flags?: MessageFlags;
 	/**
-	 * Name of thread to create (only available if webhook is in a forum channel)
+	 * Name of thread to create
 	 *
-	 * If the webhook is in a thread channel, you must provide either `thread_id` in the query string params, or `thread_name` in the JSON/form params.
-	 * If `thread_id` is provided, the message will send in that thread. If `thread_name` is provided, a thread with that name will be created in the forum channel.
+	 * Available only if the webhook is in a forum channel and a thread is not specified in {@link RESTPostAPIWebhookWithTokenQuery.thread_id} query parameter
 	 */
 	thread_name: string;
 }>;
@@ -178,6 +177,8 @@ export interface RESTPostAPIWebhookWithTokenQuery {
 	wait?: boolean;
 	/**
 	 * Send a message to the specified thread within a webhook's channel. The thread will automatically be unarchived.
+	 *
+	 * Available only if the {@link RESTPostAPIWebhookWithTokenJSONBody.thread_name} JSON body property is not specified
 	 */
 	thread_id?: Snowflake;
 }

--- a/rest/v9/webhook.ts
+++ b/rest/v9/webhook.ts
@@ -144,6 +144,10 @@ export type RESTPostAPIWebhookWithTokenJSONBody = AddUndefinedToPossiblyUndefine
 	 * Message flags combined as a bitfield
 	 */
 	flags?: MessageFlags;
+	/**
+	 * Name of thread to create (only available if webhook is in a forum channel)
+	 */
+	thread_name: string;
 }>;
 
 /**

--- a/rest/v9/webhook.ts
+++ b/rest/v9/webhook.ts
@@ -146,6 +146,9 @@ export type RESTPostAPIWebhookWithTokenJSONBody = AddUndefinedToPossiblyUndefine
 	flags?: MessageFlags;
 	/**
 	 * Name of thread to create (only available if webhook is in a forum channel)
+	 *
+	 * If the webhook is in a thread channel, you must provide either `thread_id` in the query string params, or `thread_name` in the JSON/form params.
+	 * If `thread_id` is provided, the message will send in that thread. If `thread_name` is provided, a thread with that name will be created in the forum channel.
 	 */
 	thread_name: string;
 }>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
- https://github.com/discord/discord-api-docs/pull/5007