### PR TITLE
feat(APIApplicationCommandStringOption): add `min_length` and `max_length`

### DIFF
--- a/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/string.ts
+++ b/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/string.ts
@@ -8,7 +8,7 @@ import type { APIApplicationCommandOptionChoice, ApplicationCommandOptionType } 
 interface APIApplicationCommandStringOptionBase
 	extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.String> {
 	/**
-	 * For option type `STRING`, the minimum allowed length (minimum of 1).
+	 * For option type `STRING`, the minimum allowed length (minimum of 0).
 	 */
 	min_length?: number;
 	/**

--- a/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/string.ts
+++ b/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/string.ts
@@ -5,8 +5,20 @@ import type {
 } from './base.ts';
 import type { APIApplicationCommandOptionChoice, ApplicationCommandOptionType } from './shared.ts';
 
+interface APIApplicationCommandStringOptionBase
+	extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.String> {
+	/**
+	 * For option type `STRING`, the minimum allowed length (minimum of 1).
+	 */
+	min_length?: number;
+	/**
+	 * For option type `STRING`, the maximum allowed length (minimum of 1).
+	 */
+	max_length?: number;
+}
+
 export type APIApplicationCommandStringOption = APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper<
-	APIApplicationCommandOptionBase<ApplicationCommandOptionType.String>,
+	APIApplicationCommandStringOptionBase,
 	APIApplicationCommandOptionChoice<string>
 >;
 

--- a/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/string.ts
+++ b/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/string.ts
@@ -8,7 +8,7 @@ import type { APIApplicationCommandOptionChoice, ApplicationCommandOptionType } 
 interface APIApplicationCommandStringOptionBase
 	extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.String> {
 	/**
-	 * For option type `STRING`, the minimum allowed length (minimum of 1).
+	 * For option type `STRING`, the minimum allowed length (minimum of 0).
 	 */
 	min_length?: number;
 	/**

--- a/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/string.ts
+++ b/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/string.ts
@@ -5,8 +5,20 @@ import type {
 } from './base.ts';
 import type { APIApplicationCommandOptionChoice, ApplicationCommandOptionType } from './shared.ts';
 
+interface APIApplicationCommandStringOptionBase
+	extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.String> {
+	/**
+	 * For option type `STRING`, the minimum allowed length (minimum of 1).
+	 */
+	min_length?: number;
+	/**
+	 * For option type `STRING`, the maximum allowed length (minimum of 1).
+	 */
+	max_length?: number;
+}
+
 export type APIApplicationCommandStringOption = APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper<
-	APIApplicationCommandOptionBase<ApplicationCommandOptionType.String>,
+	APIApplicationCommandStringOptionBase,
 	APIApplicationCommandOptionChoice<string>
 >;
 

--- a/payloads/v10/_interactions/_applicationCommands/_chatInput/string.ts
+++ b/payloads/v10/_interactions/_applicationCommands/_chatInput/string.ts
@@ -8,7 +8,7 @@ import type { APIApplicationCommandOptionChoice, ApplicationCommandOptionType } 
 interface APIApplicationCommandStringOptionBase
 	extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.String> {
 	/**
-	 * For option type `STRING`, the minimum allowed length (minimum of 1).
+	 * For option type `STRING`, the minimum allowed length (minimum of 0).
 	 */
 	min_length?: number;
 	/**

--- a/payloads/v10/_interactions/_applicationCommands/_chatInput/string.ts
+++ b/payloads/v10/_interactions/_applicationCommands/_chatInput/string.ts
@@ -5,8 +5,20 @@ import type {
 } from './base';
 import type { APIApplicationCommandOptionChoice, ApplicationCommandOptionType } from './shared';
 
+interface APIApplicationCommandStringOptionBase
+	extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.String> {
+	/**
+	 * For option type `STRING`, the minimum allowed length (minimum of 1).
+	 */
+	min_length?: number;
+	/**
+	 * For option type `STRING`, the maximum allowed length (minimum of 1).
+	 */
+	max_length?: number;
+}
+
 export type APIApplicationCommandStringOption = APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper<
-	APIApplicationCommandOptionBase<ApplicationCommandOptionType.String>,
+	APIApplicationCommandStringOptionBase,
 	APIApplicationCommandOptionChoice<string>
 >;
 

--- a/payloads/v9/_interactions/_applicationCommands/_chatInput/string.ts
+++ b/payloads/v9/_interactions/_applicationCommands/_chatInput/string.ts
@@ -8,7 +8,7 @@ import type { APIApplicationCommandOptionChoice, ApplicationCommandOptionType } 
 interface APIApplicationCommandStringOptionBase
 	extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.String> {
 	/**
-	 * For option type `STRING`, the minimum allowed length (minimum of 1).
+	 * For option type `STRING`, the minimum allowed length (minimum of 0).
 	 */
 	min_length?: number;
 	/**

--- a/payloads/v9/_interactions/_applicationCommands/_chatInput/string.ts
+++ b/payloads/v9/_interactions/_applicationCommands/_chatInput/string.ts
@@ -5,8 +5,20 @@ import type {
 } from './base';
 import type { APIApplicationCommandOptionChoice, ApplicationCommandOptionType } from './shared';
 
+interface APIApplicationCommandStringOptionBase
+	extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.String> {
+	/**
+	 * For option type `STRING`, the minimum allowed length (minimum of 1).
+	 */
+	min_length?: number;
+	/**
+	 * For option type `STRING`, the maximum allowed length (minimum of 1).
+	 */
+	max_length?: number;
+}
+
 export type APIApplicationCommandStringOption = APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper<
-	APIApplicationCommandOptionBase<ApplicationCommandOptionType.String>,
+	APIApplicationCommandStringOptionBase,
 	APIApplicationCommandOptionChoice<string>
 >;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Adds `min_length` and `max_length` fields to `APIApplicationCommandStringOption`. 
Closes #512.

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**

- https://github.com/discord/discord-api-docs/pull/5143
