### PR TITLE
refactor(GatewayIdentifyProperties): remove `$` prefix from keys

### DIFF
--- a/deno/gateway/v10.ts
+++ b/deno/gateway/v10.ts
@@ -1568,15 +1568,15 @@ export interface GatewayIdentifyProperties {
 	/**
 	 * Your operating system
 	 */
-	$os: string;
+	os: string;
 	/**
 	 * Your library name
 	 */
-	$browser: string;
+	browser: string;
 	/**
 	 * Your library name
 	 */
-	$device: string;
+	device: string;
 }
 
 /**

--- a/deno/gateway/v9.ts
+++ b/deno/gateway/v9.ts
@@ -1567,15 +1567,15 @@ export interface GatewayIdentifyProperties {
 	/**
 	 * Your operating system
 	 */
-	$os: string;
+	os: string;
 	/**
 	 * Your library name
 	 */
-	$browser: string;
+	browser: string;
 	/**
 	 * Your library name
 	 */
-	$device: string;
+	device: string;
 }
 
 /**

--- a/gateway/v10.ts
+++ b/gateway/v10.ts
@@ -1568,15 +1568,15 @@ export interface GatewayIdentifyProperties {
 	/**
 	 * Your operating system
 	 */
-	$os: string;
+	os: string;
 	/**
 	 * Your library name
 	 */
-	$browser: string;
+	browser: string;
 	/**
 	 * Your library name
 	 */
-	$device: string;
+	device: string;
 }
 
 /**

--- a/gateway/v9.ts
+++ b/gateway/v9.ts
@@ -1567,15 +1567,15 @@ export interface GatewayIdentifyProperties {
 	/**
 	 * Your operating system
 	 */
-	$os: string;
+	os: string;
 	/**
 	 * Your library name
 	 */
-	$browser: string;
+	browser: string;
 	/**
 	 * Your library name
 	 */
-	$device: string;
+	device: string;
 }
 
 /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
- ~~discord/discord-api-docs#5058~~ https://github.com/discord/discord-api-docs/pull/5067
