### PR TITLE
feat(REST): add `CDNRoutes`

### DIFF
--- a/deno/rest/v10/mod.ts
+++ b/deno/rest/v10/mod.ts
@@ -844,6 +844,180 @@ export const Routes = {
 	},
 };
 
+export const CDNRoutes = {
+	/**
+	 * Route for:
+	 * - GET `/emojis/{emoji.id}.{png|jpeg|webp|gif}`
+	 *
+	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
+	 */
+	customEmoji(emojiId: Snowflake, format: 'png' | 'jpeg' | 'webp' | 'gif') {
+		return `/emojis/${emojiId}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/guilds/{guild.id}/icons/{guild.id}.{png|jpeg|webp|gif}`
+	 *
+	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
+	 */
+	guildIcon(guildId: Snowflake, guildIcon: string, format: 'png' | 'jpeg' | 'webp' | 'gif') {
+		return `icons/${guildId}/${guildIcon}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/splashes/{guild.id}/{guild.splash}.{png|jpeg|webp}`
+	 */
+	guildSplash(guildId: Snowflake, guildSplash: string, format: 'png' | 'jpeg' | 'webp') {
+		return `/splashes/${guildId}/${guildSplash}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/discovery-splashes/{guild.id}/{guild.discovery_splash}.{png|jpeg|webp}`
+	 */
+	guildDiscoverySplash(guildId: Snowflake, guildDiscoverySplash: string, format: 'png' | 'jpeg' | 'webp') {
+		return `/discovery-splashes/${guildId}/${guildDiscoverySplash}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/banners/{guild.id}/{guild.banner}.{png|jpeg|webp|gif}`
+	 *
+	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
+	 */
+	guildBanner(guildId: Snowflake, guildBanner: string, format: 'png' | 'jpeg' | 'webp' | 'gif') {
+		return `/banners/${guildId}/${guildBanner}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/banners/{user.id}/{user.banner}.{png|jpeg|webp|gif}`
+	 *
+	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
+	 */
+	userBanner(userId: Snowflake, userBanner: string, format: 'png' | 'jpeg' | 'webp' | 'gif') {
+		return `/banners/${userId}/${userBanner}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/embed/avatars/{user.discriminator % 5}.png`
+	 *
+	 * The `userDiscriminator` parameter should be the user discriminator modulo 5 (e.g. 1337 % 5 = 2)
+	 */
+	defaultUserAvatar(userDiscriminator: Snowflake) {
+		return `/embed/avatars/${userDiscriminator}.png` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/avatars/{user.id}/{user.avatar}.{png|jpeg|webp|gif}`
+	 *
+	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
+	 */
+	userAvatar(userId: Snowflake, userAvatar: string, format: 'png' | 'jpeg' | 'webp' | 'gif') {
+		return `/avatars/${userId}/${userAvatar}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/guilds/{guild.id}/users/{user.id}/{guild_member.avatar}.{png|jpeg|webp|gif}`
+	 *
+	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
+	 */
+	guildMemberAvatar(
+		guildId: Snowflake,
+		userId: Snowflake,
+		memberAvatar: string,
+		format: 'png' | 'jpeg' | 'webp' | 'gif',
+	) {
+		return `/guilds/${guildId}/users/${userId}/avatars/${memberAvatar}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/app-icons/{application.id}/{application.icon}.{png|jpeg|webp}`
+	 */
+	applicationIcon(applicationId: Snowflake, applicationIcon: string, format: 'png' | 'jpeg' | 'webp') {
+		return `/app-icons/${applicationId}/${applicationIcon}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/app-icons/{application.id}/{application.cover_image}.{png|jpeg|webp}`
+	 */
+	applicationCover(applicationId: Snowflake, applicationCoverImage: string, format: 'png' | 'jpeg' | 'webp') {
+		return `/app-icons/${applicationId}/${applicationCoverImage}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/app-icons/{application.id}/{application.asset_id}.{png|jpeg|webp}`
+	 */
+	applicationAsset(applicationId: Snowflake, applicationAssetId: string, format: 'png' | 'jpeg' | 'webp') {
+		return `/app-icons/${applicationId}/${applicationAssetId}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/app-assets/{application.id}/achievements/{achievement.id}/icons/{achievement.icon}.{png|jpeg|webp}`
+	 */
+	achievementIcon(
+		applicationId: Snowflake,
+		achievementId: Snowflake,
+		achievementIconHash: string,
+		format: 'png' | 'jpeg' | 'webp',
+	) {
+		return `/app-assets/${applicationId}/achievements/${achievementId}/icons/${achievementIconHash}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/app-assets/710982414301790216/store/{sticker_pack.banner.asset_id}.{png|jpeg|webp}`
+	 */
+	stickerPackBanner(stickerPackBannerAssetId: Snowflake, format: 'png' | 'jpeg' | 'webp') {
+		return `app-assets/710982414301790216/store/${stickerPackBannerAssetId}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `team-icons/{team.id}/{team.icon}.{png|jpeg|webp}`
+	 */
+	teamIcon(teamId: Snowflake, teamIcon: string, format: 'png' | 'jpeg' | 'webp') {
+		return `/team-icons/${teamId}/${teamIcon}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/stickers/{sticker.id}.{png|json}`
+	 */
+	sticker(stickerId: Snowflake, format: 'png' | 'json') {
+		return `/stickers/${stickerId}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/role-icons/{role.id}/{role.icon}.{png|jpeg|webp}`
+	 */
+	roleIcon(roleId: Snowflake, roleIcon: string, format: 'png' | 'jpeg' | 'webp') {
+		return `/role-icons/${roleId}/${roleIcon}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/guild-events/{guild_scheduled_event.id}/{guild_scheduled_event.image}.{png|jpeg|webp}`
+	 */
+	guildScheduledEventCover(
+		guildScheduledEventId: Snowflake,
+		guildScheduledEventCoverImage: string,
+		format: 'png' | 'jpeg' | 'webp',
+	) {
+		return `/guild-events/${guildScheduledEventId}/${guildScheduledEventCoverImage}.${format}` as const;
+	},
+};
+
 export const RouteBases = {
 	api: `https://discord.com/api/v${APIVersion}`,
 	cdn: 'https://cdn.discordapp.com',

--- a/deno/rest/v10/mod.ts
+++ b/deno/rest/v10/mod.ts
@@ -851,7 +851,7 @@ export const CDNRoutes = {
 	 *
 	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
 	 */
-	customEmoji(emojiId: Snowflake, format: 'png' | 'jpeg' | 'webp' | 'gif') {
+	emoji(emojiId: Snowflake, format: 'png' | 'jpeg' | 'webp' | 'gif') {
 		return `/emojis/${emojiId}.${format}` as const;
 	},
 
@@ -906,8 +906,10 @@ export const CDNRoutes = {
 	 * - GET `/embed/avatars/{user.discriminator % 5}.png`
 	 *
 	 * The `userDiscriminator` parameter should be the user discriminator modulo 5 (e.g. 1337 % 5 = 2)
+	 *
+	 * The numbers range from only 0 to 5
 	 */
-	defaultUserAvatar(userDiscriminator: Snowflake) {
+	defaultUserAvatar(userDiscriminator: number) {
 		return `/embed/avatars/${userDiscriminator}.png` as const;
 	},
 

--- a/deno/rest/v10/mod.ts
+++ b/deno/rest/v10/mod.ts
@@ -853,7 +853,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	emoji(emojiId: Snowflake, format: CDNFormats['Emoji']) {
+	emoji(emojiId: Snowflake, format: EmojiFormat) {
 		return `/emojis/${emojiId}.${format}` as const;
 	},
 
@@ -865,7 +865,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildIcon(guildId: Snowflake, guildIcon: string, format: CDNFormats['GuildIcon']) {
+	guildIcon(guildId: Snowflake, guildIcon: string, format: GuildIconFormat) {
 		return `icons/${guildId}/${guildIcon}.${format}` as const;
 	},
 
@@ -875,7 +875,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildSplash(guildId: Snowflake, guildSplash: string, format: CDNFormats['GuildSplash']) {
+	guildSplash(guildId: Snowflake, guildSplash: string, format: GuildSplashFormat) {
 		return `/splashes/${guildId}/${guildSplash}.${format}` as const;
 	},
 
@@ -885,7 +885,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildDiscoverySplash(guildId: Snowflake, guildDiscoverySplash: string, format: CDNFormats['GuildDiscoverySplash']) {
+	guildDiscoverySplash(guildId: Snowflake, guildDiscoverySplash: string, format: GuildDiscoverySplashFormat) {
 		return `/discovery-splashes/${guildId}/${guildDiscoverySplash}.${format}` as const;
 	},
 
@@ -897,7 +897,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildBanner(guildId: Snowflake, guildBanner: string, format: CDNFormats['GuildBanner']) {
+	guildBanner(guildId: Snowflake, guildBanner: string, format: GuildBannerFormat) {
 		return `/banners/${guildId}/${guildBanner}.${format}` as const;
 	},
 
@@ -909,7 +909,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	userBanner(userId: Snowflake, userBanner: string, format: CDNFormats['UserBanner']) {
+	userBanner(userId: Snowflake, userBanner: string, format: UserBannerFormat) {
 		return `/banners/${userId}/${userBanner}.${format}` as const;
 	},
 
@@ -933,7 +933,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	userAvatar(userId: Snowflake, userAvatar: string, format: CDNFormats['UserAvatar']) {
+	userAvatar(userId: Snowflake, userAvatar: string, format: UserAvatarFormat) {
 		return `/avatars/${userId}/${userAvatar}.${format}` as const;
 	},
 
@@ -945,12 +945,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildMemberAvatar(
-		guildId: Snowflake,
-		userId: Snowflake,
-		memberAvatar: string,
-		format: CDNFormats['GuildMemberAvatar'],
-	) {
+	guildMemberAvatar(guildId: Snowflake, userId: Snowflake, memberAvatar: string, format: GuildMemberAvatarFormat) {
 		return `/guilds/${guildId}/users/${userId}/avatars/${memberAvatar}.${format}` as const;
 	},
 
@@ -960,7 +955,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationIcon(applicationId: Snowflake, applicationIcon: string, format: CDNFormats['ApplicationIcon']) {
+	applicationIcon(applicationId: Snowflake, applicationIcon: string, format: ApplicationIconFormat) {
 		return `/app-icons/${applicationId}/${applicationIcon}.${format}` as const;
 	},
 
@@ -970,7 +965,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationCover(applicationId: Snowflake, applicationCoverImage: string, format: CDNFormats['ApplicationCover']) {
+	applicationCover(applicationId: Snowflake, applicationCoverImage: string, format: ApplicationCoverFormat) {
 		return `/app-icons/${applicationId}/${applicationCoverImage}.${format}` as const;
 	},
 
@@ -980,7 +975,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationAsset(applicationId: Snowflake, applicationAssetId: string, format: CDNFormats['ApplicationAsset']) {
+	applicationAsset(applicationId: Snowflake, applicationAssetId: string, format: ApplicationAssetFormat) {
 		return `/app-icons/${applicationId}/${applicationAssetId}.${format}` as const;
 	},
 
@@ -994,7 +989,7 @@ export const CDNRoutes = {
 		applicationId: Snowflake,
 		achievementId: Snowflake,
 		achievementIconHash: string,
-		format: CDNFormats['AchievementIcon'],
+		format: AchievementIconFormat,
 	) {
 		return `/app-assets/${applicationId}/achievements/${achievementId}/icons/${achievementIconHash}.${format}` as const;
 	},
@@ -1005,7 +1000,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	stickerPackBanner(stickerPackBannerAssetId: Snowflake, format: CDNFormats['StickerPackBanner']) {
+	stickerPackBanner(stickerPackBannerAssetId: Snowflake, format: StickerPackBannerFormat) {
 		return `app-assets/710982414301790216/store/${stickerPackBannerAssetId}.${format}` as const;
 	},
 
@@ -1015,7 +1010,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	teamIcon(teamId: Snowflake, teamIcon: string, format: CDNFormats['TeamIcon']) {
+	teamIcon(teamId: Snowflake, teamIcon: string, format: TeamIconFormat) {
 		return `/team-icons/${teamId}/${teamIcon}.${format}` as const;
 	},
 
@@ -1025,7 +1020,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, Lottie
 	 */
-	sticker(stickerId: Snowflake, format: CDNFormats['Sticker']) {
+	sticker(stickerId: Snowflake, format: StickerFormat) {
 		return `/stickers/${stickerId}.${format}` as const;
 	},
 
@@ -1035,7 +1030,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	roleIcon(roleId: Snowflake, roleIcon: string, format: CDNFormats['RoleIcon']) {
+	roleIcon(roleId: Snowflake, roleIcon: string, format: RoleIconFormat) {
 		return `/role-icons/${roleId}/${roleIcon}.${format}` as const;
 	},
 
@@ -1048,7 +1043,7 @@ export const CDNRoutes = {
 	guildScheduledEventCover(
 		guildScheduledEventId: Snowflake,
 		guildScheduledEventCoverImage: string,
-		format: CDNFormats['GuildScheduledEventCover'],
+		format: GuildScheduledEventCoverFormat,
 	) {
 		return `/guild-events/${guildScheduledEventId}/${guildScheduledEventCoverImage}.${format}` as const;
 	},
@@ -1059,37 +1054,30 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildMemberBanner(
-		guildId: Snowflake,
-		userId: Snowflake,
-		guildMemberBanner: string,
-		format: CDNFormats['GuildMemberBanner'],
-	) {
+	guildMemberBanner(guildId: Snowflake, userId: Snowflake, guildMemberBanner: string, format: GuildMemberBannerFormat) {
 		return `/guilds/${guildId}/users/${userId}/banners/${guildMemberBanner}.${format}` as const;
 	},
 };
 
-export interface CDNFormats {
-	Emoji: Exclude<ImageFormat, ImageFormat.Lottie>;
-	GuildIcon: Exclude<ImageFormat, ImageFormat.Lottie>;
-	GuildSplash: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
-	GuildDiscoverySplash: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
-	GuildBanner: Exclude<ImageFormat, ImageFormat.Lottie>;
-	UserBanner: Exclude<ImageFormat, ImageFormat.Lottie>;
-	DefaultUserAvatar: Extract<ImageFormat, ImageFormat.PNG>;
-	UserAvatar: Exclude<ImageFormat, ImageFormat.Lottie>;
-	GuildMemberAvatar: Exclude<ImageFormat, ImageFormat.Lottie>;
-	ApplicationIcon: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
-	ApplicationCover: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
-	ApplicationAsset: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
-	AchievementIcon: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
-	StickerPackBanner: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
-	TeamIcon: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
-	Sticker: Extract<ImageFormat, ImageFormat.PNG | ImageFormat.Lottie>;
-	RoleIcon: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
-	GuildScheduledEventCover: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
-	GuildMemberBanner: Exclude<ImageFormat, ImageFormat.Lottie>;
-}
+export type EmojiFormat = Exclude<ImageFormat, ImageFormat.Lottie>;
+export type GuildIconFormat = Exclude<ImageFormat, ImageFormat.Lottie>;
+export type GuildSplashFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+export type GuildDiscoverySplashFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+export type GuildBannerFormat = Exclude<ImageFormat, ImageFormat.Lottie>;
+export type UserBannerFormat = Exclude<ImageFormat, ImageFormat.Lottie>;
+export type DefaultUserAvatar = Extract<ImageFormat, ImageFormat.PNG>;
+export type UserAvatarFormat = Exclude<ImageFormat, ImageFormat.Lottie>;
+export type GuildMemberAvatarFormat = Exclude<ImageFormat, ImageFormat.Lottie>;
+export type ApplicationIconFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+export type ApplicationCoverFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+export type ApplicationAssetFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+export type AchievementIconFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+export type StickerPackBannerFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+export type TeamIconFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+export type StickerFormat = Extract<ImageFormat, ImageFormat.PNG | ImageFormat.Lottie>;
+export type RoleIconFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+export type GuildScheduledEventCoverFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+export type GuildMemberBannerFormat = Exclude<ImageFormat, ImageFormat.Lottie>;
 
 export enum ImageFormat {
 	JPEG = 'jpeg',
@@ -1097,6 +1085,15 @@ export enum ImageFormat {
 	WebP = 'webp',
 	GIF = 'gif',
 	Lottie = 'json',
+}
+
+export interface CDNQuery {
+	/**
+	 * The returned image can have the size changed by using this query parameter
+	 *
+	 * Image size can be any power of two between 16 and 4096
+	 */
+	size?: number;
 }
 
 export const RouteBases = {

--- a/deno/rest/v10/mod.ts
+++ b/deno/rest/v10/mod.ts
@@ -853,7 +853,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	emoji(emojiId: Snowflake, format: ImageFormat) {
+	emoji(emojiId: Snowflake, format: Exclude<ImageFormat, ImageFormat.Lottie>) {
 		return `/emojis/${emojiId}.${format}` as const;
 	},
 
@@ -865,7 +865,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildIcon(guildId: Snowflake, guildIcon: string, format: ImageFormat) {
+	guildIcon(guildId: Snowflake, guildIcon: string, format: Exclude<ImageFormat, ImageFormat.Lottie>) {
 		return `icons/${guildId}/${guildIcon}.${format}` as const;
 	},
 
@@ -875,7 +875,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildSplash(guildId: Snowflake, guildSplash: string, format: ImageFormat) {
+	guildSplash(
+		guildId: Snowflake,
+		guildSplash: string,
+		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
+	) {
 		return `/splashes/${guildId}/${guildSplash}.${format}` as const;
 	},
 
@@ -885,7 +889,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildDiscoverySplash(guildId: Snowflake, guildDiscoverySplash: string, format: ImageFormat) {
+	guildDiscoverySplash(
+		guildId: Snowflake,
+		guildDiscoverySplash: string,
+		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
+	) {
 		return `/discovery-splashes/${guildId}/${guildDiscoverySplash}.${format}` as const;
 	},
 
@@ -897,7 +905,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildBanner(guildId: Snowflake, guildBanner: string, format: ImageFormat) {
+	guildBanner(guildId: Snowflake, guildBanner: string, format: Exclude<ImageFormat, ImageFormat.Lottie>) {
 		return `/banners/${guildId}/${guildBanner}.${format}` as const;
 	},
 
@@ -909,7 +917,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	userBanner(userId: Snowflake, userBanner: string, format: ImageFormat) {
+	userBanner(userId: Snowflake, userBanner: string, format: Exclude<ImageFormat, ImageFormat.Lottie>) {
 		return `/banners/${userId}/${userBanner}.${format}` as const;
 	},
 
@@ -933,7 +941,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	userAvatar(userId: Snowflake, userAvatar: string, format: ImageFormat) {
+	userAvatar(userId: Snowflake, userAvatar: string, format: Exclude<ImageFormat, ImageFormat.Lottie>) {
 		return `/avatars/${userId}/${userAvatar}.${format}` as const;
 	},
 
@@ -945,7 +953,12 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildMemberAvatar(guildId: Snowflake, userId: Snowflake, memberAvatar: string, format: ImageFormat) {
+	guildMemberAvatar(
+		guildId: Snowflake,
+		userId: Snowflake,
+		memberAvatar: string,
+		format: Exclude<ImageFormat, ImageFormat.Lottie>,
+	) {
 		return `/guilds/${guildId}/users/${userId}/avatars/${memberAvatar}.${format}` as const;
 	},
 
@@ -955,7 +968,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationIcon(applicationId: Snowflake, applicationIcon: string, format: ImageFormat) {
+	applicationIcon(
+		applicationId: Snowflake,
+		applicationIcon: string,
+		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
+	) {
 		return `/app-icons/${applicationId}/${applicationIcon}.${format}` as const;
 	},
 
@@ -965,7 +982,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationCover(applicationId: Snowflake, applicationCoverImage: string, format: ImageFormat) {
+	applicationCover(
+		applicationId: Snowflake,
+		applicationCoverImage: string,
+		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
+	) {
 		return `/app-icons/${applicationId}/${applicationCoverImage}.${format}` as const;
 	},
 
@@ -975,7 +996,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationAsset(applicationId: Snowflake, applicationAssetId: string, format: ImageFormat) {
+	applicationAsset(
+		applicationId: Snowflake,
+		applicationAssetId: string,
+		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
+	) {
 		return `/app-icons/${applicationId}/${applicationAssetId}.${format}` as const;
 	},
 
@@ -989,7 +1014,7 @@ export const CDNRoutes = {
 		applicationId: Snowflake,
 		achievementId: Snowflake,
 		achievementIconHash: string,
-		format: ImageFormat,
+		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
 	) {
 		return `/app-assets/${applicationId}/achievements/${achievementId}/icons/${achievementIconHash}.${format}` as const;
 	},
@@ -1000,7 +1025,10 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	stickerPackBanner(stickerPackBannerAssetId: Snowflake, format: ImageFormat) {
+	stickerPackBanner(
+		stickerPackBannerAssetId: Snowflake,
+		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
+	) {
 		return `app-assets/710982414301790216/store/${stickerPackBannerAssetId}.${format}` as const;
 	},
 
@@ -1010,7 +1038,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	teamIcon(teamId: Snowflake, teamIcon: string, format: ImageFormat) {
+	teamIcon(teamId: Snowflake, teamIcon: string, format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>) {
 		return `/team-icons/${teamId}/${teamIcon}.${format}` as const;
 	},
 
@@ -1020,7 +1048,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, Lottie
 	 */
-	sticker(stickerId: Snowflake, format: ImageFormat) {
+	sticker(stickerId: Snowflake, format: Extract<ImageFormat, ImageFormat.PNG | ImageFormat.Lottie>) {
 		return `/stickers/${stickerId}.${format}` as const;
 	},
 
@@ -1030,7 +1058,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	roleIcon(roleId: Snowflake, roleIcon: string, format: ImageFormat) {
+	roleIcon(roleId: Snowflake, roleIcon: string, format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>) {
 		return `/role-icons/${roleId}/${roleIcon}.${format}` as const;
 	},
 
@@ -1043,7 +1071,7 @@ export const CDNRoutes = {
 	guildScheduledEventCover(
 		guildScheduledEventId: Snowflake,
 		guildScheduledEventCoverImage: string,
-		format: ImageFormat,
+		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
 	) {
 		return `/guild-events/${guildScheduledEventId}/${guildScheduledEventCoverImage}.${format}` as const;
 	},
@@ -1054,7 +1082,12 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildMemberBanner(guildId: Snowflake, userId: Snowflake, guildMemberBanner: string, format: ImageFormat) {
+	guildMemberBanner(
+		guildId: Snowflake,
+		userId: Snowflake,
+		guildMemberBanner: string,
+		format: Exclude<ImageFormat, ImageFormat.Lottie>,
+	) {
 		return `/guilds/${guildId}/users/${userId}/banners/${guildMemberBanner}.${format}` as const;
 	},
 };

--- a/deno/rest/v10/mod.ts
+++ b/deno/rest/v10/mod.ts
@@ -853,7 +853,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	emoji(emojiId: Snowflake, format: Exclude<ImageFormat, ImageFormat.Lottie>) {
+	emoji(emojiId: Snowflake, format: CDNFormats['Emoji']) {
 		return `/emojis/${emojiId}.${format}` as const;
 	},
 
@@ -865,7 +865,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildIcon(guildId: Snowflake, guildIcon: string, format: Exclude<ImageFormat, ImageFormat.Lottie>) {
+	guildIcon(guildId: Snowflake, guildIcon: string, format: CDNFormats['GuildIcon']) {
 		return `icons/${guildId}/${guildIcon}.${format}` as const;
 	},
 
@@ -875,11 +875,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildSplash(
-		guildId: Snowflake,
-		guildSplash: string,
-		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
-	) {
+	guildSplash(guildId: Snowflake, guildSplash: string, format: CDNFormats['GuildSplash']) {
 		return `/splashes/${guildId}/${guildSplash}.${format}` as const;
 	},
 
@@ -889,11 +885,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildDiscoverySplash(
-		guildId: Snowflake,
-		guildDiscoverySplash: string,
-		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
-	) {
+	guildDiscoverySplash(guildId: Snowflake, guildDiscoverySplash: string, format: CDNFormats['GuildDiscoverySplash']) {
 		return `/discovery-splashes/${guildId}/${guildDiscoverySplash}.${format}` as const;
 	},
 
@@ -905,7 +897,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildBanner(guildId: Snowflake, guildBanner: string, format: Exclude<ImageFormat, ImageFormat.Lottie>) {
+	guildBanner(guildId: Snowflake, guildBanner: string, format: CDNFormats['GuildBanner']) {
 		return `/banners/${guildId}/${guildBanner}.${format}` as const;
 	},
 
@@ -917,7 +909,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	userBanner(userId: Snowflake, userBanner: string, format: Exclude<ImageFormat, ImageFormat.Lottie>) {
+	userBanner(userId: Snowflake, userBanner: string, format: CDNFormats['UserBanner']) {
 		return `/banners/${userId}/${userBanner}.${format}` as const;
 	},
 
@@ -941,7 +933,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	userAvatar(userId: Snowflake, userAvatar: string, format: Exclude<ImageFormat, ImageFormat.Lottie>) {
+	userAvatar(userId: Snowflake, userAvatar: string, format: CDNFormats['UserAvatar']) {
 		return `/avatars/${userId}/${userAvatar}.${format}` as const;
 	},
 
@@ -957,7 +949,7 @@ export const CDNRoutes = {
 		guildId: Snowflake,
 		userId: Snowflake,
 		memberAvatar: string,
-		format: Exclude<ImageFormat, ImageFormat.Lottie>,
+		format: CDNFormats['GuildMemberAvatar'],
 	) {
 		return `/guilds/${guildId}/users/${userId}/avatars/${memberAvatar}.${format}` as const;
 	},
@@ -968,11 +960,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationIcon(
-		applicationId: Snowflake,
-		applicationIcon: string,
-		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
-	) {
+	applicationIcon(applicationId: Snowflake, applicationIcon: string, format: CDNFormats['ApplicationIcon']) {
 		return `/app-icons/${applicationId}/${applicationIcon}.${format}` as const;
 	},
 
@@ -982,11 +970,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationCover(
-		applicationId: Snowflake,
-		applicationCoverImage: string,
-		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
-	) {
+	applicationCover(applicationId: Snowflake, applicationCoverImage: string, format: CDNFormats['ApplicationCover']) {
 		return `/app-icons/${applicationId}/${applicationCoverImage}.${format}` as const;
 	},
 
@@ -996,11 +980,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationAsset(
-		applicationId: Snowflake,
-		applicationAssetId: string,
-		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
-	) {
+	applicationAsset(applicationId: Snowflake, applicationAssetId: string, format: CDNFormats['ApplicationAsset']) {
 		return `/app-icons/${applicationId}/${applicationAssetId}.${format}` as const;
 	},
 
@@ -1014,7 +994,7 @@ export const CDNRoutes = {
 		applicationId: Snowflake,
 		achievementId: Snowflake,
 		achievementIconHash: string,
-		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
+		format: CDNFormats['AchievementIcon'],
 	) {
 		return `/app-assets/${applicationId}/achievements/${achievementId}/icons/${achievementIconHash}.${format}` as const;
 	},
@@ -1025,10 +1005,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	stickerPackBanner(
-		stickerPackBannerAssetId: Snowflake,
-		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
-	) {
+	stickerPackBanner(stickerPackBannerAssetId: Snowflake, format: CDNFormats['StickerPackBanner']) {
 		return `app-assets/710982414301790216/store/${stickerPackBannerAssetId}.${format}` as const;
 	},
 
@@ -1038,7 +1015,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	teamIcon(teamId: Snowflake, teamIcon: string, format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>) {
+	teamIcon(teamId: Snowflake, teamIcon: string, format: CDNFormats['TeamIcon']) {
 		return `/team-icons/${teamId}/${teamIcon}.${format}` as const;
 	},
 
@@ -1048,7 +1025,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, Lottie
 	 */
-	sticker(stickerId: Snowflake, format: Extract<ImageFormat, ImageFormat.PNG | ImageFormat.Lottie>) {
+	sticker(stickerId: Snowflake, format: CDNFormats['Sticker']) {
 		return `/stickers/${stickerId}.${format}` as const;
 	},
 
@@ -1058,7 +1035,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	roleIcon(roleId: Snowflake, roleIcon: string, format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>) {
+	roleIcon(roleId: Snowflake, roleIcon: string, format: CDNFormats['RoleIcon']) {
 		return `/role-icons/${roleId}/${roleIcon}.${format}` as const;
 	},
 
@@ -1071,7 +1048,7 @@ export const CDNRoutes = {
 	guildScheduledEventCover(
 		guildScheduledEventId: Snowflake,
 		guildScheduledEventCoverImage: string,
-		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
+		format: CDNFormats['GuildScheduledEventCover'],
 	) {
 		return `/guild-events/${guildScheduledEventId}/${guildScheduledEventCoverImage}.${format}` as const;
 	},
@@ -1086,11 +1063,33 @@ export const CDNRoutes = {
 		guildId: Snowflake,
 		userId: Snowflake,
 		guildMemberBanner: string,
-		format: Exclude<ImageFormat, ImageFormat.Lottie>,
+		format: CDNFormats['GuildMemberBanner'],
 	) {
 		return `/guilds/${guildId}/users/${userId}/banners/${guildMemberBanner}.${format}` as const;
 	},
 };
+
+export interface CDNFormats {
+	Emoji: Exclude<ImageFormat, ImageFormat.Lottie>;
+	GuildIcon: Exclude<ImageFormat, ImageFormat.Lottie>;
+	GuildSplash: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+	GuildDiscoverySplash: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+	GuildBanner: Exclude<ImageFormat, ImageFormat.Lottie>;
+	UserBanner: Exclude<ImageFormat, ImageFormat.Lottie>;
+	DefaultUserAvatar: Extract<ImageFormat, ImageFormat.PNG>;
+	UserAvatar: Exclude<ImageFormat, ImageFormat.Lottie>;
+	GuildMemberAvatar: Exclude<ImageFormat, ImageFormat.Lottie>;
+	ApplicationIcon: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+	ApplicationCover: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+	ApplicationAsset: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+	AchievementIcon: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+	StickerPackBanner: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+	TeamIcon: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+	Sticker: Extract<ImageFormat, ImageFormat.PNG | ImageFormat.Lottie>;
+	RoleIcon: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+	GuildScheduledEventCover: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+	GuildMemberBanner: Exclude<ImageFormat, ImageFormat.Lottie>;
+}
 
 export enum ImageFormat {
 	JPEG = 'jpeg',

--- a/deno/rest/v10/mod.ts
+++ b/deno/rest/v10/mod.ts
@@ -844,6 +844,8 @@ export const Routes = {
 	},
 };
 
+export const StickerPackApplicationId = '710982414301790216';
+
 export const CDNRoutes = {
 	/**
 	 * Route for:
@@ -921,7 +923,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extension: PNG
 	 */
-	defaultUserAvatar(userDiscriminator: 0 | 1 | 2 | 3 | 4 | 5) {
+	defaultUserAvatar(userDiscriminator: DefaultUserAvatarAssets) {
 		return `/embed/avatars/${userDiscriminator}.png` as const;
 	},
 
@@ -1001,7 +1003,7 @@ export const CDNRoutes = {
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
 	stickerPackBanner(stickerPackBannerAssetId: Snowflake, format: StickerPackBannerFormat) {
-		return `app-assets/710982414301790216/store/${stickerPackBannerAssetId}.${format}` as const;
+		return `/app-assets/${StickerPackApplicationId}/store/${stickerPackBannerAssetId}.${format}` as const;
 	},
 
 	/**
@@ -1058,6 +1060,8 @@ export const CDNRoutes = {
 		return `/guilds/${guildId}/users/${userId}/banners/${guildMemberBanner}.${format}` as const;
 	},
 };
+
+export type DefaultUserAvatarAssets = 0 | 1 | 2 | 3 | 4 | 5;
 
 export type EmojiFormat = Exclude<ImageFormat, ImageFormat.Lottie>;
 export type GuildIconFormat = Exclude<ImageFormat, ImageFormat.Lottie>;

--- a/deno/rest/v10/mod.ts
+++ b/deno/rest/v10/mod.ts
@@ -850,8 +850,10 @@ export const CDNRoutes = {
 	 * - GET `/emojis/{emoji.id}.{png|jpeg|webp|gif}`
 	 *
 	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	emoji(emojiId: Snowflake, format: 'png' | 'jpeg' | 'webp' | 'gif') {
+	emoji(emojiId: Snowflake, format: ImageFormat) {
 		return `/emojis/${emojiId}.${format}` as const;
 	},
 
@@ -860,24 +862,30 @@ export const CDNRoutes = {
 	 * - GET `/guilds/{guild.id}/icons/{guild.id}.{png|jpeg|webp|gif}`
 	 *
 	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildIcon(guildId: Snowflake, guildIcon: string, format: 'png' | 'jpeg' | 'webp' | 'gif') {
+	guildIcon(guildId: Snowflake, guildIcon: string, format: ImageFormat) {
 		return `icons/${guildId}/${guildIcon}.${format}` as const;
 	},
 
 	/**
 	 * Route for:
 	 * - GET `/splashes/{guild.id}/{guild.splash}.{png|jpeg|webp}`
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildSplash(guildId: Snowflake, guildSplash: string, format: 'png' | 'jpeg' | 'webp') {
+	guildSplash(guildId: Snowflake, guildSplash: string, format: ImageFormat) {
 		return `/splashes/${guildId}/${guildSplash}.${format}` as const;
 	},
 
 	/**
 	 * Route for:
 	 * - GET `/discovery-splashes/{guild.id}/{guild.discovery_splash}.{png|jpeg|webp}`
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildDiscoverySplash(guildId: Snowflake, guildDiscoverySplash: string, format: 'png' | 'jpeg' | 'webp') {
+	guildDiscoverySplash(guildId: Snowflake, guildDiscoverySplash: string, format: ImageFormat) {
 		return `/discovery-splashes/${guildId}/${guildDiscoverySplash}.${format}` as const;
 	},
 
@@ -886,8 +894,10 @@ export const CDNRoutes = {
 	 * - GET `/banners/{guild.id}/{guild.banner}.{png|jpeg|webp|gif}`
 	 *
 	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildBanner(guildId: Snowflake, guildBanner: string, format: 'png' | 'jpeg' | 'webp' | 'gif') {
+	guildBanner(guildId: Snowflake, guildBanner: string, format: ImageFormat) {
 		return `/banners/${guildId}/${guildBanner}.${format}` as const;
 	},
 
@@ -896,8 +906,10 @@ export const CDNRoutes = {
 	 * - GET `/banners/{user.id}/{user.banner}.{png|jpeg|webp|gif}`
 	 *
 	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	userBanner(userId: Snowflake, userBanner: string, format: 'png' | 'jpeg' | 'webp' | 'gif') {
+	userBanner(userId: Snowflake, userBanner: string, format: ImageFormat) {
 		return `/banners/${userId}/${userBanner}.${format}` as const;
 	},
 
@@ -907,9 +919,9 @@ export const CDNRoutes = {
 	 *
 	 * The `userDiscriminator` parameter should be the user discriminator modulo 5 (e.g. 1337 % 5 = 2)
 	 *
-	 * The numbers range from only 0 to 5
+	 * This route supports the extension: PNG
 	 */
-	defaultUserAvatar(userDiscriminator: number) {
+	defaultUserAvatar(userDiscriminator: 0 | 1 | 2 | 3 | 4 | 5) {
 		return `/embed/avatars/${userDiscriminator}.png` as const;
 	},
 
@@ -918,8 +930,10 @@ export const CDNRoutes = {
 	 * - GET `/avatars/{user.id}/{user.avatar}.{png|jpeg|webp|gif}`
 	 *
 	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	userAvatar(userId: Snowflake, userAvatar: string, format: 'png' | 'jpeg' | 'webp' | 'gif') {
+	userAvatar(userId: Snowflake, userAvatar: string, format: ImageFormat) {
 		return `/avatars/${userId}/${userAvatar}.${format}` as const;
 	},
 
@@ -928,49 +942,54 @@ export const CDNRoutes = {
 	 * - GET `/guilds/{guild.id}/users/{user.id}/{guild_member.avatar}.{png|jpeg|webp|gif}`
 	 *
 	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildMemberAvatar(
-		guildId: Snowflake,
-		userId: Snowflake,
-		memberAvatar: string,
-		format: 'png' | 'jpeg' | 'webp' | 'gif',
-	) {
+	guildMemberAvatar(guildId: Snowflake, userId: Snowflake, memberAvatar: string, format: ImageFormat) {
 		return `/guilds/${guildId}/users/${userId}/avatars/${memberAvatar}.${format}` as const;
 	},
 
 	/**
 	 * Route for:
 	 * - GET `/app-icons/{application.id}/{application.icon}.{png|jpeg|webp}`
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationIcon(applicationId: Snowflake, applicationIcon: string, format: 'png' | 'jpeg' | 'webp') {
+	applicationIcon(applicationId: Snowflake, applicationIcon: string, format: ImageFormat) {
 		return `/app-icons/${applicationId}/${applicationIcon}.${format}` as const;
 	},
 
 	/**
 	 * Route for:
 	 * - GET `/app-icons/{application.id}/{application.cover_image}.{png|jpeg|webp}`
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationCover(applicationId: Snowflake, applicationCoverImage: string, format: 'png' | 'jpeg' | 'webp') {
+	applicationCover(applicationId: Snowflake, applicationCoverImage: string, format: ImageFormat) {
 		return `/app-icons/${applicationId}/${applicationCoverImage}.${format}` as const;
 	},
 
 	/**
 	 * Route for:
 	 * - GET `/app-icons/{application.id}/{application.asset_id}.{png|jpeg|webp}`
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationAsset(applicationId: Snowflake, applicationAssetId: string, format: 'png' | 'jpeg' | 'webp') {
+	applicationAsset(applicationId: Snowflake, applicationAssetId: string, format: ImageFormat) {
 		return `/app-icons/${applicationId}/${applicationAssetId}.${format}` as const;
 	},
 
 	/**
 	 * Route for:
 	 * - GET `/app-assets/{application.id}/achievements/{achievement.id}/icons/{achievement.icon}.{png|jpeg|webp}`
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
 	achievementIcon(
 		applicationId: Snowflake,
 		achievementId: Snowflake,
 		achievementIconHash: string,
-		format: 'png' | 'jpeg' | 'webp',
+		format: ImageFormat,
 	) {
 		return `/app-assets/${applicationId}/achievements/${achievementId}/icons/${achievementIconHash}.${format}` as const;
 	},
@@ -978,47 +997,75 @@ export const CDNRoutes = {
 	/**
 	 * Route for:
 	 * - GET `/app-assets/710982414301790216/store/{sticker_pack.banner.asset_id}.{png|jpeg|webp}`
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	stickerPackBanner(stickerPackBannerAssetId: Snowflake, format: 'png' | 'jpeg' | 'webp') {
+	stickerPackBanner(stickerPackBannerAssetId: Snowflake, format: ImageFormat) {
 		return `app-assets/710982414301790216/store/${stickerPackBannerAssetId}.${format}` as const;
 	},
 
 	/**
 	 * Route for:
 	 * - GET `team-icons/{team.id}/{team.icon}.{png|jpeg|webp}`
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	teamIcon(teamId: Snowflake, teamIcon: string, format: 'png' | 'jpeg' | 'webp') {
+	teamIcon(teamId: Snowflake, teamIcon: string, format: ImageFormat) {
 		return `/team-icons/${teamId}/${teamIcon}.${format}` as const;
 	},
 
 	/**
 	 * Route for:
 	 * - GET `/stickers/{sticker.id}.{png|json}`
+	 *
+	 * This route supports the extensions: PNG, Lottie
 	 */
-	sticker(stickerId: Snowflake, format: 'png' | 'json') {
+	sticker(stickerId: Snowflake, format: ImageFormat) {
 		return `/stickers/${stickerId}.${format}` as const;
 	},
 
 	/**
 	 * Route for:
 	 * - GET `/role-icons/{role.id}/{role.icon}.{png|jpeg|webp}`
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	roleIcon(roleId: Snowflake, roleIcon: string, format: 'png' | 'jpeg' | 'webp') {
+	roleIcon(roleId: Snowflake, roleIcon: string, format: ImageFormat) {
 		return `/role-icons/${roleId}/${roleIcon}.${format}` as const;
 	},
 
 	/**
 	 * Route for:
 	 * - GET `/guild-events/{guild_scheduled_event.id}/{guild_scheduled_event.image}.{png|jpeg|webp}`
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
 	guildScheduledEventCover(
 		guildScheduledEventId: Snowflake,
 		guildScheduledEventCoverImage: string,
-		format: 'png' | 'jpeg' | 'webp',
+		format: ImageFormat,
 	) {
 		return `/guild-events/${guildScheduledEventId}/${guildScheduledEventCoverImage}.${format}` as const;
 	},
+
+	/**
+	 * Route for:
+	 * - GET `/guilds/${guild.id}/users/${user.id}/banners/${guild_member.banner}.{png|jpeg|webp|gif}`
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP, GIF
+	 */
+	guildMemberBanner(guildId: Snowflake, userId: Snowflake, guildMemberBanner: string, format: ImageFormat) {
+		return `/guilds/${guildId}/users/${userId}/banners/${guildMemberBanner}.${format}` as const;
+	},
 };
+
+export enum ImageFormat {
+	JPEG = 'jpeg',
+	PNG = 'png',
+	WebP = 'webp',
+	GIF = 'gif',
+	Lottie = 'json',
+}
 
 export const RouteBases = {
 	api: `https://discord.com/api/v${APIVersion}`,

--- a/deno/rest/v9/mod.ts
+++ b/deno/rest/v9/mod.ts
@@ -853,6 +853,180 @@ export const Routes = {
 	},
 };
 
+export const CDNRoutes = {
+	/**
+	 * Route for:
+	 * - GET `/emojis/{emoji.id}.{png|jpeg|webp|gif}`
+	 *
+	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
+	 */
+	customEmoji(emojiId: Snowflake, format: 'png' | 'jpeg' | 'webp' | 'gif') {
+		return `/emojis/${emojiId}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/guilds/{guild.id}/icons/{guild.id}.{png|jpeg|webp|gif}`
+	 *
+	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
+	 */
+	guildIcon(guildId: Snowflake, guildIcon: string, format: 'png' | 'jpeg' | 'webp' | 'gif') {
+		return `icons/${guildId}/${guildIcon}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/splashes/{guild.id}/{guild.splash}.{png|jpeg|webp}`
+	 */
+	guildSplash(guildId: Snowflake, guildSplash: string, format: 'png' | 'jpeg' | 'webp') {
+		return `/splashes/${guildId}/${guildSplash}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/discovery-splashes/{guild.id}/{guild.discovery_splash}.{png|jpeg|webp}`
+	 */
+	guildDiscoverySplash(guildId: Snowflake, guildDiscoverySplash: string, format: 'png' | 'jpeg' | 'webp') {
+		return `/discovery-splashes/${guildId}/${guildDiscoverySplash}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/banners/{guild.id}/{guild.banner}.{png|jpeg|webp|gif}`
+	 *
+	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
+	 */
+	guildBanner(guildId: Snowflake, guildBanner: string, format: 'png' | 'jpeg' | 'webp' | 'gif') {
+		return `/banners/${guildId}/${guildBanner}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/banners/{user.id}/{user.banner}.{png|jpeg|webp|gif}`
+	 *
+	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
+	 */
+	userBanner(userId: Snowflake, userBanner: string, format: 'png' | 'jpeg' | 'webp' | 'gif') {
+		return `/banners/${userId}/${userBanner}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/embed/avatars/{user.discriminator % 5}.png`
+	 *
+	 * The `userDiscriminator` parameter should be the user discriminator modulo 5 (e.g. 1337 % 5 = 2)
+	 */
+	defaultUserAvatar(userDiscriminator: Snowflake) {
+		return `/embed/avatars/${userDiscriminator}.png` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/avatars/{user.id}/{user.avatar}.{png|jpeg|webp|gif}`
+	 *
+	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
+	 */
+	userAvatar(userId: Snowflake, userAvatar: string, format: 'png' | 'jpeg' | 'webp' | 'gif') {
+		return `/avatars/${userId}/${userAvatar}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/guilds/{guild.id}/users/{user.id}/{guild_member.avatar}.{png|jpeg|webp|gif}`
+	 *
+	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
+	 */
+	guildMemberAvatar(
+		guildId: Snowflake,
+		userId: Snowflake,
+		memberAvatar: string,
+		format: 'png' | 'jpeg' | 'webp' | 'gif',
+	) {
+		return `/guilds/${guildId}/users/${userId}/avatars/${memberAvatar}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/app-icons/{application.id}/{application.icon}.{png|jpeg|webp}`
+	 */
+	applicationIcon(applicationId: Snowflake, applicationIcon: string, format: 'png' | 'jpeg' | 'webp') {
+		return `/app-icons/${applicationId}/${applicationIcon}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/app-icons/{application.id}/{application.cover_image}.{png|jpeg|webp}`
+	 */
+	applicationCover(applicationId: Snowflake, applicationCoverImage: string, format: 'png' | 'jpeg' | 'webp') {
+		return `/app-icons/${applicationId}/${applicationCoverImage}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/app-icons/{application.id}/{application.asset_id}.{png|jpeg|webp}`
+	 */
+	applicationAsset(applicationId: Snowflake, applicationAssetId: string, format: 'png' | 'jpeg' | 'webp') {
+		return `/app-icons/${applicationId}/${applicationAssetId}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/app-assets/{application.id}/achievements/{achievement.id}/icons/{achievement.icon}.{png|jpeg|webp}`
+	 */
+	achievementIcon(
+		applicationId: Snowflake,
+		achievementId: Snowflake,
+		achievementIconHash: string,
+		format: 'png' | 'jpeg' | 'webp',
+	) {
+		return `/app-assets/${applicationId}/achievements/${achievementId}/icons/${achievementIconHash}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/app-assets/710982414301790216/store/{sticker_pack.banner.asset_id}.{png|jpeg|webp}`
+	 */
+	stickerPackBanner(stickerPackBannerAssetId: Snowflake, format: 'png' | 'jpeg' | 'webp') {
+		return `app-assets/710982414301790216/store/${stickerPackBannerAssetId}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `team-icons/{team.id}/{team.icon}.{png|jpeg|webp}`
+	 */
+	teamIcon(teamId: Snowflake, teamIcon: string, format: 'png' | 'jpeg' | 'webp') {
+		return `/team-icons/${teamId}/${teamIcon}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/stickers/{sticker.id}.{png|json}`
+	 */
+	sticker(stickerId: Snowflake, format: 'png' | 'json') {
+		return `/stickers/${stickerId}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/role-icons/{role.id}/{role.icon}.{png|jpeg|webp}`
+	 */
+	roleIcon(roleId: Snowflake, roleIcon: string, format: 'png' | 'jpeg' | 'webp') {
+		return `/role-icons/${roleId}/${roleIcon}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/guild-events/{guild_scheduled_event.id}/{guild_scheduled_event.image}.{png|jpeg|webp}`
+	 */
+	guildScheduledEventCover(
+		guildScheduledEventId: Snowflake,
+		guildScheduledEventCoverImage: string,
+		format: 'png' | 'jpeg' | 'webp',
+	) {
+		return `/guild-events/${guildScheduledEventId}/${guildScheduledEventCoverImage}.${format}` as const;
+	},
+};
+
 export const RouteBases = {
 	api: `https://discord.com/api/v${APIVersion}`,
 	cdn: 'https://cdn.discordapp.com',

--- a/deno/rest/v9/mod.ts
+++ b/deno/rest/v9/mod.ts
@@ -862,7 +862,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	emoji(emojiId: Snowflake, format: Exclude<ImageFormat, ImageFormat.Lottie>) {
+	emoji(emojiId: Snowflake, format: CDNFormats['Emoji']) {
 		return `/emojis/${emojiId}.${format}` as const;
 	},
 
@@ -874,7 +874,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildIcon(guildId: Snowflake, guildIcon: string, format: Exclude<ImageFormat, ImageFormat.Lottie>) {
+	guildIcon(guildId: Snowflake, guildIcon: string, format: CDNFormats['GuildIcon']) {
 		return `icons/${guildId}/${guildIcon}.${format}` as const;
 	},
 
@@ -884,11 +884,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildSplash(
-		guildId: Snowflake,
-		guildSplash: string,
-		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
-	) {
+	guildSplash(guildId: Snowflake, guildSplash: string, format: CDNFormats['GuildSplash']) {
 		return `/splashes/${guildId}/${guildSplash}.${format}` as const;
 	},
 
@@ -898,11 +894,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildDiscoverySplash(
-		guildId: Snowflake,
-		guildDiscoverySplash: string,
-		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
-	) {
+	guildDiscoverySplash(guildId: Snowflake, guildDiscoverySplash: string, format: CDNFormats['GuildDiscoverySplash']) {
 		return `/discovery-splashes/${guildId}/${guildDiscoverySplash}.${format}` as const;
 	},
 
@@ -914,7 +906,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildBanner(guildId: Snowflake, guildBanner: string, format: Exclude<ImageFormat, ImageFormat.Lottie>) {
+	guildBanner(guildId: Snowflake, guildBanner: string, format: CDNFormats['GuildBanner']) {
 		return `/banners/${guildId}/${guildBanner}.${format}` as const;
 	},
 
@@ -926,7 +918,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	userBanner(userId: Snowflake, userBanner: string, format: Exclude<ImageFormat, ImageFormat.Lottie>) {
+	userBanner(userId: Snowflake, userBanner: string, format: CDNFormats['UserBanner']) {
 		return `/banners/${userId}/${userBanner}.${format}` as const;
 	},
 
@@ -950,7 +942,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	userAvatar(userId: Snowflake, userAvatar: string, format: Exclude<ImageFormat, ImageFormat.Lottie>) {
+	userAvatar(userId: Snowflake, userAvatar: string, format: CDNFormats['UserAvatar']) {
 		return `/avatars/${userId}/${userAvatar}.${format}` as const;
 	},
 
@@ -966,7 +958,7 @@ export const CDNRoutes = {
 		guildId: Snowflake,
 		userId: Snowflake,
 		memberAvatar: string,
-		format: Exclude<ImageFormat, ImageFormat.Lottie>,
+		format: CDNFormats['GuildMemberAvatar'],
 	) {
 		return `/guilds/${guildId}/users/${userId}/avatars/${memberAvatar}.${format}` as const;
 	},
@@ -977,11 +969,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationIcon(
-		applicationId: Snowflake,
-		applicationIcon: string,
-		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
-	) {
+	applicationIcon(applicationId: Snowflake, applicationIcon: string, format: CDNFormats['ApplicationIcon']) {
 		return `/app-icons/${applicationId}/${applicationIcon}.${format}` as const;
 	},
 
@@ -991,11 +979,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationCover(
-		applicationId: Snowflake,
-		applicationCoverImage: string,
-		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
-	) {
+	applicationCover(applicationId: Snowflake, applicationCoverImage: string, format: CDNFormats['ApplicationCover']) {
 		return `/app-icons/${applicationId}/${applicationCoverImage}.${format}` as const;
 	},
 
@@ -1005,11 +989,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationAsset(
-		applicationId: Snowflake,
-		applicationAssetId: string,
-		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
-	) {
+	applicationAsset(applicationId: Snowflake, applicationAssetId: string, format: CDNFormats['ApplicationAsset']) {
 		return `/app-icons/${applicationId}/${applicationAssetId}.${format}` as const;
 	},
 
@@ -1023,7 +1003,7 @@ export const CDNRoutes = {
 		applicationId: Snowflake,
 		achievementId: Snowflake,
 		achievementIconHash: string,
-		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
+		format: CDNFormats['AchievementIcon'],
 	) {
 		return `/app-assets/${applicationId}/achievements/${achievementId}/icons/${achievementIconHash}.${format}` as const;
 	},
@@ -1034,10 +1014,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	stickerPackBanner(
-		stickerPackBannerAssetId: Snowflake,
-		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
-	) {
+	stickerPackBanner(stickerPackBannerAssetId: Snowflake, format: CDNFormats['StickerPackBanner']) {
 		return `app-assets/710982414301790216/store/${stickerPackBannerAssetId}.${format}` as const;
 	},
 
@@ -1047,7 +1024,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	teamIcon(teamId: Snowflake, teamIcon: string, format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>) {
+	teamIcon(teamId: Snowflake, teamIcon: string, format: CDNFormats['TeamIcon']) {
 		return `/team-icons/${teamId}/${teamIcon}.${format}` as const;
 	},
 
@@ -1057,7 +1034,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, Lottie
 	 */
-	sticker(stickerId: Snowflake, format: Extract<ImageFormat, ImageFormat.PNG | ImageFormat.Lottie>) {
+	sticker(stickerId: Snowflake, format: CDNFormats['Sticker']) {
 		return `/stickers/${stickerId}.${format}` as const;
 	},
 
@@ -1067,7 +1044,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	roleIcon(roleId: Snowflake, roleIcon: string, format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>) {
+	roleIcon(roleId: Snowflake, roleIcon: string, format: CDNFormats['RoleIcon']) {
 		return `/role-icons/${roleId}/${roleIcon}.${format}` as const;
 	},
 
@@ -1080,7 +1057,7 @@ export const CDNRoutes = {
 	guildScheduledEventCover(
 		guildScheduledEventId: Snowflake,
 		guildScheduledEventCoverImage: string,
-		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
+		format: CDNFormats['GuildScheduledEventCover'],
 	) {
 		return `/guild-events/${guildScheduledEventId}/${guildScheduledEventCoverImage}.${format}` as const;
 	},
@@ -1095,11 +1072,33 @@ export const CDNRoutes = {
 		guildId: Snowflake,
 		userId: Snowflake,
 		guildMemberBanner: string,
-		format: Exclude<ImageFormat, ImageFormat.Lottie>,
+		format: CDNFormats['GuildMemberBanner'],
 	) {
 		return `/guilds/${guildId}/users/${userId}/banners/${guildMemberBanner}.${format}` as const;
 	},
 };
+
+export interface CDNFormats {
+	Emoji: Exclude<ImageFormat, ImageFormat.Lottie>;
+	GuildIcon: Exclude<ImageFormat, ImageFormat.Lottie>;
+	GuildSplash: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+	GuildDiscoverySplash: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+	GuildBanner: Exclude<ImageFormat, ImageFormat.Lottie>;
+	UserBanner: Exclude<ImageFormat, ImageFormat.Lottie>;
+	DefaultUserAvatar: Extract<ImageFormat, ImageFormat.PNG>;
+	UserAvatar: Exclude<ImageFormat, ImageFormat.Lottie>;
+	GuildMemberAvatar: Exclude<ImageFormat, ImageFormat.Lottie>;
+	ApplicationIcon: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+	ApplicationCover: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+	ApplicationAsset: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+	AchievementIcon: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+	StickerPackBanner: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+	TeamIcon: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+	Sticker: Extract<ImageFormat, ImageFormat.PNG | ImageFormat.Lottie>;
+	RoleIcon: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+	GuildScheduledEventCover: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+	GuildMemberBanner: Exclude<ImageFormat, ImageFormat.Lottie>;
+}
 
 export enum ImageFormat {
 	JPEG = 'jpeg',

--- a/deno/rest/v9/mod.ts
+++ b/deno/rest/v9/mod.ts
@@ -862,7 +862,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	emoji(emojiId: Snowflake, format: CDNFormats['Emoji']) {
+	emoji(emojiId: Snowflake, format: EmojiFormat) {
 		return `/emojis/${emojiId}.${format}` as const;
 	},
 
@@ -874,7 +874,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildIcon(guildId: Snowflake, guildIcon: string, format: CDNFormats['GuildIcon']) {
+	guildIcon(guildId: Snowflake, guildIcon: string, format: GuildIconFormat) {
 		return `icons/${guildId}/${guildIcon}.${format}` as const;
 	},
 
@@ -884,7 +884,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildSplash(guildId: Snowflake, guildSplash: string, format: CDNFormats['GuildSplash']) {
+	guildSplash(guildId: Snowflake, guildSplash: string, format: GuildSplashFormat) {
 		return `/splashes/${guildId}/${guildSplash}.${format}` as const;
 	},
 
@@ -894,7 +894,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildDiscoverySplash(guildId: Snowflake, guildDiscoverySplash: string, format: CDNFormats['GuildDiscoverySplash']) {
+	guildDiscoverySplash(guildId: Snowflake, guildDiscoverySplash: string, format: GuildDiscoverySplashFormat) {
 		return `/discovery-splashes/${guildId}/${guildDiscoverySplash}.${format}` as const;
 	},
 
@@ -906,7 +906,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildBanner(guildId: Snowflake, guildBanner: string, format: CDNFormats['GuildBanner']) {
+	guildBanner(guildId: Snowflake, guildBanner: string, format: GuildBannerFormat) {
 		return `/banners/${guildId}/${guildBanner}.${format}` as const;
 	},
 
@@ -918,7 +918,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	userBanner(userId: Snowflake, userBanner: string, format: CDNFormats['UserBanner']) {
+	userBanner(userId: Snowflake, userBanner: string, format: UserBannerFormat) {
 		return `/banners/${userId}/${userBanner}.${format}` as const;
 	},
 
@@ -942,7 +942,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	userAvatar(userId: Snowflake, userAvatar: string, format: CDNFormats['UserAvatar']) {
+	userAvatar(userId: Snowflake, userAvatar: string, format: UserAvatarFormat) {
 		return `/avatars/${userId}/${userAvatar}.${format}` as const;
 	},
 
@@ -954,12 +954,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildMemberAvatar(
-		guildId: Snowflake,
-		userId: Snowflake,
-		memberAvatar: string,
-		format: CDNFormats['GuildMemberAvatar'],
-	) {
+	guildMemberAvatar(guildId: Snowflake, userId: Snowflake, memberAvatar: string, format: GuildMemberAvatarFormat) {
 		return `/guilds/${guildId}/users/${userId}/avatars/${memberAvatar}.${format}` as const;
 	},
 
@@ -969,7 +964,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationIcon(applicationId: Snowflake, applicationIcon: string, format: CDNFormats['ApplicationIcon']) {
+	applicationIcon(applicationId: Snowflake, applicationIcon: string, format: ApplicationIconFormat) {
 		return `/app-icons/${applicationId}/${applicationIcon}.${format}` as const;
 	},
 
@@ -979,7 +974,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationCover(applicationId: Snowflake, applicationCoverImage: string, format: CDNFormats['ApplicationCover']) {
+	applicationCover(applicationId: Snowflake, applicationCoverImage: string, format: ApplicationCoverFormat) {
 		return `/app-icons/${applicationId}/${applicationCoverImage}.${format}` as const;
 	},
 
@@ -989,7 +984,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationAsset(applicationId: Snowflake, applicationAssetId: string, format: CDNFormats['ApplicationAsset']) {
+	applicationAsset(applicationId: Snowflake, applicationAssetId: string, format: ApplicationAssetFormat) {
 		return `/app-icons/${applicationId}/${applicationAssetId}.${format}` as const;
 	},
 
@@ -1003,7 +998,7 @@ export const CDNRoutes = {
 		applicationId: Snowflake,
 		achievementId: Snowflake,
 		achievementIconHash: string,
-		format: CDNFormats['AchievementIcon'],
+		format: AchievementIconFormat,
 	) {
 		return `/app-assets/${applicationId}/achievements/${achievementId}/icons/${achievementIconHash}.${format}` as const;
 	},
@@ -1014,7 +1009,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	stickerPackBanner(stickerPackBannerAssetId: Snowflake, format: CDNFormats['StickerPackBanner']) {
+	stickerPackBanner(stickerPackBannerAssetId: Snowflake, format: StickerPackBannerFormat) {
 		return `app-assets/710982414301790216/store/${stickerPackBannerAssetId}.${format}` as const;
 	},
 
@@ -1024,7 +1019,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	teamIcon(teamId: Snowflake, teamIcon: string, format: CDNFormats['TeamIcon']) {
+	teamIcon(teamId: Snowflake, teamIcon: string, format: TeamIconFormat) {
 		return `/team-icons/${teamId}/${teamIcon}.${format}` as const;
 	},
 
@@ -1034,7 +1029,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, Lottie
 	 */
-	sticker(stickerId: Snowflake, format: CDNFormats['Sticker']) {
+	sticker(stickerId: Snowflake, format: StickerFormat) {
 		return `/stickers/${stickerId}.${format}` as const;
 	},
 
@@ -1044,7 +1039,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	roleIcon(roleId: Snowflake, roleIcon: string, format: CDNFormats['RoleIcon']) {
+	roleIcon(roleId: Snowflake, roleIcon: string, format: RoleIconFormat) {
 		return `/role-icons/${roleId}/${roleIcon}.${format}` as const;
 	},
 
@@ -1057,7 +1052,7 @@ export const CDNRoutes = {
 	guildScheduledEventCover(
 		guildScheduledEventId: Snowflake,
 		guildScheduledEventCoverImage: string,
-		format: CDNFormats['GuildScheduledEventCover'],
+		format: GuildScheduledEventCoverFormat,
 	) {
 		return `/guild-events/${guildScheduledEventId}/${guildScheduledEventCoverImage}.${format}` as const;
 	},
@@ -1068,37 +1063,30 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildMemberBanner(
-		guildId: Snowflake,
-		userId: Snowflake,
-		guildMemberBanner: string,
-		format: CDNFormats['GuildMemberBanner'],
-	) {
+	guildMemberBanner(guildId: Snowflake, userId: Snowflake, guildMemberBanner: string, format: GuildMemberBannerFormat) {
 		return `/guilds/${guildId}/users/${userId}/banners/${guildMemberBanner}.${format}` as const;
 	},
 };
 
-export interface CDNFormats {
-	Emoji: Exclude<ImageFormat, ImageFormat.Lottie>;
-	GuildIcon: Exclude<ImageFormat, ImageFormat.Lottie>;
-	GuildSplash: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
-	GuildDiscoverySplash: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
-	GuildBanner: Exclude<ImageFormat, ImageFormat.Lottie>;
-	UserBanner: Exclude<ImageFormat, ImageFormat.Lottie>;
-	DefaultUserAvatar: Extract<ImageFormat, ImageFormat.PNG>;
-	UserAvatar: Exclude<ImageFormat, ImageFormat.Lottie>;
-	GuildMemberAvatar: Exclude<ImageFormat, ImageFormat.Lottie>;
-	ApplicationIcon: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
-	ApplicationCover: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
-	ApplicationAsset: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
-	AchievementIcon: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
-	StickerPackBanner: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
-	TeamIcon: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
-	Sticker: Extract<ImageFormat, ImageFormat.PNG | ImageFormat.Lottie>;
-	RoleIcon: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
-	GuildScheduledEventCover: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
-	GuildMemberBanner: Exclude<ImageFormat, ImageFormat.Lottie>;
-}
+export type EmojiFormat = Exclude<ImageFormat, ImageFormat.Lottie>;
+export type GuildIconFormat = Exclude<ImageFormat, ImageFormat.Lottie>;
+export type GuildSplashFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+export type GuildDiscoverySplashFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+export type GuildBannerFormat = Exclude<ImageFormat, ImageFormat.Lottie>;
+export type UserBannerFormat = Exclude<ImageFormat, ImageFormat.Lottie>;
+export type DefaultUserAvatar = Extract<ImageFormat, ImageFormat.PNG>;
+export type UserAvatarFormat = Exclude<ImageFormat, ImageFormat.Lottie>;
+export type GuildMemberAvatarFormat = Exclude<ImageFormat, ImageFormat.Lottie>;
+export type ApplicationIconFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+export type ApplicationCoverFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+export type ApplicationAssetFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+export type AchievementIconFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+export type StickerPackBannerFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+export type TeamIconFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+export type StickerFormat = Extract<ImageFormat, ImageFormat.PNG | ImageFormat.Lottie>;
+export type RoleIconFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+export type GuildScheduledEventCoverFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+export type GuildMemberBannerFormat = Exclude<ImageFormat, ImageFormat.Lottie>;
 
 export enum ImageFormat {
 	JPEG = 'jpeg',
@@ -1106,6 +1094,15 @@ export enum ImageFormat {
 	WebP = 'webp',
 	GIF = 'gif',
 	Lottie = 'json',
+}
+
+export interface CDNQuery {
+	/**
+	 * The returned image can have the size changed by using this query parameter
+	 *
+	 * Image size can be any power of two between 16 and 4096
+	 */
+	size?: number;
 }
 
 export const RouteBases = {

--- a/deno/rest/v9/mod.ts
+++ b/deno/rest/v9/mod.ts
@@ -862,7 +862,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	emoji(emojiId: Snowflake, format: ImageFormat) {
+	emoji(emojiId: Snowflake, format: Exclude<ImageFormat, ImageFormat.Lottie>) {
 		return `/emojis/${emojiId}.${format}` as const;
 	},
 
@@ -874,7 +874,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildIcon(guildId: Snowflake, guildIcon: string, format: ImageFormat) {
+	guildIcon(guildId: Snowflake, guildIcon: string, format: Exclude<ImageFormat, ImageFormat.Lottie>) {
 		return `icons/${guildId}/${guildIcon}.${format}` as const;
 	},
 
@@ -884,7 +884,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildSplash(guildId: Snowflake, guildSplash: string, format: ImageFormat) {
+	guildSplash(
+		guildId: Snowflake,
+		guildSplash: string,
+		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
+	) {
 		return `/splashes/${guildId}/${guildSplash}.${format}` as const;
 	},
 
@@ -894,7 +898,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildDiscoverySplash(guildId: Snowflake, guildDiscoverySplash: string, format: ImageFormat) {
+	guildDiscoverySplash(
+		guildId: Snowflake,
+		guildDiscoverySplash: string,
+		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
+	) {
 		return `/discovery-splashes/${guildId}/${guildDiscoverySplash}.${format}` as const;
 	},
 
@@ -906,7 +914,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildBanner(guildId: Snowflake, guildBanner: string, format: ImageFormat) {
+	guildBanner(guildId: Snowflake, guildBanner: string, format: Exclude<ImageFormat, ImageFormat.Lottie>) {
 		return `/banners/${guildId}/${guildBanner}.${format}` as const;
 	},
 
@@ -918,7 +926,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	userBanner(userId: Snowflake, userBanner: string, format: ImageFormat) {
+	userBanner(userId: Snowflake, userBanner: string, format: Exclude<ImageFormat, ImageFormat.Lottie>) {
 		return `/banners/${userId}/${userBanner}.${format}` as const;
 	},
 
@@ -942,7 +950,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	userAvatar(userId: Snowflake, userAvatar: string, format: ImageFormat) {
+	userAvatar(userId: Snowflake, userAvatar: string, format: Exclude<ImageFormat, ImageFormat.Lottie>) {
 		return `/avatars/${userId}/${userAvatar}.${format}` as const;
 	},
 
@@ -954,7 +962,12 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildMemberAvatar(guildId: Snowflake, userId: Snowflake, memberAvatar: string, format: ImageFormat) {
+	guildMemberAvatar(
+		guildId: Snowflake,
+		userId: Snowflake,
+		memberAvatar: string,
+		format: Exclude<ImageFormat, ImageFormat.Lottie>,
+	) {
 		return `/guilds/${guildId}/users/${userId}/avatars/${memberAvatar}.${format}` as const;
 	},
 
@@ -964,7 +977,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationIcon(applicationId: Snowflake, applicationIcon: string, format: ImageFormat) {
+	applicationIcon(
+		applicationId: Snowflake,
+		applicationIcon: string,
+		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
+	) {
 		return `/app-icons/${applicationId}/${applicationIcon}.${format}` as const;
 	},
 
@@ -974,7 +991,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationCover(applicationId: Snowflake, applicationCoverImage: string, format: ImageFormat) {
+	applicationCover(
+		applicationId: Snowflake,
+		applicationCoverImage: string,
+		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
+	) {
 		return `/app-icons/${applicationId}/${applicationCoverImage}.${format}` as const;
 	},
 
@@ -984,7 +1005,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationAsset(applicationId: Snowflake, applicationAssetId: string, format: ImageFormat) {
+	applicationAsset(
+		applicationId: Snowflake,
+		applicationAssetId: string,
+		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
+	) {
 		return `/app-icons/${applicationId}/${applicationAssetId}.${format}` as const;
 	},
 
@@ -998,7 +1023,7 @@ export const CDNRoutes = {
 		applicationId: Snowflake,
 		achievementId: Snowflake,
 		achievementIconHash: string,
-		format: ImageFormat,
+		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
 	) {
 		return `/app-assets/${applicationId}/achievements/${achievementId}/icons/${achievementIconHash}.${format}` as const;
 	},
@@ -1009,7 +1034,10 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	stickerPackBanner(stickerPackBannerAssetId: Snowflake, format: ImageFormat) {
+	stickerPackBanner(
+		stickerPackBannerAssetId: Snowflake,
+		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
+	) {
 		return `app-assets/710982414301790216/store/${stickerPackBannerAssetId}.${format}` as const;
 	},
 
@@ -1019,7 +1047,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	teamIcon(teamId: Snowflake, teamIcon: string, format: ImageFormat) {
+	teamIcon(teamId: Snowflake, teamIcon: string, format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>) {
 		return `/team-icons/${teamId}/${teamIcon}.${format}` as const;
 	},
 
@@ -1029,7 +1057,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, Lottie
 	 */
-	sticker(stickerId: Snowflake, format: ImageFormat) {
+	sticker(stickerId: Snowflake, format: Extract<ImageFormat, ImageFormat.PNG | ImageFormat.Lottie>) {
 		return `/stickers/${stickerId}.${format}` as const;
 	},
 
@@ -1039,7 +1067,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	roleIcon(roleId: Snowflake, roleIcon: string, format: ImageFormat) {
+	roleIcon(roleId: Snowflake, roleIcon: string, format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>) {
 		return `/role-icons/${roleId}/${roleIcon}.${format}` as const;
 	},
 
@@ -1052,7 +1080,7 @@ export const CDNRoutes = {
 	guildScheduledEventCover(
 		guildScheduledEventId: Snowflake,
 		guildScheduledEventCoverImage: string,
-		format: ImageFormat,
+		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
 	) {
 		return `/guild-events/${guildScheduledEventId}/${guildScheduledEventCoverImage}.${format}` as const;
 	},
@@ -1063,7 +1091,12 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildMemberBanner(guildId: Snowflake, userId: Snowflake, guildMemberBanner: string, format: ImageFormat) {
+	guildMemberBanner(
+		guildId: Snowflake,
+		userId: Snowflake,
+		guildMemberBanner: string,
+		format: Exclude<ImageFormat, ImageFormat.Lottie>,
+	) {
 		return `/guilds/${guildId}/users/${userId}/banners/${guildMemberBanner}.${format}` as const;
 	},
 };

--- a/deno/rest/v9/mod.ts
+++ b/deno/rest/v9/mod.ts
@@ -859,8 +859,10 @@ export const CDNRoutes = {
 	 * - GET `/emojis/{emoji.id}.{png|jpeg|webp|gif}`
 	 *
 	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	emoji(emojiId: Snowflake, format: 'png' | 'jpeg' | 'webp' | 'gif') {
+	emoji(emojiId: Snowflake, format: ImageFormat) {
 		return `/emojis/${emojiId}.${format}` as const;
 	},
 
@@ -869,24 +871,30 @@ export const CDNRoutes = {
 	 * - GET `/guilds/{guild.id}/icons/{guild.id}.{png|jpeg|webp|gif}`
 	 *
 	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildIcon(guildId: Snowflake, guildIcon: string, format: 'png' | 'jpeg' | 'webp' | 'gif') {
+	guildIcon(guildId: Snowflake, guildIcon: string, format: ImageFormat) {
 		return `icons/${guildId}/${guildIcon}.${format}` as const;
 	},
 
 	/**
 	 * Route for:
 	 * - GET `/splashes/{guild.id}/{guild.splash}.{png|jpeg|webp}`
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildSplash(guildId: Snowflake, guildSplash: string, format: 'png' | 'jpeg' | 'webp') {
+	guildSplash(guildId: Snowflake, guildSplash: string, format: ImageFormat) {
 		return `/splashes/${guildId}/${guildSplash}.${format}` as const;
 	},
 
 	/**
 	 * Route for:
 	 * - GET `/discovery-splashes/{guild.id}/{guild.discovery_splash}.{png|jpeg|webp}`
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildDiscoverySplash(guildId: Snowflake, guildDiscoverySplash: string, format: 'png' | 'jpeg' | 'webp') {
+	guildDiscoverySplash(guildId: Snowflake, guildDiscoverySplash: string, format: ImageFormat) {
 		return `/discovery-splashes/${guildId}/${guildDiscoverySplash}.${format}` as const;
 	},
 
@@ -895,8 +903,10 @@ export const CDNRoutes = {
 	 * - GET `/banners/{guild.id}/{guild.banner}.{png|jpeg|webp|gif}`
 	 *
 	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildBanner(guildId: Snowflake, guildBanner: string, format: 'png' | 'jpeg' | 'webp' | 'gif') {
+	guildBanner(guildId: Snowflake, guildBanner: string, format: ImageFormat) {
 		return `/banners/${guildId}/${guildBanner}.${format}` as const;
 	},
 
@@ -905,8 +915,10 @@ export const CDNRoutes = {
 	 * - GET `/banners/{user.id}/{user.banner}.{png|jpeg|webp|gif}`
 	 *
 	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	userBanner(userId: Snowflake, userBanner: string, format: 'png' | 'jpeg' | 'webp' | 'gif') {
+	userBanner(userId: Snowflake, userBanner: string, format: ImageFormat) {
 		return `/banners/${userId}/${userBanner}.${format}` as const;
 	},
 
@@ -916,9 +928,9 @@ export const CDNRoutes = {
 	 *
 	 * The `userDiscriminator` parameter should be the user discriminator modulo 5 (e.g. 1337 % 5 = 2)
 	 *
-	 * The numbers range from only 0 to 5
+	 * This route supports the extension: PNG
 	 */
-	defaultUserAvatar(userDiscriminator: number) {
+	defaultUserAvatar(userDiscriminator: 0 | 1 | 2 | 3 | 4 | 5) {
 		return `/embed/avatars/${userDiscriminator}.png` as const;
 	},
 
@@ -927,8 +939,10 @@ export const CDNRoutes = {
 	 * - GET `/avatars/{user.id}/{user.avatar}.{png|jpeg|webp|gif}`
 	 *
 	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	userAvatar(userId: Snowflake, userAvatar: string, format: 'png' | 'jpeg' | 'webp' | 'gif') {
+	userAvatar(userId: Snowflake, userAvatar: string, format: ImageFormat) {
 		return `/avatars/${userId}/${userAvatar}.${format}` as const;
 	},
 
@@ -937,49 +951,54 @@ export const CDNRoutes = {
 	 * - GET `/guilds/{guild.id}/users/{user.id}/{guild_member.avatar}.{png|jpeg|webp|gif}`
 	 *
 	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildMemberAvatar(
-		guildId: Snowflake,
-		userId: Snowflake,
-		memberAvatar: string,
-		format: 'png' | 'jpeg' | 'webp' | 'gif',
-	) {
+	guildMemberAvatar(guildId: Snowflake, userId: Snowflake, memberAvatar: string, format: ImageFormat) {
 		return `/guilds/${guildId}/users/${userId}/avatars/${memberAvatar}.${format}` as const;
 	},
 
 	/**
 	 * Route for:
 	 * - GET `/app-icons/{application.id}/{application.icon}.{png|jpeg|webp}`
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationIcon(applicationId: Snowflake, applicationIcon: string, format: 'png' | 'jpeg' | 'webp') {
+	applicationIcon(applicationId: Snowflake, applicationIcon: string, format: ImageFormat) {
 		return `/app-icons/${applicationId}/${applicationIcon}.${format}` as const;
 	},
 
 	/**
 	 * Route for:
 	 * - GET `/app-icons/{application.id}/{application.cover_image}.{png|jpeg|webp}`
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationCover(applicationId: Snowflake, applicationCoverImage: string, format: 'png' | 'jpeg' | 'webp') {
+	applicationCover(applicationId: Snowflake, applicationCoverImage: string, format: ImageFormat) {
 		return `/app-icons/${applicationId}/${applicationCoverImage}.${format}` as const;
 	},
 
 	/**
 	 * Route for:
 	 * - GET `/app-icons/{application.id}/{application.asset_id}.{png|jpeg|webp}`
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationAsset(applicationId: Snowflake, applicationAssetId: string, format: 'png' | 'jpeg' | 'webp') {
+	applicationAsset(applicationId: Snowflake, applicationAssetId: string, format: ImageFormat) {
 		return `/app-icons/${applicationId}/${applicationAssetId}.${format}` as const;
 	},
 
 	/**
 	 * Route for:
 	 * - GET `/app-assets/{application.id}/achievements/{achievement.id}/icons/{achievement.icon}.{png|jpeg|webp}`
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
 	achievementIcon(
 		applicationId: Snowflake,
 		achievementId: Snowflake,
 		achievementIconHash: string,
-		format: 'png' | 'jpeg' | 'webp',
+		format: ImageFormat,
 	) {
 		return `/app-assets/${applicationId}/achievements/${achievementId}/icons/${achievementIconHash}.${format}` as const;
 	},
@@ -987,47 +1006,75 @@ export const CDNRoutes = {
 	/**
 	 * Route for:
 	 * - GET `/app-assets/710982414301790216/store/{sticker_pack.banner.asset_id}.{png|jpeg|webp}`
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	stickerPackBanner(stickerPackBannerAssetId: Snowflake, format: 'png' | 'jpeg' | 'webp') {
+	stickerPackBanner(stickerPackBannerAssetId: Snowflake, format: ImageFormat) {
 		return `app-assets/710982414301790216/store/${stickerPackBannerAssetId}.${format}` as const;
 	},
 
 	/**
 	 * Route for:
 	 * - GET `team-icons/{team.id}/{team.icon}.{png|jpeg|webp}`
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	teamIcon(teamId: Snowflake, teamIcon: string, format: 'png' | 'jpeg' | 'webp') {
+	teamIcon(teamId: Snowflake, teamIcon: string, format: ImageFormat) {
 		return `/team-icons/${teamId}/${teamIcon}.${format}` as const;
 	},
 
 	/**
 	 * Route for:
 	 * - GET `/stickers/{sticker.id}.{png|json}`
+	 *
+	 * This route supports the extensions: PNG, Lottie
 	 */
-	sticker(stickerId: Snowflake, format: 'png' | 'json') {
+	sticker(stickerId: Snowflake, format: ImageFormat) {
 		return `/stickers/${stickerId}.${format}` as const;
 	},
 
 	/**
 	 * Route for:
 	 * - GET `/role-icons/{role.id}/{role.icon}.{png|jpeg|webp}`
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	roleIcon(roleId: Snowflake, roleIcon: string, format: 'png' | 'jpeg' | 'webp') {
+	roleIcon(roleId: Snowflake, roleIcon: string, format: ImageFormat) {
 		return `/role-icons/${roleId}/${roleIcon}.${format}` as const;
 	},
 
 	/**
 	 * Route for:
 	 * - GET `/guild-events/{guild_scheduled_event.id}/{guild_scheduled_event.image}.{png|jpeg|webp}`
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
 	guildScheduledEventCover(
 		guildScheduledEventId: Snowflake,
 		guildScheduledEventCoverImage: string,
-		format: 'png' | 'jpeg' | 'webp',
+		format: ImageFormat,
 	) {
 		return `/guild-events/${guildScheduledEventId}/${guildScheduledEventCoverImage}.${format}` as const;
 	},
+
+	/**
+	 * Route for:
+	 * - GET `/guilds/${guild.id}/users/${user.id}/banners/${guild_member.banner}.{png|jpeg|webp|gif}`
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP, GIF
+	 */
+	guildMemberBanner(guildId: Snowflake, userId: Snowflake, guildMemberBanner: string, format: ImageFormat) {
+		return `/guilds/${guildId}/users/${userId}/banners/${guildMemberBanner}.${format}` as const;
+	},
 };
+
+export enum ImageFormat {
+	JPEG = 'jpeg',
+	PNG = 'png',
+	WebP = 'webp',
+	GIF = 'gif',
+	Lottie = 'json',
+}
 
 export const RouteBases = {
 	api: `https://discord.com/api/v${APIVersion}`,

--- a/deno/rest/v9/mod.ts
+++ b/deno/rest/v9/mod.ts
@@ -860,7 +860,7 @@ export const CDNRoutes = {
 	 *
 	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
 	 */
-	customEmoji(emojiId: Snowflake, format: 'png' | 'jpeg' | 'webp' | 'gif') {
+	emoji(emojiId: Snowflake, format: 'png' | 'jpeg' | 'webp' | 'gif') {
 		return `/emojis/${emojiId}.${format}` as const;
 	},
 
@@ -915,8 +915,10 @@ export const CDNRoutes = {
 	 * - GET `/embed/avatars/{user.discriminator % 5}.png`
 	 *
 	 * The `userDiscriminator` parameter should be the user discriminator modulo 5 (e.g. 1337 % 5 = 2)
+	 *
+	 * The numbers range from only 0 to 5
 	 */
-	defaultUserAvatar(userDiscriminator: Snowflake) {
+	defaultUserAvatar(userDiscriminator: number) {
 		return `/embed/avatars/${userDiscriminator}.png` as const;
 	},
 

--- a/deno/rest/v9/mod.ts
+++ b/deno/rest/v9/mod.ts
@@ -853,6 +853,8 @@ export const Routes = {
 	},
 };
 
+export const StickerPackApplicationId = '710982414301790216';
+
 export const CDNRoutes = {
 	/**
 	 * Route for:
@@ -930,7 +932,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extension: PNG
 	 */
-	defaultUserAvatar(userDiscriminator: 0 | 1 | 2 | 3 | 4 | 5) {
+	defaultUserAvatar(userDiscriminator: DefaultUserAvatarAssets) {
 		return `/embed/avatars/${userDiscriminator}.png` as const;
 	},
 
@@ -1010,7 +1012,7 @@ export const CDNRoutes = {
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
 	stickerPackBanner(stickerPackBannerAssetId: Snowflake, format: StickerPackBannerFormat) {
-		return `app-assets/710982414301790216/store/${stickerPackBannerAssetId}.${format}` as const;
+		return `/app-assets/${StickerPackApplicationId}/store/${stickerPackBannerAssetId}.${format}` as const;
 	},
 
 	/**
@@ -1067,6 +1069,8 @@ export const CDNRoutes = {
 		return `/guilds/${guildId}/users/${userId}/banners/${guildMemberBanner}.${format}` as const;
 	},
 };
+
+export type DefaultUserAvatarAssets = 0 | 1 | 2 | 3 | 4 | 5;
 
 export type EmojiFormat = Exclude<ImageFormat, ImageFormat.Lottie>;
 export type GuildIconFormat = Exclude<ImageFormat, ImageFormat.Lottie>;

--- a/rest/v10/index.ts
+++ b/rest/v10/index.ts
@@ -844,6 +844,180 @@ export const Routes = {
 	},
 };
 
+export const CDNRoutes = {
+	/**
+	 * Route for:
+	 * - GET `/emojis/{emoji.id}.{png|jpeg|webp|gif}`
+	 *
+	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
+	 */
+	customEmoji(emojiId: Snowflake, format: 'png' | 'jpeg' | 'webp' | 'gif') {
+		return `/emojis/${emojiId}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/guilds/{guild.id}/icons/{guild.id}.{png|jpeg|webp|gif}`
+	 *
+	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
+	 */
+	guildIcon(guildId: Snowflake, guildIcon: string, format: 'png' | 'jpeg' | 'webp' | 'gif') {
+		return `icons/${guildId}/${guildIcon}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/splashes/{guild.id}/{guild.splash}.{png|jpeg|webp}`
+	 */
+	guildSplash(guildId: Snowflake, guildSplash: string, format: 'png' | 'jpeg' | 'webp') {
+		return `/splashes/${guildId}/${guildSplash}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/discovery-splashes/{guild.id}/{guild.discovery_splash}.{png|jpeg|webp}`
+	 */
+	guildDiscoverySplash(guildId: Snowflake, guildDiscoverySplash: string, format: 'png' | 'jpeg' | 'webp') {
+		return `/discovery-splashes/${guildId}/${guildDiscoverySplash}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/banners/{guild.id}/{guild.banner}.{png|jpeg|webp|gif}`
+	 *
+	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
+	 */
+	guildBanner(guildId: Snowflake, guildBanner: string, format: 'png' | 'jpeg' | 'webp' | 'gif') {
+		return `/banners/${guildId}/${guildBanner}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/banners/{user.id}/{user.banner}.{png|jpeg|webp|gif}`
+	 *
+	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
+	 */
+	userBanner(userId: Snowflake, userBanner: string, format: 'png' | 'jpeg' | 'webp' | 'gif') {
+		return `/banners/${userId}/${userBanner}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/embed/avatars/{user.discriminator % 5}.png`
+	 *
+	 * The `userDiscriminator` parameter should be the user discriminator modulo 5 (e.g. 1337 % 5 = 2)
+	 */
+	defaultUserAvatar(userDiscriminator: Snowflake) {
+		return `/embed/avatars/${userDiscriminator}.png` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/avatars/{user.id}/{user.avatar}.{png|jpeg|webp|gif}`
+	 *
+	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
+	 */
+	userAvatar(userId: Snowflake, userAvatar: string, format: 'png' | 'jpeg' | 'webp' | 'gif') {
+		return `/avatars/${userId}/${userAvatar}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/guilds/{guild.id}/users/{user.id}/{guild_member.avatar}.{png|jpeg|webp|gif}`
+	 *
+	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
+	 */
+	guildMemberAvatar(
+		guildId: Snowflake,
+		userId: Snowflake,
+		memberAvatar: string,
+		format: 'png' | 'jpeg' | 'webp' | 'gif',
+	) {
+		return `/guilds/${guildId}/users/${userId}/avatars/${memberAvatar}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/app-icons/{application.id}/{application.icon}.{png|jpeg|webp}`
+	 */
+	applicationIcon(applicationId: Snowflake, applicationIcon: string, format: 'png' | 'jpeg' | 'webp') {
+		return `/app-icons/${applicationId}/${applicationIcon}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/app-icons/{application.id}/{application.cover_image}.{png|jpeg|webp}`
+	 */
+	applicationCover(applicationId: Snowflake, applicationCoverImage: string, format: 'png' | 'jpeg' | 'webp') {
+		return `/app-icons/${applicationId}/${applicationCoverImage}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/app-icons/{application.id}/{application.asset_id}.{png|jpeg|webp}`
+	 */
+	applicationAsset(applicationId: Snowflake, applicationAssetId: string, format: 'png' | 'jpeg' | 'webp') {
+		return `/app-icons/${applicationId}/${applicationAssetId}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/app-assets/{application.id}/achievements/{achievement.id}/icons/{achievement.icon}.{png|jpeg|webp}`
+	 */
+	achievementIcon(
+		applicationId: Snowflake,
+		achievementId: Snowflake,
+		achievementIconHash: string,
+		format: 'png' | 'jpeg' | 'webp',
+	) {
+		return `/app-assets/${applicationId}/achievements/${achievementId}/icons/${achievementIconHash}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/app-assets/710982414301790216/store/{sticker_pack.banner.asset_id}.{png|jpeg|webp}`
+	 */
+	stickerPackBanner(stickerPackBannerAssetId: Snowflake, format: 'png' | 'jpeg' | 'webp') {
+		return `app-assets/710982414301790216/store/${stickerPackBannerAssetId}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `team-icons/{team.id}/{team.icon}.{png|jpeg|webp}`
+	 */
+	teamIcon(teamId: Snowflake, teamIcon: string, format: 'png' | 'jpeg' | 'webp') {
+		return `/team-icons/${teamId}/${teamIcon}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/stickers/{sticker.id}.{png|json}`
+	 */
+	sticker(stickerId: Snowflake, format: 'png' | 'json') {
+		return `/stickers/${stickerId}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/role-icons/{role.id}/{role.icon}.{png|jpeg|webp}`
+	 */
+	roleIcon(roleId: Snowflake, roleIcon: string, format: 'png' | 'jpeg' | 'webp') {
+		return `/role-icons/${roleId}/${roleIcon}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/guild-events/{guild_scheduled_event.id}/{guild_scheduled_event.image}.{png|jpeg|webp}`
+	 */
+	guildScheduledEventCover(
+		guildScheduledEventId: Snowflake,
+		guildScheduledEventCoverImage: string,
+		format: 'png' | 'jpeg' | 'webp',
+	) {
+		return `/guild-events/${guildScheduledEventId}/${guildScheduledEventCoverImage}.${format}` as const;
+	},
+};
+
 export const RouteBases = {
 	api: `https://discord.com/api/v${APIVersion}`,
 	cdn: 'https://cdn.discordapp.com',

--- a/rest/v10/index.ts
+++ b/rest/v10/index.ts
@@ -851,7 +851,7 @@ export const CDNRoutes = {
 	 *
 	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
 	 */
-	customEmoji(emojiId: Snowflake, format: 'png' | 'jpeg' | 'webp' | 'gif') {
+	emoji(emojiId: Snowflake, format: 'png' | 'jpeg' | 'webp' | 'gif') {
 		return `/emojis/${emojiId}.${format}` as const;
 	},
 
@@ -906,8 +906,10 @@ export const CDNRoutes = {
 	 * - GET `/embed/avatars/{user.discriminator % 5}.png`
 	 *
 	 * The `userDiscriminator` parameter should be the user discriminator modulo 5 (e.g. 1337 % 5 = 2)
+	 *
+	 * The numbers range from only 0 to 5
 	 */
-	defaultUserAvatar(userDiscriminator: Snowflake) {
+	defaultUserAvatar(userDiscriminator: number) {
 		return `/embed/avatars/${userDiscriminator}.png` as const;
 	},
 

--- a/rest/v10/index.ts
+++ b/rest/v10/index.ts
@@ -853,7 +853,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	emoji(emojiId: Snowflake, format: CDNFormats['Emoji']) {
+	emoji(emojiId: Snowflake, format: EmojiFormat) {
 		return `/emojis/${emojiId}.${format}` as const;
 	},
 
@@ -865,7 +865,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildIcon(guildId: Snowflake, guildIcon: string, format: CDNFormats['GuildIcon']) {
+	guildIcon(guildId: Snowflake, guildIcon: string, format: GuildIconFormat) {
 		return `icons/${guildId}/${guildIcon}.${format}` as const;
 	},
 
@@ -875,7 +875,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildSplash(guildId: Snowflake, guildSplash: string, format: CDNFormats['GuildSplash']) {
+	guildSplash(guildId: Snowflake, guildSplash: string, format: GuildSplashFormat) {
 		return `/splashes/${guildId}/${guildSplash}.${format}` as const;
 	},
 
@@ -885,7 +885,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildDiscoverySplash(guildId: Snowflake, guildDiscoverySplash: string, format: CDNFormats['GuildDiscoverySplash']) {
+	guildDiscoverySplash(guildId: Snowflake, guildDiscoverySplash: string, format: GuildDiscoverySplashFormat) {
 		return `/discovery-splashes/${guildId}/${guildDiscoverySplash}.${format}` as const;
 	},
 
@@ -897,7 +897,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildBanner(guildId: Snowflake, guildBanner: string, format: CDNFormats['GuildBanner']) {
+	guildBanner(guildId: Snowflake, guildBanner: string, format: GuildBannerFormat) {
 		return `/banners/${guildId}/${guildBanner}.${format}` as const;
 	},
 
@@ -909,7 +909,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	userBanner(userId: Snowflake, userBanner: string, format: CDNFormats['UserBanner']) {
+	userBanner(userId: Snowflake, userBanner: string, format: UserBannerFormat) {
 		return `/banners/${userId}/${userBanner}.${format}` as const;
 	},
 
@@ -933,7 +933,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	userAvatar(userId: Snowflake, userAvatar: string, format: CDNFormats['UserAvatar']) {
+	userAvatar(userId: Snowflake, userAvatar: string, format: UserAvatarFormat) {
 		return `/avatars/${userId}/${userAvatar}.${format}` as const;
 	},
 
@@ -945,12 +945,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildMemberAvatar(
-		guildId: Snowflake,
-		userId: Snowflake,
-		memberAvatar: string,
-		format: CDNFormats['GuildMemberAvatar'],
-	) {
+	guildMemberAvatar(guildId: Snowflake, userId: Snowflake, memberAvatar: string, format: GuildMemberAvatarFormat) {
 		return `/guilds/${guildId}/users/${userId}/avatars/${memberAvatar}.${format}` as const;
 	},
 
@@ -960,7 +955,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationIcon(applicationId: Snowflake, applicationIcon: string, format: CDNFormats['ApplicationIcon']) {
+	applicationIcon(applicationId: Snowflake, applicationIcon: string, format: ApplicationIconFormat) {
 		return `/app-icons/${applicationId}/${applicationIcon}.${format}` as const;
 	},
 
@@ -970,7 +965,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationCover(applicationId: Snowflake, applicationCoverImage: string, format: CDNFormats['ApplicationCover']) {
+	applicationCover(applicationId: Snowflake, applicationCoverImage: string, format: ApplicationCoverFormat) {
 		return `/app-icons/${applicationId}/${applicationCoverImage}.${format}` as const;
 	},
 
@@ -980,7 +975,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationAsset(applicationId: Snowflake, applicationAssetId: string, format: CDNFormats['ApplicationAsset']) {
+	applicationAsset(applicationId: Snowflake, applicationAssetId: string, format: ApplicationAssetFormat) {
 		return `/app-icons/${applicationId}/${applicationAssetId}.${format}` as const;
 	},
 
@@ -994,7 +989,7 @@ export const CDNRoutes = {
 		applicationId: Snowflake,
 		achievementId: Snowflake,
 		achievementIconHash: string,
-		format: CDNFormats['AchievementIcon'],
+		format: AchievementIconFormat,
 	) {
 		return `/app-assets/${applicationId}/achievements/${achievementId}/icons/${achievementIconHash}.${format}` as const;
 	},
@@ -1005,7 +1000,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	stickerPackBanner(stickerPackBannerAssetId: Snowflake, format: CDNFormats['StickerPackBanner']) {
+	stickerPackBanner(stickerPackBannerAssetId: Snowflake, format: StickerPackBannerFormat) {
 		return `app-assets/710982414301790216/store/${stickerPackBannerAssetId}.${format}` as const;
 	},
 
@@ -1015,7 +1010,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	teamIcon(teamId: Snowflake, teamIcon: string, format: CDNFormats['TeamIcon']) {
+	teamIcon(teamId: Snowflake, teamIcon: string, format: TeamIconFormat) {
 		return `/team-icons/${teamId}/${teamIcon}.${format}` as const;
 	},
 
@@ -1025,7 +1020,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, Lottie
 	 */
-	sticker(stickerId: Snowflake, format: CDNFormats['Sticker']) {
+	sticker(stickerId: Snowflake, format: StickerFormat) {
 		return `/stickers/${stickerId}.${format}` as const;
 	},
 
@@ -1035,7 +1030,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	roleIcon(roleId: Snowflake, roleIcon: string, format: CDNFormats['RoleIcon']) {
+	roleIcon(roleId: Snowflake, roleIcon: string, format: RoleIconFormat) {
 		return `/role-icons/${roleId}/${roleIcon}.${format}` as const;
 	},
 
@@ -1048,7 +1043,7 @@ export const CDNRoutes = {
 	guildScheduledEventCover(
 		guildScheduledEventId: Snowflake,
 		guildScheduledEventCoverImage: string,
-		format: CDNFormats['GuildScheduledEventCover'],
+		format: GuildScheduledEventCoverFormat,
 	) {
 		return `/guild-events/${guildScheduledEventId}/${guildScheduledEventCoverImage}.${format}` as const;
 	},
@@ -1059,37 +1054,30 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildMemberBanner(
-		guildId: Snowflake,
-		userId: Snowflake,
-		guildMemberBanner: string,
-		format: CDNFormats['GuildMemberBanner'],
-	) {
+	guildMemberBanner(guildId: Snowflake, userId: Snowflake, guildMemberBanner: string, format: GuildMemberBannerFormat) {
 		return `/guilds/${guildId}/users/${userId}/banners/${guildMemberBanner}.${format}` as const;
 	},
 };
 
-export interface CDNFormats {
-	Emoji: Exclude<ImageFormat, ImageFormat.Lottie>;
-	GuildIcon: Exclude<ImageFormat, ImageFormat.Lottie>;
-	GuildSplash: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
-	GuildDiscoverySplash: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
-	GuildBanner: Exclude<ImageFormat, ImageFormat.Lottie>;
-	UserBanner: Exclude<ImageFormat, ImageFormat.Lottie>;
-	DefaultUserAvatar: Extract<ImageFormat, ImageFormat.PNG>;
-	UserAvatar: Exclude<ImageFormat, ImageFormat.Lottie>;
-	GuildMemberAvatar: Exclude<ImageFormat, ImageFormat.Lottie>;
-	ApplicationIcon: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
-	ApplicationCover: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
-	ApplicationAsset: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
-	AchievementIcon: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
-	StickerPackBanner: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
-	TeamIcon: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
-	Sticker: Extract<ImageFormat, ImageFormat.PNG | ImageFormat.Lottie>;
-	RoleIcon: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
-	GuildScheduledEventCover: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
-	GuildMemberBanner: Exclude<ImageFormat, ImageFormat.Lottie>;
-}
+export type EmojiFormat = Exclude<ImageFormat, ImageFormat.Lottie>;
+export type GuildIconFormat = Exclude<ImageFormat, ImageFormat.Lottie>;
+export type GuildSplashFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+export type GuildDiscoverySplashFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+export type GuildBannerFormat = Exclude<ImageFormat, ImageFormat.Lottie>;
+export type UserBannerFormat = Exclude<ImageFormat, ImageFormat.Lottie>;
+export type DefaultUserAvatar = Extract<ImageFormat, ImageFormat.PNG>;
+export type UserAvatarFormat = Exclude<ImageFormat, ImageFormat.Lottie>;
+export type GuildMemberAvatarFormat = Exclude<ImageFormat, ImageFormat.Lottie>;
+export type ApplicationIconFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+export type ApplicationCoverFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+export type ApplicationAssetFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+export type AchievementIconFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+export type StickerPackBannerFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+export type TeamIconFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+export type StickerFormat = Extract<ImageFormat, ImageFormat.PNG | ImageFormat.Lottie>;
+export type RoleIconFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+export type GuildScheduledEventCoverFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+export type GuildMemberBannerFormat = Exclude<ImageFormat, ImageFormat.Lottie>;
 
 export enum ImageFormat {
 	JPEG = 'jpeg',
@@ -1097,6 +1085,15 @@ export enum ImageFormat {
 	WebP = 'webp',
 	GIF = 'gif',
 	Lottie = 'json',
+}
+
+export interface CDNQuery {
+	/**
+	 * The returned image can have the size changed by using this query parameter
+	 *
+	 * Image size can be any power of two between 16 and 4096
+	 */
+	size?: number;
 }
 
 export const RouteBases = {

--- a/rest/v10/index.ts
+++ b/rest/v10/index.ts
@@ -853,7 +853,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	emoji(emojiId: Snowflake, format: ImageFormat) {
+	emoji(emojiId: Snowflake, format: Exclude<ImageFormat, ImageFormat.Lottie>) {
 		return `/emojis/${emojiId}.${format}` as const;
 	},
 
@@ -865,7 +865,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildIcon(guildId: Snowflake, guildIcon: string, format: ImageFormat) {
+	guildIcon(guildId: Snowflake, guildIcon: string, format: Exclude<ImageFormat, ImageFormat.Lottie>) {
 		return `icons/${guildId}/${guildIcon}.${format}` as const;
 	},
 
@@ -875,7 +875,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildSplash(guildId: Snowflake, guildSplash: string, format: ImageFormat) {
+	guildSplash(
+		guildId: Snowflake,
+		guildSplash: string,
+		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
+	) {
 		return `/splashes/${guildId}/${guildSplash}.${format}` as const;
 	},
 
@@ -885,7 +889,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildDiscoverySplash(guildId: Snowflake, guildDiscoverySplash: string, format: ImageFormat) {
+	guildDiscoverySplash(
+		guildId: Snowflake,
+		guildDiscoverySplash: string,
+		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
+	) {
 		return `/discovery-splashes/${guildId}/${guildDiscoverySplash}.${format}` as const;
 	},
 
@@ -897,7 +905,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildBanner(guildId: Snowflake, guildBanner: string, format: ImageFormat) {
+	guildBanner(guildId: Snowflake, guildBanner: string, format: Exclude<ImageFormat, ImageFormat.Lottie>) {
 		return `/banners/${guildId}/${guildBanner}.${format}` as const;
 	},
 
@@ -909,7 +917,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	userBanner(userId: Snowflake, userBanner: string, format: ImageFormat) {
+	userBanner(userId: Snowflake, userBanner: string, format: Exclude<ImageFormat, ImageFormat.Lottie>) {
 		return `/banners/${userId}/${userBanner}.${format}` as const;
 	},
 
@@ -933,7 +941,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	userAvatar(userId: Snowflake, userAvatar: string, format: ImageFormat) {
+	userAvatar(userId: Snowflake, userAvatar: string, format: Exclude<ImageFormat, ImageFormat.Lottie>) {
 		return `/avatars/${userId}/${userAvatar}.${format}` as const;
 	},
 
@@ -945,7 +953,12 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildMemberAvatar(guildId: Snowflake, userId: Snowflake, memberAvatar: string, format: ImageFormat) {
+	guildMemberAvatar(
+		guildId: Snowflake,
+		userId: Snowflake,
+		memberAvatar: string,
+		format: Exclude<ImageFormat, ImageFormat.Lottie>,
+	) {
 		return `/guilds/${guildId}/users/${userId}/avatars/${memberAvatar}.${format}` as const;
 	},
 
@@ -955,7 +968,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationIcon(applicationId: Snowflake, applicationIcon: string, format: ImageFormat) {
+	applicationIcon(
+		applicationId: Snowflake,
+		applicationIcon: string,
+		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
+	) {
 		return `/app-icons/${applicationId}/${applicationIcon}.${format}` as const;
 	},
 
@@ -965,7 +982,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationCover(applicationId: Snowflake, applicationCoverImage: string, format: ImageFormat) {
+	applicationCover(
+		applicationId: Snowflake,
+		applicationCoverImage: string,
+		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
+	) {
 		return `/app-icons/${applicationId}/${applicationCoverImage}.${format}` as const;
 	},
 
@@ -975,7 +996,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationAsset(applicationId: Snowflake, applicationAssetId: string, format: ImageFormat) {
+	applicationAsset(
+		applicationId: Snowflake,
+		applicationAssetId: string,
+		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
+	) {
 		return `/app-icons/${applicationId}/${applicationAssetId}.${format}` as const;
 	},
 
@@ -989,7 +1014,7 @@ export const CDNRoutes = {
 		applicationId: Snowflake,
 		achievementId: Snowflake,
 		achievementIconHash: string,
-		format: ImageFormat,
+		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
 	) {
 		return `/app-assets/${applicationId}/achievements/${achievementId}/icons/${achievementIconHash}.${format}` as const;
 	},
@@ -1000,7 +1025,10 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	stickerPackBanner(stickerPackBannerAssetId: Snowflake, format: ImageFormat) {
+	stickerPackBanner(
+		stickerPackBannerAssetId: Snowflake,
+		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
+	) {
 		return `app-assets/710982414301790216/store/${stickerPackBannerAssetId}.${format}` as const;
 	},
 
@@ -1010,7 +1038,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	teamIcon(teamId: Snowflake, teamIcon: string, format: ImageFormat) {
+	teamIcon(teamId: Snowflake, teamIcon: string, format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>) {
 		return `/team-icons/${teamId}/${teamIcon}.${format}` as const;
 	},
 
@@ -1020,7 +1048,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, Lottie
 	 */
-	sticker(stickerId: Snowflake, format: ImageFormat) {
+	sticker(stickerId: Snowflake, format: Extract<ImageFormat, ImageFormat.PNG | ImageFormat.Lottie>) {
 		return `/stickers/${stickerId}.${format}` as const;
 	},
 
@@ -1030,7 +1058,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	roleIcon(roleId: Snowflake, roleIcon: string, format: ImageFormat) {
+	roleIcon(roleId: Snowflake, roleIcon: string, format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>) {
 		return `/role-icons/${roleId}/${roleIcon}.${format}` as const;
 	},
 
@@ -1043,7 +1071,7 @@ export const CDNRoutes = {
 	guildScheduledEventCover(
 		guildScheduledEventId: Snowflake,
 		guildScheduledEventCoverImage: string,
-		format: ImageFormat,
+		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
 	) {
 		return `/guild-events/${guildScheduledEventId}/${guildScheduledEventCoverImage}.${format}` as const;
 	},
@@ -1054,7 +1082,12 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildMemberBanner(guildId: Snowflake, userId: Snowflake, guildMemberBanner: string, format: ImageFormat) {
+	guildMemberBanner(
+		guildId: Snowflake,
+		userId: Snowflake,
+		guildMemberBanner: string,
+		format: Exclude<ImageFormat, ImageFormat.Lottie>,
+	) {
 		return `/guilds/${guildId}/users/${userId}/banners/${guildMemberBanner}.${format}` as const;
 	},
 };

--- a/rest/v10/index.ts
+++ b/rest/v10/index.ts
@@ -853,7 +853,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	emoji(emojiId: Snowflake, format: Exclude<ImageFormat, ImageFormat.Lottie>) {
+	emoji(emojiId: Snowflake, format: CDNFormats['Emoji']) {
 		return `/emojis/${emojiId}.${format}` as const;
 	},
 
@@ -865,7 +865,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildIcon(guildId: Snowflake, guildIcon: string, format: Exclude<ImageFormat, ImageFormat.Lottie>) {
+	guildIcon(guildId: Snowflake, guildIcon: string, format: CDNFormats['GuildIcon']) {
 		return `icons/${guildId}/${guildIcon}.${format}` as const;
 	},
 
@@ -875,11 +875,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildSplash(
-		guildId: Snowflake,
-		guildSplash: string,
-		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
-	) {
+	guildSplash(guildId: Snowflake, guildSplash: string, format: CDNFormats['GuildSplash']) {
 		return `/splashes/${guildId}/${guildSplash}.${format}` as const;
 	},
 
@@ -889,11 +885,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildDiscoverySplash(
-		guildId: Snowflake,
-		guildDiscoverySplash: string,
-		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
-	) {
+	guildDiscoverySplash(guildId: Snowflake, guildDiscoverySplash: string, format: CDNFormats['GuildDiscoverySplash']) {
 		return `/discovery-splashes/${guildId}/${guildDiscoverySplash}.${format}` as const;
 	},
 
@@ -905,7 +897,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildBanner(guildId: Snowflake, guildBanner: string, format: Exclude<ImageFormat, ImageFormat.Lottie>) {
+	guildBanner(guildId: Snowflake, guildBanner: string, format: CDNFormats['GuildBanner']) {
 		return `/banners/${guildId}/${guildBanner}.${format}` as const;
 	},
 
@@ -917,7 +909,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	userBanner(userId: Snowflake, userBanner: string, format: Exclude<ImageFormat, ImageFormat.Lottie>) {
+	userBanner(userId: Snowflake, userBanner: string, format: CDNFormats['UserBanner']) {
 		return `/banners/${userId}/${userBanner}.${format}` as const;
 	},
 
@@ -941,7 +933,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	userAvatar(userId: Snowflake, userAvatar: string, format: Exclude<ImageFormat, ImageFormat.Lottie>) {
+	userAvatar(userId: Snowflake, userAvatar: string, format: CDNFormats['UserAvatar']) {
 		return `/avatars/${userId}/${userAvatar}.${format}` as const;
 	},
 
@@ -957,7 +949,7 @@ export const CDNRoutes = {
 		guildId: Snowflake,
 		userId: Snowflake,
 		memberAvatar: string,
-		format: Exclude<ImageFormat, ImageFormat.Lottie>,
+		format: CDNFormats['GuildMemberAvatar'],
 	) {
 		return `/guilds/${guildId}/users/${userId}/avatars/${memberAvatar}.${format}` as const;
 	},
@@ -968,11 +960,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationIcon(
-		applicationId: Snowflake,
-		applicationIcon: string,
-		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
-	) {
+	applicationIcon(applicationId: Snowflake, applicationIcon: string, format: CDNFormats['ApplicationIcon']) {
 		return `/app-icons/${applicationId}/${applicationIcon}.${format}` as const;
 	},
 
@@ -982,11 +970,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationCover(
-		applicationId: Snowflake,
-		applicationCoverImage: string,
-		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
-	) {
+	applicationCover(applicationId: Snowflake, applicationCoverImage: string, format: CDNFormats['ApplicationCover']) {
 		return `/app-icons/${applicationId}/${applicationCoverImage}.${format}` as const;
 	},
 
@@ -996,11 +980,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationAsset(
-		applicationId: Snowflake,
-		applicationAssetId: string,
-		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
-	) {
+	applicationAsset(applicationId: Snowflake, applicationAssetId: string, format: CDNFormats['ApplicationAsset']) {
 		return `/app-icons/${applicationId}/${applicationAssetId}.${format}` as const;
 	},
 
@@ -1014,7 +994,7 @@ export const CDNRoutes = {
 		applicationId: Snowflake,
 		achievementId: Snowflake,
 		achievementIconHash: string,
-		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
+		format: CDNFormats['AchievementIcon'],
 	) {
 		return `/app-assets/${applicationId}/achievements/${achievementId}/icons/${achievementIconHash}.${format}` as const;
 	},
@@ -1025,10 +1005,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	stickerPackBanner(
-		stickerPackBannerAssetId: Snowflake,
-		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
-	) {
+	stickerPackBanner(stickerPackBannerAssetId: Snowflake, format: CDNFormats['StickerPackBanner']) {
 		return `app-assets/710982414301790216/store/${stickerPackBannerAssetId}.${format}` as const;
 	},
 
@@ -1038,7 +1015,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	teamIcon(teamId: Snowflake, teamIcon: string, format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>) {
+	teamIcon(teamId: Snowflake, teamIcon: string, format: CDNFormats['TeamIcon']) {
 		return `/team-icons/${teamId}/${teamIcon}.${format}` as const;
 	},
 
@@ -1048,7 +1025,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, Lottie
 	 */
-	sticker(stickerId: Snowflake, format: Extract<ImageFormat, ImageFormat.PNG | ImageFormat.Lottie>) {
+	sticker(stickerId: Snowflake, format: CDNFormats['Sticker']) {
 		return `/stickers/${stickerId}.${format}` as const;
 	},
 
@@ -1058,7 +1035,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	roleIcon(roleId: Snowflake, roleIcon: string, format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>) {
+	roleIcon(roleId: Snowflake, roleIcon: string, format: CDNFormats['RoleIcon']) {
 		return `/role-icons/${roleId}/${roleIcon}.${format}` as const;
 	},
 
@@ -1071,7 +1048,7 @@ export const CDNRoutes = {
 	guildScheduledEventCover(
 		guildScheduledEventId: Snowflake,
 		guildScheduledEventCoverImage: string,
-		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
+		format: CDNFormats['GuildScheduledEventCover'],
 	) {
 		return `/guild-events/${guildScheduledEventId}/${guildScheduledEventCoverImage}.${format}` as const;
 	},
@@ -1086,11 +1063,33 @@ export const CDNRoutes = {
 		guildId: Snowflake,
 		userId: Snowflake,
 		guildMemberBanner: string,
-		format: Exclude<ImageFormat, ImageFormat.Lottie>,
+		format: CDNFormats['GuildMemberBanner'],
 	) {
 		return `/guilds/${guildId}/users/${userId}/banners/${guildMemberBanner}.${format}` as const;
 	},
 };
+
+export interface CDNFormats {
+	Emoji: Exclude<ImageFormat, ImageFormat.Lottie>;
+	GuildIcon: Exclude<ImageFormat, ImageFormat.Lottie>;
+	GuildSplash: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+	GuildDiscoverySplash: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+	GuildBanner: Exclude<ImageFormat, ImageFormat.Lottie>;
+	UserBanner: Exclude<ImageFormat, ImageFormat.Lottie>;
+	DefaultUserAvatar: Extract<ImageFormat, ImageFormat.PNG>;
+	UserAvatar: Exclude<ImageFormat, ImageFormat.Lottie>;
+	GuildMemberAvatar: Exclude<ImageFormat, ImageFormat.Lottie>;
+	ApplicationIcon: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+	ApplicationCover: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+	ApplicationAsset: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+	AchievementIcon: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+	StickerPackBanner: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+	TeamIcon: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+	Sticker: Extract<ImageFormat, ImageFormat.PNG | ImageFormat.Lottie>;
+	RoleIcon: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+	GuildScheduledEventCover: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+	GuildMemberBanner: Exclude<ImageFormat, ImageFormat.Lottie>;
+}
 
 export enum ImageFormat {
 	JPEG = 'jpeg',

--- a/rest/v10/index.ts
+++ b/rest/v10/index.ts
@@ -844,6 +844,8 @@ export const Routes = {
 	},
 };
 
+export const StickerPackApplicationId = '710982414301790216';
+
 export const CDNRoutes = {
 	/**
 	 * Route for:
@@ -921,7 +923,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extension: PNG
 	 */
-	defaultUserAvatar(userDiscriminator: 0 | 1 | 2 | 3 | 4 | 5) {
+	defaultUserAvatar(userDiscriminator: DefaultUserAvatarAssets) {
 		return `/embed/avatars/${userDiscriminator}.png` as const;
 	},
 
@@ -1001,7 +1003,7 @@ export const CDNRoutes = {
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
 	stickerPackBanner(stickerPackBannerAssetId: Snowflake, format: StickerPackBannerFormat) {
-		return `app-assets/710982414301790216/store/${stickerPackBannerAssetId}.${format}` as const;
+		return `/app-assets/${StickerPackApplicationId}/store/${stickerPackBannerAssetId}.${format}` as const;
 	},
 
 	/**
@@ -1058,6 +1060,8 @@ export const CDNRoutes = {
 		return `/guilds/${guildId}/users/${userId}/banners/${guildMemberBanner}.${format}` as const;
 	},
 };
+
+export type DefaultUserAvatarAssets = 0 | 1 | 2 | 3 | 4 | 5;
 
 export type EmojiFormat = Exclude<ImageFormat, ImageFormat.Lottie>;
 export type GuildIconFormat = Exclude<ImageFormat, ImageFormat.Lottie>;

--- a/rest/v10/index.ts
+++ b/rest/v10/index.ts
@@ -850,8 +850,10 @@ export const CDNRoutes = {
 	 * - GET `/emojis/{emoji.id}.{png|jpeg|webp|gif}`
 	 *
 	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	emoji(emojiId: Snowflake, format: 'png' | 'jpeg' | 'webp' | 'gif') {
+	emoji(emojiId: Snowflake, format: ImageFormat) {
 		return `/emojis/${emojiId}.${format}` as const;
 	},
 
@@ -860,24 +862,30 @@ export const CDNRoutes = {
 	 * - GET `/guilds/{guild.id}/icons/{guild.id}.{png|jpeg|webp|gif}`
 	 *
 	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildIcon(guildId: Snowflake, guildIcon: string, format: 'png' | 'jpeg' | 'webp' | 'gif') {
+	guildIcon(guildId: Snowflake, guildIcon: string, format: ImageFormat) {
 		return `icons/${guildId}/${guildIcon}.${format}` as const;
 	},
 
 	/**
 	 * Route for:
 	 * - GET `/splashes/{guild.id}/{guild.splash}.{png|jpeg|webp}`
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildSplash(guildId: Snowflake, guildSplash: string, format: 'png' | 'jpeg' | 'webp') {
+	guildSplash(guildId: Snowflake, guildSplash: string, format: ImageFormat) {
 		return `/splashes/${guildId}/${guildSplash}.${format}` as const;
 	},
 
 	/**
 	 * Route for:
 	 * - GET `/discovery-splashes/{guild.id}/{guild.discovery_splash}.{png|jpeg|webp}`
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildDiscoverySplash(guildId: Snowflake, guildDiscoverySplash: string, format: 'png' | 'jpeg' | 'webp') {
+	guildDiscoverySplash(guildId: Snowflake, guildDiscoverySplash: string, format: ImageFormat) {
 		return `/discovery-splashes/${guildId}/${guildDiscoverySplash}.${format}` as const;
 	},
 
@@ -886,8 +894,10 @@ export const CDNRoutes = {
 	 * - GET `/banners/{guild.id}/{guild.banner}.{png|jpeg|webp|gif}`
 	 *
 	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildBanner(guildId: Snowflake, guildBanner: string, format: 'png' | 'jpeg' | 'webp' | 'gif') {
+	guildBanner(guildId: Snowflake, guildBanner: string, format: ImageFormat) {
 		return `/banners/${guildId}/${guildBanner}.${format}` as const;
 	},
 
@@ -896,8 +906,10 @@ export const CDNRoutes = {
 	 * - GET `/banners/{user.id}/{user.banner}.{png|jpeg|webp|gif}`
 	 *
 	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	userBanner(userId: Snowflake, userBanner: string, format: 'png' | 'jpeg' | 'webp' | 'gif') {
+	userBanner(userId: Snowflake, userBanner: string, format: ImageFormat) {
 		return `/banners/${userId}/${userBanner}.${format}` as const;
 	},
 
@@ -907,9 +919,9 @@ export const CDNRoutes = {
 	 *
 	 * The `userDiscriminator` parameter should be the user discriminator modulo 5 (e.g. 1337 % 5 = 2)
 	 *
-	 * The numbers range from only 0 to 5
+	 * This route supports the extension: PNG
 	 */
-	defaultUserAvatar(userDiscriminator: number) {
+	defaultUserAvatar(userDiscriminator: 0 | 1 | 2 | 3 | 4 | 5) {
 		return `/embed/avatars/${userDiscriminator}.png` as const;
 	},
 
@@ -918,8 +930,10 @@ export const CDNRoutes = {
 	 * - GET `/avatars/{user.id}/{user.avatar}.{png|jpeg|webp|gif}`
 	 *
 	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	userAvatar(userId: Snowflake, userAvatar: string, format: 'png' | 'jpeg' | 'webp' | 'gif') {
+	userAvatar(userId: Snowflake, userAvatar: string, format: ImageFormat) {
 		return `/avatars/${userId}/${userAvatar}.${format}` as const;
 	},
 
@@ -928,49 +942,54 @@ export const CDNRoutes = {
 	 * - GET `/guilds/{guild.id}/users/{user.id}/{guild_member.avatar}.{png|jpeg|webp|gif}`
 	 *
 	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildMemberAvatar(
-		guildId: Snowflake,
-		userId: Snowflake,
-		memberAvatar: string,
-		format: 'png' | 'jpeg' | 'webp' | 'gif',
-	) {
+	guildMemberAvatar(guildId: Snowflake, userId: Snowflake, memberAvatar: string, format: ImageFormat) {
 		return `/guilds/${guildId}/users/${userId}/avatars/${memberAvatar}.${format}` as const;
 	},
 
 	/**
 	 * Route for:
 	 * - GET `/app-icons/{application.id}/{application.icon}.{png|jpeg|webp}`
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationIcon(applicationId: Snowflake, applicationIcon: string, format: 'png' | 'jpeg' | 'webp') {
+	applicationIcon(applicationId: Snowflake, applicationIcon: string, format: ImageFormat) {
 		return `/app-icons/${applicationId}/${applicationIcon}.${format}` as const;
 	},
 
 	/**
 	 * Route for:
 	 * - GET `/app-icons/{application.id}/{application.cover_image}.{png|jpeg|webp}`
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationCover(applicationId: Snowflake, applicationCoverImage: string, format: 'png' | 'jpeg' | 'webp') {
+	applicationCover(applicationId: Snowflake, applicationCoverImage: string, format: ImageFormat) {
 		return `/app-icons/${applicationId}/${applicationCoverImage}.${format}` as const;
 	},
 
 	/**
 	 * Route for:
 	 * - GET `/app-icons/{application.id}/{application.asset_id}.{png|jpeg|webp}`
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationAsset(applicationId: Snowflake, applicationAssetId: string, format: 'png' | 'jpeg' | 'webp') {
+	applicationAsset(applicationId: Snowflake, applicationAssetId: string, format: ImageFormat) {
 		return `/app-icons/${applicationId}/${applicationAssetId}.${format}` as const;
 	},
 
 	/**
 	 * Route for:
 	 * - GET `/app-assets/{application.id}/achievements/{achievement.id}/icons/{achievement.icon}.{png|jpeg|webp}`
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
 	achievementIcon(
 		applicationId: Snowflake,
 		achievementId: Snowflake,
 		achievementIconHash: string,
-		format: 'png' | 'jpeg' | 'webp',
+		format: ImageFormat,
 	) {
 		return `/app-assets/${applicationId}/achievements/${achievementId}/icons/${achievementIconHash}.${format}` as const;
 	},
@@ -978,47 +997,75 @@ export const CDNRoutes = {
 	/**
 	 * Route for:
 	 * - GET `/app-assets/710982414301790216/store/{sticker_pack.banner.asset_id}.{png|jpeg|webp}`
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	stickerPackBanner(stickerPackBannerAssetId: Snowflake, format: 'png' | 'jpeg' | 'webp') {
+	stickerPackBanner(stickerPackBannerAssetId: Snowflake, format: ImageFormat) {
 		return `app-assets/710982414301790216/store/${stickerPackBannerAssetId}.${format}` as const;
 	},
 
 	/**
 	 * Route for:
 	 * - GET `team-icons/{team.id}/{team.icon}.{png|jpeg|webp}`
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	teamIcon(teamId: Snowflake, teamIcon: string, format: 'png' | 'jpeg' | 'webp') {
+	teamIcon(teamId: Snowflake, teamIcon: string, format: ImageFormat) {
 		return `/team-icons/${teamId}/${teamIcon}.${format}` as const;
 	},
 
 	/**
 	 * Route for:
 	 * - GET `/stickers/{sticker.id}.{png|json}`
+	 *
+	 * This route supports the extensions: PNG, Lottie
 	 */
-	sticker(stickerId: Snowflake, format: 'png' | 'json') {
+	sticker(stickerId: Snowflake, format: ImageFormat) {
 		return `/stickers/${stickerId}.${format}` as const;
 	},
 
 	/**
 	 * Route for:
 	 * - GET `/role-icons/{role.id}/{role.icon}.{png|jpeg|webp}`
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	roleIcon(roleId: Snowflake, roleIcon: string, format: 'png' | 'jpeg' | 'webp') {
+	roleIcon(roleId: Snowflake, roleIcon: string, format: ImageFormat) {
 		return `/role-icons/${roleId}/${roleIcon}.${format}` as const;
 	},
 
 	/**
 	 * Route for:
 	 * - GET `/guild-events/{guild_scheduled_event.id}/{guild_scheduled_event.image}.{png|jpeg|webp}`
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
 	guildScheduledEventCover(
 		guildScheduledEventId: Snowflake,
 		guildScheduledEventCoverImage: string,
-		format: 'png' | 'jpeg' | 'webp',
+		format: ImageFormat,
 	) {
 		return `/guild-events/${guildScheduledEventId}/${guildScheduledEventCoverImage}.${format}` as const;
 	},
+
+	/**
+	 * Route for:
+	 * - GET `/guilds/${guild.id}/users/${user.id}/banners/${guild_member.banner}.{png|jpeg|webp|gif}`
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP, GIF
+	 */
+	guildMemberBanner(guildId: Snowflake, userId: Snowflake, guildMemberBanner: string, format: ImageFormat) {
+		return `/guilds/${guildId}/users/${userId}/banners/${guildMemberBanner}.${format}` as const;
+	},
 };
+
+export enum ImageFormat {
+	JPEG = 'jpeg',
+	PNG = 'png',
+	WebP = 'webp',
+	GIF = 'gif',
+	Lottie = 'json',
+}
 
 export const RouteBases = {
 	api: `https://discord.com/api/v${APIVersion}`,

--- a/rest/v9/index.ts
+++ b/rest/v9/index.ts
@@ -853,6 +853,180 @@ export const Routes = {
 	},
 };
 
+export const CDNRoutes = {
+	/**
+	 * Route for:
+	 * - GET `/emojis/{emoji.id}.{png|jpeg|webp|gif}`
+	 *
+	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
+	 */
+	customEmoji(emojiId: Snowflake, format: 'png' | 'jpeg' | 'webp' | 'gif') {
+		return `/emojis/${emojiId}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/guilds/{guild.id}/icons/{guild.id}.{png|jpeg|webp|gif}`
+	 *
+	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
+	 */
+	guildIcon(guildId: Snowflake, guildIcon: string, format: 'png' | 'jpeg' | 'webp' | 'gif') {
+		return `icons/${guildId}/${guildIcon}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/splashes/{guild.id}/{guild.splash}.{png|jpeg|webp}`
+	 */
+	guildSplash(guildId: Snowflake, guildSplash: string, format: 'png' | 'jpeg' | 'webp') {
+		return `/splashes/${guildId}/${guildSplash}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/discovery-splashes/{guild.id}/{guild.discovery_splash}.{png|jpeg|webp}`
+	 */
+	guildDiscoverySplash(guildId: Snowflake, guildDiscoverySplash: string, format: 'png' | 'jpeg' | 'webp') {
+		return `/discovery-splashes/${guildId}/${guildDiscoverySplash}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/banners/{guild.id}/{guild.banner}.{png|jpeg|webp|gif}`
+	 *
+	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
+	 */
+	guildBanner(guildId: Snowflake, guildBanner: string, format: 'png' | 'jpeg' | 'webp' | 'gif') {
+		return `/banners/${guildId}/${guildBanner}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/banners/{user.id}/{user.banner}.{png|jpeg|webp|gif}`
+	 *
+	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
+	 */
+	userBanner(userId: Snowflake, userBanner: string, format: 'png' | 'jpeg' | 'webp' | 'gif') {
+		return `/banners/${userId}/${userBanner}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/embed/avatars/{user.discriminator % 5}.png`
+	 *
+	 * The `userDiscriminator` parameter should be the user discriminator modulo 5 (e.g. 1337 % 5 = 2)
+	 */
+	defaultUserAvatar(userDiscriminator: Snowflake) {
+		return `/embed/avatars/${userDiscriminator}.png` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/avatars/{user.id}/{user.avatar}.{png|jpeg|webp|gif}`
+	 *
+	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
+	 */
+	userAvatar(userId: Snowflake, userAvatar: string, format: 'png' | 'jpeg' | 'webp' | 'gif') {
+		return `/avatars/${userId}/${userAvatar}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/guilds/{guild.id}/users/{user.id}/{guild_member.avatar}.{png|jpeg|webp|gif}`
+	 *
+	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
+	 */
+	guildMemberAvatar(
+		guildId: Snowflake,
+		userId: Snowflake,
+		memberAvatar: string,
+		format: 'png' | 'jpeg' | 'webp' | 'gif',
+	) {
+		return `/guilds/${guildId}/users/${userId}/avatars/${memberAvatar}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/app-icons/{application.id}/{application.icon}.{png|jpeg|webp}`
+	 */
+	applicationIcon(applicationId: Snowflake, applicationIcon: string, format: 'png' | 'jpeg' | 'webp') {
+		return `/app-icons/${applicationId}/${applicationIcon}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/app-icons/{application.id}/{application.cover_image}.{png|jpeg|webp}`
+	 */
+	applicationCover(applicationId: Snowflake, applicationCoverImage: string, format: 'png' | 'jpeg' | 'webp') {
+		return `/app-icons/${applicationId}/${applicationCoverImage}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/app-icons/{application.id}/{application.asset_id}.{png|jpeg|webp}`
+	 */
+	applicationAsset(applicationId: Snowflake, applicationAssetId: string, format: 'png' | 'jpeg' | 'webp') {
+		return `/app-icons/${applicationId}/${applicationAssetId}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/app-assets/{application.id}/achievements/{achievement.id}/icons/{achievement.icon}.{png|jpeg|webp}`
+	 */
+	achievementIcon(
+		applicationId: Snowflake,
+		achievementId: Snowflake,
+		achievementIconHash: string,
+		format: 'png' | 'jpeg' | 'webp',
+	) {
+		return `/app-assets/${applicationId}/achievements/${achievementId}/icons/${achievementIconHash}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/app-assets/710982414301790216/store/{sticker_pack.banner.asset_id}.{png|jpeg|webp}`
+	 */
+	stickerPackBanner(stickerPackBannerAssetId: Snowflake, format: 'png' | 'jpeg' | 'webp') {
+		return `app-assets/710982414301790216/store/${stickerPackBannerAssetId}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `team-icons/{team.id}/{team.icon}.{png|jpeg|webp}`
+	 */
+	teamIcon(teamId: Snowflake, teamIcon: string, format: 'png' | 'jpeg' | 'webp') {
+		return `/team-icons/${teamId}/${teamIcon}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/stickers/{sticker.id}.{png|json}`
+	 */
+	sticker(stickerId: Snowflake, format: 'png' | 'json') {
+		return `/stickers/${stickerId}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/role-icons/{role.id}/{role.icon}.{png|jpeg|webp}`
+	 */
+	roleIcon(roleId: Snowflake, roleIcon: string, format: 'png' | 'jpeg' | 'webp') {
+		return `/role-icons/${roleId}/${roleIcon}.${format}` as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/guild-events/{guild_scheduled_event.id}/{guild_scheduled_event.image}.{png|jpeg|webp}`
+	 */
+	guildScheduledEventCover(
+		guildScheduledEventId: Snowflake,
+		guildScheduledEventCoverImage: string,
+		format: 'png' | 'jpeg' | 'webp',
+	) {
+		return `/guild-events/${guildScheduledEventId}/${guildScheduledEventCoverImage}.${format}` as const;
+	},
+};
+
 export const RouteBases = {
 	api: `https://discord.com/api/v${APIVersion}`,
 	cdn: 'https://cdn.discordapp.com',

--- a/rest/v9/index.ts
+++ b/rest/v9/index.ts
@@ -862,7 +862,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	emoji(emojiId: Snowflake, format: Exclude<ImageFormat, ImageFormat.Lottie>) {
+	emoji(emojiId: Snowflake, format: CDNFormats['Emoji']) {
 		return `/emojis/${emojiId}.${format}` as const;
 	},
 
@@ -874,7 +874,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildIcon(guildId: Snowflake, guildIcon: string, format: Exclude<ImageFormat, ImageFormat.Lottie>) {
+	guildIcon(guildId: Snowflake, guildIcon: string, format: CDNFormats['GuildIcon']) {
 		return `icons/${guildId}/${guildIcon}.${format}` as const;
 	},
 
@@ -884,11 +884,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildSplash(
-		guildId: Snowflake,
-		guildSplash: string,
-		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
-	) {
+	guildSplash(guildId: Snowflake, guildSplash: string, format: CDNFormats['GuildSplash']) {
 		return `/splashes/${guildId}/${guildSplash}.${format}` as const;
 	},
 
@@ -898,11 +894,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildDiscoverySplash(
-		guildId: Snowflake,
-		guildDiscoverySplash: string,
-		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
-	) {
+	guildDiscoverySplash(guildId: Snowflake, guildDiscoverySplash: string, format: CDNFormats['GuildDiscoverySplash']) {
 		return `/discovery-splashes/${guildId}/${guildDiscoverySplash}.${format}` as const;
 	},
 
@@ -914,7 +906,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildBanner(guildId: Snowflake, guildBanner: string, format: Exclude<ImageFormat, ImageFormat.Lottie>) {
+	guildBanner(guildId: Snowflake, guildBanner: string, format: CDNFormats['GuildBanner']) {
 		return `/banners/${guildId}/${guildBanner}.${format}` as const;
 	},
 
@@ -926,7 +918,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	userBanner(userId: Snowflake, userBanner: string, format: Exclude<ImageFormat, ImageFormat.Lottie>) {
+	userBanner(userId: Snowflake, userBanner: string, format: CDNFormats['UserBanner']) {
 		return `/banners/${userId}/${userBanner}.${format}` as const;
 	},
 
@@ -950,7 +942,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	userAvatar(userId: Snowflake, userAvatar: string, format: Exclude<ImageFormat, ImageFormat.Lottie>) {
+	userAvatar(userId: Snowflake, userAvatar: string, format: CDNFormats['UserAvatar']) {
 		return `/avatars/${userId}/${userAvatar}.${format}` as const;
 	},
 
@@ -966,7 +958,7 @@ export const CDNRoutes = {
 		guildId: Snowflake,
 		userId: Snowflake,
 		memberAvatar: string,
-		format: Exclude<ImageFormat, ImageFormat.Lottie>,
+		format: CDNFormats['GuildMemberAvatar'],
 	) {
 		return `/guilds/${guildId}/users/${userId}/avatars/${memberAvatar}.${format}` as const;
 	},
@@ -977,11 +969,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationIcon(
-		applicationId: Snowflake,
-		applicationIcon: string,
-		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
-	) {
+	applicationIcon(applicationId: Snowflake, applicationIcon: string, format: CDNFormats['ApplicationIcon']) {
 		return `/app-icons/${applicationId}/${applicationIcon}.${format}` as const;
 	},
 
@@ -991,11 +979,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationCover(
-		applicationId: Snowflake,
-		applicationCoverImage: string,
-		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
-	) {
+	applicationCover(applicationId: Snowflake, applicationCoverImage: string, format: CDNFormats['ApplicationCover']) {
 		return `/app-icons/${applicationId}/${applicationCoverImage}.${format}` as const;
 	},
 
@@ -1005,11 +989,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationAsset(
-		applicationId: Snowflake,
-		applicationAssetId: string,
-		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
-	) {
+	applicationAsset(applicationId: Snowflake, applicationAssetId: string, format: CDNFormats['ApplicationAsset']) {
 		return `/app-icons/${applicationId}/${applicationAssetId}.${format}` as const;
 	},
 
@@ -1023,7 +1003,7 @@ export const CDNRoutes = {
 		applicationId: Snowflake,
 		achievementId: Snowflake,
 		achievementIconHash: string,
-		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
+		format: CDNFormats['AchievementIcon'],
 	) {
 		return `/app-assets/${applicationId}/achievements/${achievementId}/icons/${achievementIconHash}.${format}` as const;
 	},
@@ -1034,10 +1014,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	stickerPackBanner(
-		stickerPackBannerAssetId: Snowflake,
-		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
-	) {
+	stickerPackBanner(stickerPackBannerAssetId: Snowflake, format: CDNFormats['StickerPackBanner']) {
 		return `app-assets/710982414301790216/store/${stickerPackBannerAssetId}.${format}` as const;
 	},
 
@@ -1047,7 +1024,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	teamIcon(teamId: Snowflake, teamIcon: string, format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>) {
+	teamIcon(teamId: Snowflake, teamIcon: string, format: CDNFormats['TeamIcon']) {
 		return `/team-icons/${teamId}/${teamIcon}.${format}` as const;
 	},
 
@@ -1057,7 +1034,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, Lottie
 	 */
-	sticker(stickerId: Snowflake, format: Extract<ImageFormat, ImageFormat.PNG | ImageFormat.Lottie>) {
+	sticker(stickerId: Snowflake, format: CDNFormats['Sticker']) {
 		return `/stickers/${stickerId}.${format}` as const;
 	},
 
@@ -1067,7 +1044,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	roleIcon(roleId: Snowflake, roleIcon: string, format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>) {
+	roleIcon(roleId: Snowflake, roleIcon: string, format: CDNFormats['RoleIcon']) {
 		return `/role-icons/${roleId}/${roleIcon}.${format}` as const;
 	},
 
@@ -1080,7 +1057,7 @@ export const CDNRoutes = {
 	guildScheduledEventCover(
 		guildScheduledEventId: Snowflake,
 		guildScheduledEventCoverImage: string,
-		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
+		format: CDNFormats['GuildScheduledEventCover'],
 	) {
 		return `/guild-events/${guildScheduledEventId}/${guildScheduledEventCoverImage}.${format}` as const;
 	},
@@ -1095,11 +1072,33 @@ export const CDNRoutes = {
 		guildId: Snowflake,
 		userId: Snowflake,
 		guildMemberBanner: string,
-		format: Exclude<ImageFormat, ImageFormat.Lottie>,
+		format: CDNFormats['GuildMemberBanner'],
 	) {
 		return `/guilds/${guildId}/users/${userId}/banners/${guildMemberBanner}.${format}` as const;
 	},
 };
+
+export interface CDNFormats {
+	Emoji: Exclude<ImageFormat, ImageFormat.Lottie>;
+	GuildIcon: Exclude<ImageFormat, ImageFormat.Lottie>;
+	GuildSplash: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+	GuildDiscoverySplash: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+	GuildBanner: Exclude<ImageFormat, ImageFormat.Lottie>;
+	UserBanner: Exclude<ImageFormat, ImageFormat.Lottie>;
+	DefaultUserAvatar: Extract<ImageFormat, ImageFormat.PNG>;
+	UserAvatar: Exclude<ImageFormat, ImageFormat.Lottie>;
+	GuildMemberAvatar: Exclude<ImageFormat, ImageFormat.Lottie>;
+	ApplicationIcon: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+	ApplicationCover: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+	ApplicationAsset: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+	AchievementIcon: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+	StickerPackBanner: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+	TeamIcon: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+	Sticker: Extract<ImageFormat, ImageFormat.PNG | ImageFormat.Lottie>;
+	RoleIcon: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+	GuildScheduledEventCover: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+	GuildMemberBanner: Exclude<ImageFormat, ImageFormat.Lottie>;
+}
 
 export enum ImageFormat {
 	JPEG = 'jpeg',

--- a/rest/v9/index.ts
+++ b/rest/v9/index.ts
@@ -862,7 +862,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	emoji(emojiId: Snowflake, format: CDNFormats['Emoji']) {
+	emoji(emojiId: Snowflake, format: EmojiFormat) {
 		return `/emojis/${emojiId}.${format}` as const;
 	},
 
@@ -874,7 +874,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildIcon(guildId: Snowflake, guildIcon: string, format: CDNFormats['GuildIcon']) {
+	guildIcon(guildId: Snowflake, guildIcon: string, format: GuildIconFormat) {
 		return `icons/${guildId}/${guildIcon}.${format}` as const;
 	},
 
@@ -884,7 +884,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildSplash(guildId: Snowflake, guildSplash: string, format: CDNFormats['GuildSplash']) {
+	guildSplash(guildId: Snowflake, guildSplash: string, format: GuildSplashFormat) {
 		return `/splashes/${guildId}/${guildSplash}.${format}` as const;
 	},
 
@@ -894,7 +894,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildDiscoverySplash(guildId: Snowflake, guildDiscoverySplash: string, format: CDNFormats['GuildDiscoverySplash']) {
+	guildDiscoverySplash(guildId: Snowflake, guildDiscoverySplash: string, format: GuildDiscoverySplashFormat) {
 		return `/discovery-splashes/${guildId}/${guildDiscoverySplash}.${format}` as const;
 	},
 
@@ -906,7 +906,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildBanner(guildId: Snowflake, guildBanner: string, format: CDNFormats['GuildBanner']) {
+	guildBanner(guildId: Snowflake, guildBanner: string, format: GuildBannerFormat) {
 		return `/banners/${guildId}/${guildBanner}.${format}` as const;
 	},
 
@@ -918,7 +918,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	userBanner(userId: Snowflake, userBanner: string, format: CDNFormats['UserBanner']) {
+	userBanner(userId: Snowflake, userBanner: string, format: UserBannerFormat) {
 		return `/banners/${userId}/${userBanner}.${format}` as const;
 	},
 
@@ -942,7 +942,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	userAvatar(userId: Snowflake, userAvatar: string, format: CDNFormats['UserAvatar']) {
+	userAvatar(userId: Snowflake, userAvatar: string, format: UserAvatarFormat) {
 		return `/avatars/${userId}/${userAvatar}.${format}` as const;
 	},
 
@@ -954,12 +954,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildMemberAvatar(
-		guildId: Snowflake,
-		userId: Snowflake,
-		memberAvatar: string,
-		format: CDNFormats['GuildMemberAvatar'],
-	) {
+	guildMemberAvatar(guildId: Snowflake, userId: Snowflake, memberAvatar: string, format: GuildMemberAvatarFormat) {
 		return `/guilds/${guildId}/users/${userId}/avatars/${memberAvatar}.${format}` as const;
 	},
 
@@ -969,7 +964,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationIcon(applicationId: Snowflake, applicationIcon: string, format: CDNFormats['ApplicationIcon']) {
+	applicationIcon(applicationId: Snowflake, applicationIcon: string, format: ApplicationIconFormat) {
 		return `/app-icons/${applicationId}/${applicationIcon}.${format}` as const;
 	},
 
@@ -979,7 +974,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationCover(applicationId: Snowflake, applicationCoverImage: string, format: CDNFormats['ApplicationCover']) {
+	applicationCover(applicationId: Snowflake, applicationCoverImage: string, format: ApplicationCoverFormat) {
 		return `/app-icons/${applicationId}/${applicationCoverImage}.${format}` as const;
 	},
 
@@ -989,7 +984,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationAsset(applicationId: Snowflake, applicationAssetId: string, format: CDNFormats['ApplicationAsset']) {
+	applicationAsset(applicationId: Snowflake, applicationAssetId: string, format: ApplicationAssetFormat) {
 		return `/app-icons/${applicationId}/${applicationAssetId}.${format}` as const;
 	},
 
@@ -1003,7 +998,7 @@ export const CDNRoutes = {
 		applicationId: Snowflake,
 		achievementId: Snowflake,
 		achievementIconHash: string,
-		format: CDNFormats['AchievementIcon'],
+		format: AchievementIconFormat,
 	) {
 		return `/app-assets/${applicationId}/achievements/${achievementId}/icons/${achievementIconHash}.${format}` as const;
 	},
@@ -1014,7 +1009,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	stickerPackBanner(stickerPackBannerAssetId: Snowflake, format: CDNFormats['StickerPackBanner']) {
+	stickerPackBanner(stickerPackBannerAssetId: Snowflake, format: StickerPackBannerFormat) {
 		return `app-assets/710982414301790216/store/${stickerPackBannerAssetId}.${format}` as const;
 	},
 
@@ -1024,7 +1019,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	teamIcon(teamId: Snowflake, teamIcon: string, format: CDNFormats['TeamIcon']) {
+	teamIcon(teamId: Snowflake, teamIcon: string, format: TeamIconFormat) {
 		return `/team-icons/${teamId}/${teamIcon}.${format}` as const;
 	},
 
@@ -1034,7 +1029,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, Lottie
 	 */
-	sticker(stickerId: Snowflake, format: CDNFormats['Sticker']) {
+	sticker(stickerId: Snowflake, format: StickerFormat) {
 		return `/stickers/${stickerId}.${format}` as const;
 	},
 
@@ -1044,7 +1039,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	roleIcon(roleId: Snowflake, roleIcon: string, format: CDNFormats['RoleIcon']) {
+	roleIcon(roleId: Snowflake, roleIcon: string, format: RoleIconFormat) {
 		return `/role-icons/${roleId}/${roleIcon}.${format}` as const;
 	},
 
@@ -1057,7 +1052,7 @@ export const CDNRoutes = {
 	guildScheduledEventCover(
 		guildScheduledEventId: Snowflake,
 		guildScheduledEventCoverImage: string,
-		format: CDNFormats['GuildScheduledEventCover'],
+		format: GuildScheduledEventCoverFormat,
 	) {
 		return `/guild-events/${guildScheduledEventId}/${guildScheduledEventCoverImage}.${format}` as const;
 	},
@@ -1068,37 +1063,30 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildMemberBanner(
-		guildId: Snowflake,
-		userId: Snowflake,
-		guildMemberBanner: string,
-		format: CDNFormats['GuildMemberBanner'],
-	) {
+	guildMemberBanner(guildId: Snowflake, userId: Snowflake, guildMemberBanner: string, format: GuildMemberBannerFormat) {
 		return `/guilds/${guildId}/users/${userId}/banners/${guildMemberBanner}.${format}` as const;
 	},
 };
 
-export interface CDNFormats {
-	Emoji: Exclude<ImageFormat, ImageFormat.Lottie>;
-	GuildIcon: Exclude<ImageFormat, ImageFormat.Lottie>;
-	GuildSplash: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
-	GuildDiscoverySplash: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
-	GuildBanner: Exclude<ImageFormat, ImageFormat.Lottie>;
-	UserBanner: Exclude<ImageFormat, ImageFormat.Lottie>;
-	DefaultUserAvatar: Extract<ImageFormat, ImageFormat.PNG>;
-	UserAvatar: Exclude<ImageFormat, ImageFormat.Lottie>;
-	GuildMemberAvatar: Exclude<ImageFormat, ImageFormat.Lottie>;
-	ApplicationIcon: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
-	ApplicationCover: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
-	ApplicationAsset: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
-	AchievementIcon: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
-	StickerPackBanner: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
-	TeamIcon: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
-	Sticker: Extract<ImageFormat, ImageFormat.PNG | ImageFormat.Lottie>;
-	RoleIcon: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
-	GuildScheduledEventCover: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
-	GuildMemberBanner: Exclude<ImageFormat, ImageFormat.Lottie>;
-}
+export type EmojiFormat = Exclude<ImageFormat, ImageFormat.Lottie>;
+export type GuildIconFormat = Exclude<ImageFormat, ImageFormat.Lottie>;
+export type GuildSplashFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+export type GuildDiscoverySplashFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+export type GuildBannerFormat = Exclude<ImageFormat, ImageFormat.Lottie>;
+export type UserBannerFormat = Exclude<ImageFormat, ImageFormat.Lottie>;
+export type DefaultUserAvatar = Extract<ImageFormat, ImageFormat.PNG>;
+export type UserAvatarFormat = Exclude<ImageFormat, ImageFormat.Lottie>;
+export type GuildMemberAvatarFormat = Exclude<ImageFormat, ImageFormat.Lottie>;
+export type ApplicationIconFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+export type ApplicationCoverFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+export type ApplicationAssetFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+export type AchievementIconFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+export type StickerPackBannerFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+export type TeamIconFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+export type StickerFormat = Extract<ImageFormat, ImageFormat.PNG | ImageFormat.Lottie>;
+export type RoleIconFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+export type GuildScheduledEventCoverFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+export type GuildMemberBannerFormat = Exclude<ImageFormat, ImageFormat.Lottie>;
 
 export enum ImageFormat {
 	JPEG = 'jpeg',
@@ -1106,6 +1094,15 @@ export enum ImageFormat {
 	WebP = 'webp',
 	GIF = 'gif',
 	Lottie = 'json',
+}
+
+export interface CDNQuery {
+	/**
+	 * The returned image can have the size changed by using this query parameter
+	 *
+	 * Image size can be any power of two between 16 and 4096
+	 */
+	size?: number;
 }
 
 export const RouteBases = {

--- a/rest/v9/index.ts
+++ b/rest/v9/index.ts
@@ -862,7 +862,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	emoji(emojiId: Snowflake, format: ImageFormat) {
+	emoji(emojiId: Snowflake, format: Exclude<ImageFormat, ImageFormat.Lottie>) {
 		return `/emojis/${emojiId}.${format}` as const;
 	},
 
@@ -874,7 +874,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildIcon(guildId: Snowflake, guildIcon: string, format: ImageFormat) {
+	guildIcon(guildId: Snowflake, guildIcon: string, format: Exclude<ImageFormat, ImageFormat.Lottie>) {
 		return `icons/${guildId}/${guildIcon}.${format}` as const;
 	},
 
@@ -884,7 +884,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildSplash(guildId: Snowflake, guildSplash: string, format: ImageFormat) {
+	guildSplash(
+		guildId: Snowflake,
+		guildSplash: string,
+		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
+	) {
 		return `/splashes/${guildId}/${guildSplash}.${format}` as const;
 	},
 
@@ -894,7 +898,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildDiscoverySplash(guildId: Snowflake, guildDiscoverySplash: string, format: ImageFormat) {
+	guildDiscoverySplash(
+		guildId: Snowflake,
+		guildDiscoverySplash: string,
+		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
+	) {
 		return `/discovery-splashes/${guildId}/${guildDiscoverySplash}.${format}` as const;
 	},
 
@@ -906,7 +914,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildBanner(guildId: Snowflake, guildBanner: string, format: ImageFormat) {
+	guildBanner(guildId: Snowflake, guildBanner: string, format: Exclude<ImageFormat, ImageFormat.Lottie>) {
 		return `/banners/${guildId}/${guildBanner}.${format}` as const;
 	},
 
@@ -918,7 +926,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	userBanner(userId: Snowflake, userBanner: string, format: ImageFormat) {
+	userBanner(userId: Snowflake, userBanner: string, format: Exclude<ImageFormat, ImageFormat.Lottie>) {
 		return `/banners/${userId}/${userBanner}.${format}` as const;
 	},
 
@@ -942,7 +950,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	userAvatar(userId: Snowflake, userAvatar: string, format: ImageFormat) {
+	userAvatar(userId: Snowflake, userAvatar: string, format: Exclude<ImageFormat, ImageFormat.Lottie>) {
 		return `/avatars/${userId}/${userAvatar}.${format}` as const;
 	},
 
@@ -954,7 +962,12 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildMemberAvatar(guildId: Snowflake, userId: Snowflake, memberAvatar: string, format: ImageFormat) {
+	guildMemberAvatar(
+		guildId: Snowflake,
+		userId: Snowflake,
+		memberAvatar: string,
+		format: Exclude<ImageFormat, ImageFormat.Lottie>,
+	) {
 		return `/guilds/${guildId}/users/${userId}/avatars/${memberAvatar}.${format}` as const;
 	},
 
@@ -964,7 +977,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationIcon(applicationId: Snowflake, applicationIcon: string, format: ImageFormat) {
+	applicationIcon(
+		applicationId: Snowflake,
+		applicationIcon: string,
+		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
+	) {
 		return `/app-icons/${applicationId}/${applicationIcon}.${format}` as const;
 	},
 
@@ -974,7 +991,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationCover(applicationId: Snowflake, applicationCoverImage: string, format: ImageFormat) {
+	applicationCover(
+		applicationId: Snowflake,
+		applicationCoverImage: string,
+		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
+	) {
 		return `/app-icons/${applicationId}/${applicationCoverImage}.${format}` as const;
 	},
 
@@ -984,7 +1005,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationAsset(applicationId: Snowflake, applicationAssetId: string, format: ImageFormat) {
+	applicationAsset(
+		applicationId: Snowflake,
+		applicationAssetId: string,
+		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
+	) {
 		return `/app-icons/${applicationId}/${applicationAssetId}.${format}` as const;
 	},
 
@@ -998,7 +1023,7 @@ export const CDNRoutes = {
 		applicationId: Snowflake,
 		achievementId: Snowflake,
 		achievementIconHash: string,
-		format: ImageFormat,
+		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
 	) {
 		return `/app-assets/${applicationId}/achievements/${achievementId}/icons/${achievementIconHash}.${format}` as const;
 	},
@@ -1009,7 +1034,10 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	stickerPackBanner(stickerPackBannerAssetId: Snowflake, format: ImageFormat) {
+	stickerPackBanner(
+		stickerPackBannerAssetId: Snowflake,
+		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
+	) {
 		return `app-assets/710982414301790216/store/${stickerPackBannerAssetId}.${format}` as const;
 	},
 
@@ -1019,7 +1047,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	teamIcon(teamId: Snowflake, teamIcon: string, format: ImageFormat) {
+	teamIcon(teamId: Snowflake, teamIcon: string, format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>) {
 		return `/team-icons/${teamId}/${teamIcon}.${format}` as const;
 	},
 
@@ -1029,7 +1057,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, Lottie
 	 */
-	sticker(stickerId: Snowflake, format: ImageFormat) {
+	sticker(stickerId: Snowflake, format: Extract<ImageFormat, ImageFormat.PNG | ImageFormat.Lottie>) {
 		return `/stickers/${stickerId}.${format}` as const;
 	},
 
@@ -1039,7 +1067,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	roleIcon(roleId: Snowflake, roleIcon: string, format: ImageFormat) {
+	roleIcon(roleId: Snowflake, roleIcon: string, format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>) {
 		return `/role-icons/${roleId}/${roleIcon}.${format}` as const;
 	},
 
@@ -1052,7 +1080,7 @@ export const CDNRoutes = {
 	guildScheduledEventCover(
 		guildScheduledEventId: Snowflake,
 		guildScheduledEventCoverImage: string,
-		format: ImageFormat,
+		format: Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>,
 	) {
 		return `/guild-events/${guildScheduledEventId}/${guildScheduledEventCoverImage}.${format}` as const;
 	},
@@ -1063,7 +1091,12 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildMemberBanner(guildId: Snowflake, userId: Snowflake, guildMemberBanner: string, format: ImageFormat) {
+	guildMemberBanner(
+		guildId: Snowflake,
+		userId: Snowflake,
+		guildMemberBanner: string,
+		format: Exclude<ImageFormat, ImageFormat.Lottie>,
+	) {
 		return `/guilds/${guildId}/users/${userId}/banners/${guildMemberBanner}.${format}` as const;
 	},
 };

--- a/rest/v9/index.ts
+++ b/rest/v9/index.ts
@@ -859,8 +859,10 @@ export const CDNRoutes = {
 	 * - GET `/emojis/{emoji.id}.{png|jpeg|webp|gif}`
 	 *
 	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	emoji(emojiId: Snowflake, format: 'png' | 'jpeg' | 'webp' | 'gif') {
+	emoji(emojiId: Snowflake, format: ImageFormat) {
 		return `/emojis/${emojiId}.${format}` as const;
 	},
 
@@ -869,24 +871,30 @@ export const CDNRoutes = {
 	 * - GET `/guilds/{guild.id}/icons/{guild.id}.{png|jpeg|webp|gif}`
 	 *
 	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildIcon(guildId: Snowflake, guildIcon: string, format: 'png' | 'jpeg' | 'webp' | 'gif') {
+	guildIcon(guildId: Snowflake, guildIcon: string, format: ImageFormat) {
 		return `icons/${guildId}/${guildIcon}.${format}` as const;
 	},
 
 	/**
 	 * Route for:
 	 * - GET `/splashes/{guild.id}/{guild.splash}.{png|jpeg|webp}`
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildSplash(guildId: Snowflake, guildSplash: string, format: 'png' | 'jpeg' | 'webp') {
+	guildSplash(guildId: Snowflake, guildSplash: string, format: ImageFormat) {
 		return `/splashes/${guildId}/${guildSplash}.${format}` as const;
 	},
 
 	/**
 	 * Route for:
 	 * - GET `/discovery-splashes/{guild.id}/{guild.discovery_splash}.{png|jpeg|webp}`
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildDiscoverySplash(guildId: Snowflake, guildDiscoverySplash: string, format: 'png' | 'jpeg' | 'webp') {
+	guildDiscoverySplash(guildId: Snowflake, guildDiscoverySplash: string, format: ImageFormat) {
 		return `/discovery-splashes/${guildId}/${guildDiscoverySplash}.${format}` as const;
 	},
 
@@ -895,8 +903,10 @@ export const CDNRoutes = {
 	 * - GET `/banners/{guild.id}/{guild.banner}.{png|jpeg|webp|gif}`
 	 *
 	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildBanner(guildId: Snowflake, guildBanner: string, format: 'png' | 'jpeg' | 'webp' | 'gif') {
+	guildBanner(guildId: Snowflake, guildBanner: string, format: ImageFormat) {
 		return `/banners/${guildId}/${guildBanner}.${format}` as const;
 	},
 
@@ -905,8 +915,10 @@ export const CDNRoutes = {
 	 * - GET `/banners/{user.id}/{user.banner}.{png|jpeg|webp|gif}`
 	 *
 	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	userBanner(userId: Snowflake, userBanner: string, format: 'png' | 'jpeg' | 'webp' | 'gif') {
+	userBanner(userId: Snowflake, userBanner: string, format: ImageFormat) {
 		return `/banners/${userId}/${userBanner}.${format}` as const;
 	},
 
@@ -916,9 +928,9 @@ export const CDNRoutes = {
 	 *
 	 * The `userDiscriminator` parameter should be the user discriminator modulo 5 (e.g. 1337 % 5 = 2)
 	 *
-	 * The numbers range from only 0 to 5
+	 * This route supports the extension: PNG
 	 */
-	defaultUserAvatar(userDiscriminator: number) {
+	defaultUserAvatar(userDiscriminator: 0 | 1 | 2 | 3 | 4 | 5) {
 		return `/embed/avatars/${userDiscriminator}.png` as const;
 	},
 
@@ -927,8 +939,10 @@ export const CDNRoutes = {
 	 * - GET `/avatars/{user.id}/{user.avatar}.{png|jpeg|webp|gif}`
 	 *
 	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	userAvatar(userId: Snowflake, userAvatar: string, format: 'png' | 'jpeg' | 'webp' | 'gif') {
+	userAvatar(userId: Snowflake, userAvatar: string, format: ImageFormat) {
 		return `/avatars/${userId}/${userAvatar}.${format}` as const;
 	},
 
@@ -937,49 +951,54 @@ export const CDNRoutes = {
 	 * - GET `/guilds/{guild.id}/users/{user.id}/{guild_member.avatar}.{png|jpeg|webp|gif}`
 	 *
 	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildMemberAvatar(
-		guildId: Snowflake,
-		userId: Snowflake,
-		memberAvatar: string,
-		format: 'png' | 'jpeg' | 'webp' | 'gif',
-	) {
+	guildMemberAvatar(guildId: Snowflake, userId: Snowflake, memberAvatar: string, format: ImageFormat) {
 		return `/guilds/${guildId}/users/${userId}/avatars/${memberAvatar}.${format}` as const;
 	},
 
 	/**
 	 * Route for:
 	 * - GET `/app-icons/{application.id}/{application.icon}.{png|jpeg|webp}`
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationIcon(applicationId: Snowflake, applicationIcon: string, format: 'png' | 'jpeg' | 'webp') {
+	applicationIcon(applicationId: Snowflake, applicationIcon: string, format: ImageFormat) {
 		return `/app-icons/${applicationId}/${applicationIcon}.${format}` as const;
 	},
 
 	/**
 	 * Route for:
 	 * - GET `/app-icons/{application.id}/{application.cover_image}.{png|jpeg|webp}`
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationCover(applicationId: Snowflake, applicationCoverImage: string, format: 'png' | 'jpeg' | 'webp') {
+	applicationCover(applicationId: Snowflake, applicationCoverImage: string, format: ImageFormat) {
 		return `/app-icons/${applicationId}/${applicationCoverImage}.${format}` as const;
 	},
 
 	/**
 	 * Route for:
 	 * - GET `/app-icons/{application.id}/{application.asset_id}.{png|jpeg|webp}`
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationAsset(applicationId: Snowflake, applicationAssetId: string, format: 'png' | 'jpeg' | 'webp') {
+	applicationAsset(applicationId: Snowflake, applicationAssetId: string, format: ImageFormat) {
 		return `/app-icons/${applicationId}/${applicationAssetId}.${format}` as const;
 	},
 
 	/**
 	 * Route for:
 	 * - GET `/app-assets/{application.id}/achievements/{achievement.id}/icons/{achievement.icon}.{png|jpeg|webp}`
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
 	achievementIcon(
 		applicationId: Snowflake,
 		achievementId: Snowflake,
 		achievementIconHash: string,
-		format: 'png' | 'jpeg' | 'webp',
+		format: ImageFormat,
 	) {
 		return `/app-assets/${applicationId}/achievements/${achievementId}/icons/${achievementIconHash}.${format}` as const;
 	},
@@ -987,47 +1006,75 @@ export const CDNRoutes = {
 	/**
 	 * Route for:
 	 * - GET `/app-assets/710982414301790216/store/{sticker_pack.banner.asset_id}.{png|jpeg|webp}`
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	stickerPackBanner(stickerPackBannerAssetId: Snowflake, format: 'png' | 'jpeg' | 'webp') {
+	stickerPackBanner(stickerPackBannerAssetId: Snowflake, format: ImageFormat) {
 		return `app-assets/710982414301790216/store/${stickerPackBannerAssetId}.${format}` as const;
 	},
 
 	/**
 	 * Route for:
 	 * - GET `team-icons/{team.id}/{team.icon}.{png|jpeg|webp}`
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	teamIcon(teamId: Snowflake, teamIcon: string, format: 'png' | 'jpeg' | 'webp') {
+	teamIcon(teamId: Snowflake, teamIcon: string, format: ImageFormat) {
 		return `/team-icons/${teamId}/${teamIcon}.${format}` as const;
 	},
 
 	/**
 	 * Route for:
 	 * - GET `/stickers/{sticker.id}.{png|json}`
+	 *
+	 * This route supports the extensions: PNG, Lottie
 	 */
-	sticker(stickerId: Snowflake, format: 'png' | 'json') {
+	sticker(stickerId: Snowflake, format: ImageFormat) {
 		return `/stickers/${stickerId}.${format}` as const;
 	},
 
 	/**
 	 * Route for:
 	 * - GET `/role-icons/{role.id}/{role.icon}.{png|jpeg|webp}`
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	roleIcon(roleId: Snowflake, roleIcon: string, format: 'png' | 'jpeg' | 'webp') {
+	roleIcon(roleId: Snowflake, roleIcon: string, format: ImageFormat) {
 		return `/role-icons/${roleId}/${roleIcon}.${format}` as const;
 	},
 
 	/**
 	 * Route for:
 	 * - GET `/guild-events/{guild_scheduled_event.id}/{guild_scheduled_event.image}.{png|jpeg|webp}`
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
 	guildScheduledEventCover(
 		guildScheduledEventId: Snowflake,
 		guildScheduledEventCoverImage: string,
-		format: 'png' | 'jpeg' | 'webp',
+		format: ImageFormat,
 	) {
 		return `/guild-events/${guildScheduledEventId}/${guildScheduledEventCoverImage}.${format}` as const;
 	},
+
+	/**
+	 * Route for:
+	 * - GET `/guilds/${guild.id}/users/${user.id}/banners/${guild_member.banner}.{png|jpeg|webp|gif}`
+	 *
+	 * This route supports the extensions: PNG, JPEG, WebP, GIF
+	 */
+	guildMemberBanner(guildId: Snowflake, userId: Snowflake, guildMemberBanner: string, format: ImageFormat) {
+		return `/guilds/${guildId}/users/${userId}/banners/${guildMemberBanner}.${format}` as const;
+	},
 };
+
+export enum ImageFormat {
+	JPEG = 'jpeg',
+	PNG = 'png',
+	WebP = 'webp',
+	GIF = 'gif',
+	Lottie = 'json',
+}
 
 export const RouteBases = {
 	api: `https://discord.com/api/v${APIVersion}`,

--- a/rest/v9/index.ts
+++ b/rest/v9/index.ts
@@ -860,7 +860,7 @@ export const CDNRoutes = {
 	 *
 	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
 	 */
-	customEmoji(emojiId: Snowflake, format: 'png' | 'jpeg' | 'webp' | 'gif') {
+	emoji(emojiId: Snowflake, format: 'png' | 'jpeg' | 'webp' | 'gif') {
 		return `/emojis/${emojiId}.${format}` as const;
 	},
 
@@ -915,8 +915,10 @@ export const CDNRoutes = {
 	 * - GET `/embed/avatars/{user.discriminator % 5}.png`
 	 *
 	 * The `userDiscriminator` parameter should be the user discriminator modulo 5 (e.g. 1337 % 5 = 2)
+	 *
+	 * The numbers range from only 0 to 5
 	 */
-	defaultUserAvatar(userDiscriminator: Snowflake) {
+	defaultUserAvatar(userDiscriminator: number) {
 		return `/embed/avatars/${userDiscriminator}.png` as const;
 	},
 

--- a/rest/v9/index.ts
+++ b/rest/v9/index.ts
@@ -853,6 +853,8 @@ export const Routes = {
 	},
 };
 
+export const StickerPackApplicationId = '710982414301790216';
+
 export const CDNRoutes = {
 	/**
 	 * Route for:
@@ -930,7 +932,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extension: PNG
 	 */
-	defaultUserAvatar(userDiscriminator: 0 | 1 | 2 | 3 | 4 | 5) {
+	defaultUserAvatar(userDiscriminator: DefaultUserAvatarAssets) {
 		return `/embed/avatars/${userDiscriminator}.png` as const;
 	},
 
@@ -1010,7 +1012,7 @@ export const CDNRoutes = {
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
 	stickerPackBanner(stickerPackBannerAssetId: Snowflake, format: StickerPackBannerFormat) {
-		return `app-assets/710982414301790216/store/${stickerPackBannerAssetId}.${format}` as const;
+		return `/app-assets/${StickerPackApplicationId}/store/${stickerPackBannerAssetId}.${format}` as const;
 	},
 
 	/**
@@ -1067,6 +1069,8 @@ export const CDNRoutes = {
 		return `/guilds/${guildId}/users/${userId}/banners/${guildMemberBanner}.${format}` as const;
 	},
 };
+
+export type DefaultUserAvatarAssets = 0 | 1 | 2 | 3 | 4 | 5;
 
 export type EmojiFormat = Exclude<ImageFormat, ImageFormat.Lottie>;
 export type GuildIconFormat = Exclude<ImageFormat, ImageFormat.Lottie>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Adds the constant `CDNRoutes`, that contains each CDN entpoint from [DDevs Portal](https://discord.com/developers/docs/reference#image-formatting-cdn-endpoints). Made it because of https://github.com/discordjs/discord-api-types/pull/453#issuecomment-1139164200. With this, many other things are being added: `ImageFormats`, `CDNQuery` and `*Format` types.

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
