### PR TITLE
fix: mark the maxmium allowed length for string option types

### DIFF
--- a/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/string.ts
+++ b/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/string.ts
@@ -8,11 +8,11 @@ import type { APIApplicationCommandOptionChoice, ApplicationCommandOptionType } 
 interface APIApplicationCommandStringOptionBase
 	extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.String> {
 	/**
-	 * For option type `STRING`, the minimum allowed length (minimum of 0).
+	 * For option type `STRING`, the minimum allowed length (minimum of 0, maximum of `6000`).
 	 */
 	min_length?: number;
 	/**
-	 * For option type `STRING`, the maximum allowed length (minimum of 1).
+	 * For option type `STRING`, the maximum allowed length (minimum of 1, maximum of `6000`).
 	 */
 	max_length?: number;
 }

--- a/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/string.ts
+++ b/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/string.ts
@@ -8,11 +8,11 @@ import type { APIApplicationCommandOptionChoice, ApplicationCommandOptionType } 
 interface APIApplicationCommandStringOptionBase
 	extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.String> {
 	/**
-	 * For option type `STRING`, the minimum allowed length (minimum of 0).
+	 * For option type `STRING`, the minimum allowed length (minimum of 0, maximum of `6000`).
 	 */
 	min_length?: number;
 	/**
-	 * For option type `STRING`, the maximum allowed length (minimum of 1).
+	 * For option type `STRING`, the maximum allowed length (minimum of 1, maximum of `6000`).
 	 */
 	max_length?: number;
 }

--- a/payloads/v10/_interactions/_applicationCommands/_chatInput/string.ts
+++ b/payloads/v10/_interactions/_applicationCommands/_chatInput/string.ts
@@ -8,11 +8,11 @@ import type { APIApplicationCommandOptionChoice, ApplicationCommandOptionType } 
 interface APIApplicationCommandStringOptionBase
 	extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.String> {
 	/**
-	 * For option type `STRING`, the minimum allowed length (minimum of 0).
+	 * For option type `STRING`, the minimum allowed length (minimum of 0, maximum of `6000`).
 	 */
 	min_length?: number;
 	/**
-	 * For option type `STRING`, the maximum allowed length (minimum of 1).
+	 * For option type `STRING`, the maximum allowed length (minimum of 1, maximum of `6000`).
 	 */
 	max_length?: number;
 }

--- a/payloads/v9/_interactions/_applicationCommands/_chatInput/string.ts
+++ b/payloads/v9/_interactions/_applicationCommands/_chatInput/string.ts
@@ -8,11 +8,11 @@ import type { APIApplicationCommandOptionChoice, ApplicationCommandOptionType } 
 interface APIApplicationCommandStringOptionBase
 	extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.String> {
 	/**
-	 * For option type `STRING`, the minimum allowed length (minimum of 0).
+	 * For option type `STRING`, the minimum allowed length (minimum of 0, maximum of `6000`).
 	 */
 	min_length?: number;
 	/**
-	 * For option type `STRING`, the maximum allowed length (minimum of 1).
+	 * For option type `STRING`, the maximum allowed length (minimum of 1, maximum of `6000`).
 	 */
 	max_length?: number;
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
add upper limit to string length
**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
https://github.com/discord/discord-api-docs/pull/5150