### PR TITLE
refactor(APIMessage): `referenced_message` is a partial message

### DIFF
--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -464,7 +464,7 @@ export interface APIMessage {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#message-object
 	 */
-	referenced_message?: APIMessage | null;
+	referenced_message?: Partial<APIMessage> | null;
 	/**
 	 * Sent if the message is a response to an Interaction
 	 */

--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -464,7 +464,7 @@ export interface APIMessage {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#message-object
 	 */
-	referenced_message?: Partial<APIMessage> | null;
+	referenced_message?: Omit<APIMessage, 'referenced_message' | 'nonce' | 'member' | 'guild_id'> | null;
 	/**
 	 * Sent if the message is a response to an Interaction
 	 */

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -464,7 +464,7 @@ export interface APIMessage {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#message-object
 	 */
-	referenced_message?: APIMessage | null;
+	referenced_message?: Partial<APIMessage> | null;
 	/**
 	 * Sent if the message is a response to an Interaction
 	 */

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -464,7 +464,7 @@ export interface APIMessage {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#message-object
 	 */
-	referenced_message?: Partial<APIMessage> | null;
+	referenced_message?: Omit<APIMessage, 'referenced_message' | 'nonce' | 'member' | 'guild_id'> | null;
 	/**
 	 * Sent if the message is a response to an Interaction
 	 */

--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -464,7 +464,7 @@ export interface APIMessage {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#message-object
 	 */
-	referenced_message?: APIMessage | null;
+	referenced_message?: Partial<APIMessage> | null;
 	/**
 	 * Sent if the message is a response to an Interaction
 	 */

--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -464,7 +464,7 @@ export interface APIMessage {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#message-object
 	 */
-	referenced_message?: Partial<APIMessage> | null;
+	referenced_message?: Omit<APIMessage, 'referenced_message' | 'nonce' | 'member' | 'guild_id'> | null;
 	/**
 	 * Sent if the message is a response to an Interaction
 	 */

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -464,7 +464,7 @@ export interface APIMessage {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#message-object
 	 */
-	referenced_message?: APIMessage | null;
+	referenced_message?: Partial<APIMessage> | null;
 	/**
 	 * Sent if the message is a response to an Interaction
 	 */

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -464,7 +464,7 @@ export interface APIMessage {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#message-object
 	 */
-	referenced_message?: Partial<APIMessage> | null;
+	referenced_message?: Omit<APIMessage, 'referenced_message' | 'nonce' | 'member' | 'guild_id'> | null;
 	/**
 	 * Sent if the message is a response to an Interaction
 	 */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
- https://github.com/discord/discord-api-docs/pull/5095