### PR TITLE
docs(RESTPatchAPIChannelJSONBody): voice channels can be set as nsfw

### DIFF
--- a/deno/rest/v10/channel.ts
+++ b/deno/rest/v10/channel.ts
@@ -64,7 +64,7 @@ export type RESTPatchAPIChannelJSONBody = AddUndefinedToPossiblyUndefinedPropert
 	/**
 	 * Whether the channel is nsfw
 	 *
-	 * Channel types: text, news
+	 * Channel types: text, voice, news
 	 */
 	nsfw?: boolean | null;
 	/**
@@ -96,7 +96,7 @@ export type RESTPatchAPIChannelJSONBody = AddUndefinedToPossiblyUndefinedPropert
 	/**
 	 * ID of the new parent category for a channel
 	 *
-	 * Channel types: text, news, voice
+	 * Channel types: text, voice, news
 	 */
 	parent_id?: Snowflake | null;
 	/**

--- a/deno/rest/v9/channel.ts
+++ b/deno/rest/v9/channel.ts
@@ -64,7 +64,7 @@ export type RESTPatchAPIChannelJSONBody = AddUndefinedToPossiblyUndefinedPropert
 	/**
 	 * Whether the channel is nsfw
 	 *
-	 * Channel types: text, news
+	 * Channel types: text, voice, news
 	 */
 	nsfw?: boolean | null;
 	/**
@@ -96,7 +96,7 @@ export type RESTPatchAPIChannelJSONBody = AddUndefinedToPossiblyUndefinedPropert
 	/**
 	 * ID of the new parent category for a channel
 	 *
-	 * Channel types: text, news, voice
+	 * Channel types: text, voice, news
 	 */
 	parent_id?: Snowflake | null;
 	/**

--- a/rest/v10/channel.ts
+++ b/rest/v10/channel.ts
@@ -64,7 +64,7 @@ export type RESTPatchAPIChannelJSONBody = AddUndefinedToPossiblyUndefinedPropert
 	/**
 	 * Whether the channel is nsfw
 	 *
-	 * Channel types: text, news
+	 * Channel types: text, voice, news
 	 */
 	nsfw?: boolean | null;
 	/**
@@ -96,7 +96,7 @@ export type RESTPatchAPIChannelJSONBody = AddUndefinedToPossiblyUndefinedPropert
 	/**
 	 * ID of the new parent category for a channel
 	 *
-	 * Channel types: text, news, voice
+	 * Channel types: text, voice, news
 	 */
 	parent_id?: Snowflake | null;
 	/**

--- a/rest/v9/channel.ts
+++ b/rest/v9/channel.ts
@@ -64,7 +64,7 @@ export type RESTPatchAPIChannelJSONBody = AddUndefinedToPossiblyUndefinedPropert
 	/**
 	 * Whether the channel is nsfw
 	 *
-	 * Channel types: text, news
+	 * Channel types: text, voice, news
 	 */
 	nsfw?: boolean | null;
 	/**
@@ -96,7 +96,7 @@ export type RESTPatchAPIChannelJSONBody = AddUndefinedToPossiblyUndefinedPropert
 	/**
 	 * ID of the new parent category for a channel
 	 *
-	 * Channel types: text, news, voice
+	 * Channel types: text, voice, news
 	 */
 	parent_id?: Snowflake | null;
 	/**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
- https://github.com/discord/discord-api-docs/pull/5013
