### PR TITLE
chore(UserFlags): add `@unstable` to `Spammer` flag

### DIFF
--- a/deno/payloads/v10/user.ts
+++ b/deno/payloads/v10/user.ts
@@ -143,7 +143,7 @@ export enum UserFlags {
 	BotHTTPInteractions = 1 << 19,
 	/**
 	 * User has been identified as spammer
-	 * 
+	 *
 	 * @unstable This user flag is currently not documented by Discord but has a known value which we will try to keep up to date.
 	 */
 	Spammer = 1 << 20,

--- a/deno/payloads/v10/user.ts
+++ b/deno/payloads/v10/user.ts
@@ -144,7 +144,7 @@ export enum UserFlags {
 	/**
 	 * User has been identified as spammer
 	 * 
-	 * @unstable This user flag is currently not documented by Discord but has known values which we will try to keep up to date.
+	 * @unstable This user flag is currently not documented by Discord but has a known value which we will try to keep up to date.
 	 */
 	Spammer = 1 << 20,
 }

--- a/deno/payloads/v10/user.ts
+++ b/deno/payloads/v10/user.ts
@@ -143,6 +143,8 @@ export enum UserFlags {
 	BotHTTPInteractions = 1 << 19,
 	/**
 	 * User has been identified as spammer
+	 * 
+	 * @unstable This user flag is currently not documented by Discord but has known values which we will try to keep up to date.
 	 */
 	Spammer = 1 << 20,
 }

--- a/deno/payloads/v8/user.ts
+++ b/deno/payloads/v8/user.ts
@@ -145,7 +145,7 @@ export enum UserFlags {
 	BotHTTPInteractions = 1 << 19,
 	/**
 	 * User has been identified as spammer
-	 * 
+	 *
 	 * @unstable This user flag is currently not documented by Discord but has a known value which we will try to keep up to date.
 	 */
 	Spammer = 1 << 20,

--- a/deno/payloads/v8/user.ts
+++ b/deno/payloads/v8/user.ts
@@ -146,7 +146,7 @@ export enum UserFlags {
 	/**
 	 * User has been identified as spammer
 	 * 
-	 * @unstable This user flag is currently not documented by Discord but has known values which we will try to keep up to date.
+	 * @unstable This user flag is currently not documented by Discord but has a known value which we will try to keep up to date.
 	 */
 	Spammer = 1 << 20,
 }

--- a/deno/payloads/v8/user.ts
+++ b/deno/payloads/v8/user.ts
@@ -145,6 +145,8 @@ export enum UserFlags {
 	BotHTTPInteractions = 1 << 19,
 	/**
 	 * User has been identified as spammer
+	 * 
+	 * @unstable This user flag is currently not documented by Discord but has known values which we will try to keep up to date.
 	 */
 	Spammer = 1 << 20,
 }

--- a/deno/payloads/v9/user.ts
+++ b/deno/payloads/v9/user.ts
@@ -143,7 +143,7 @@ export enum UserFlags {
 	BotHTTPInteractions = 1 << 19,
 	/**
 	 * User has been identified as spammer
-	 * 
+	 *
 	 * @unstable This user flag is currently not documented by Discord but has a known value which we will try to keep up to date.
 	 */
 	Spammer = 1 << 20,

--- a/deno/payloads/v9/user.ts
+++ b/deno/payloads/v9/user.ts
@@ -144,7 +144,7 @@ export enum UserFlags {
 	/**
 	 * User has been identified as spammer
 	 * 
-	 * @unstable This user flag is currently not documented by Discord but has known values which we will try to keep up to date.
+	 * @unstable This user flag is currently not documented by Discord but has a known value which we will try to keep up to date.
 	 */
 	Spammer = 1 << 20,
 }

--- a/deno/payloads/v9/user.ts
+++ b/deno/payloads/v9/user.ts
@@ -143,6 +143,8 @@ export enum UserFlags {
 	BotHTTPInteractions = 1 << 19,
 	/**
 	 * User has been identified as spammer
+	 * 
+	 * @unstable This user flag is currently not documented by Discord but has known values which we will try to keep up to date.
 	 */
 	Spammer = 1 << 20,
 }

--- a/payloads/v10/user.ts
+++ b/payloads/v10/user.ts
@@ -143,7 +143,7 @@ export enum UserFlags {
 	BotHTTPInteractions = 1 << 19,
 	/**
 	 * User has been identified as spammer
-	 * 
+	 *
 	 * @unstable This user flag is currently not documented by Discord but has a known value which we will try to keep up to date.
 	 */
 	Spammer = 1 << 20,

--- a/payloads/v10/user.ts
+++ b/payloads/v10/user.ts
@@ -144,7 +144,7 @@ export enum UserFlags {
 	/**
 	 * User has been identified as spammer
 	 * 
-	 * @unstable This user flag is currently not documented by Discord but has known values which we will try to keep up to date.
+	 * @unstable This user flag is currently not documented by Discord but has a known value which we will try to keep up to date.
 	 */
 	Spammer = 1 << 20,
 }

--- a/payloads/v10/user.ts
+++ b/payloads/v10/user.ts
@@ -143,6 +143,8 @@ export enum UserFlags {
 	BotHTTPInteractions = 1 << 19,
 	/**
 	 * User has been identified as spammer
+	 * 
+	 * @unstable This user flag is currently not documented by Discord but has known values which we will try to keep up to date.
 	 */
 	Spammer = 1 << 20,
 }

--- a/payloads/v8/user.ts
+++ b/payloads/v8/user.ts
@@ -145,7 +145,7 @@ export enum UserFlags {
 	BotHTTPInteractions = 1 << 19,
 	/**
 	 * User has been identified as spammer
-	 * 
+	 *
 	 * @unstable This user flag is currently not documented by Discord but has a known value which we will try to keep up to date.
 	 */
 	Spammer = 1 << 20,

--- a/payloads/v8/user.ts
+++ b/payloads/v8/user.ts
@@ -146,7 +146,7 @@ export enum UserFlags {
 	/**
 	 * User has been identified as spammer
 	 * 
-	 * @unstable This user flag is currently not documented by Discord but has known values which we will try to keep up to date.
+	 * @unstable This user flag is currently not documented by Discord but has a known value which we will try to keep up to date.
 	 */
 	Spammer = 1 << 20,
 }

--- a/payloads/v8/user.ts
+++ b/payloads/v8/user.ts
@@ -145,6 +145,8 @@ export enum UserFlags {
 	BotHTTPInteractions = 1 << 19,
 	/**
 	 * User has been identified as spammer
+	 * 
+	 * @unstable This user flag is currently not documented by Discord but has known values which we will try to keep up to date.
 	 */
 	Spammer = 1 << 20,
 }

--- a/payloads/v9/user.ts
+++ b/payloads/v9/user.ts
@@ -143,7 +143,7 @@ export enum UserFlags {
 	BotHTTPInteractions = 1 << 19,
 	/**
 	 * User has been identified as spammer
-	 * 
+	 *
 	 * @unstable This user flag is currently not documented by Discord but has a known value which we will try to keep up to date.
 	 */
 	Spammer = 1 << 20,

--- a/payloads/v9/user.ts
+++ b/payloads/v9/user.ts
@@ -144,7 +144,7 @@ export enum UserFlags {
 	/**
 	 * User has been identified as spammer
 	 * 
-	 * @unstable This user flag is currently not documented by Discord but has known values which we will try to keep up to date.
+	 * @unstable This user flag is currently not documented by Discord but has a known value which we will try to keep up to date.
 	 */
 	Spammer = 1 << 20,
 }

--- a/payloads/v9/user.ts
+++ b/payloads/v9/user.ts
@@ -143,6 +143,8 @@ export enum UserFlags {
 	BotHTTPInteractions = 1 << 19,
 	/**
 	 * User has been identified as spammer
+	 * 
+	 * @unstable This user flag is currently not documented by Discord but has known values which we will try to keep up to date.
 	 */
 	Spammer = 1 << 20,
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Adds `@unstable` to the `Spammer` user flag.
This idea comes from #495, which adds `Quarantined` user flag. Both of them are not documented by Discord.

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
