### PR TITLE
docs(APIApplicationCommandOption): number and integer typos in `max_value` field description

### DIFF
--- a/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/integer.ts
+++ b/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/integer.ts
@@ -12,7 +12,7 @@ interface APIApplicationCommandIntegerOptionBase
 	 */
 	min_value?: number;
 	/**
-	 * If the option is an `INTEGER` or `NUMBER` type, the minimum value permitted.
+	 * If the option is an `INTEGER` or `NUMBER` type, the maximum value permitted.
 	 */
 	max_value?: number;
 }

--- a/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/number.ts
+++ b/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/number.ts
@@ -12,7 +12,7 @@ interface APIApplicationCommandNumberOptionBase
 	 */
 	min_value?: number;
 	/**
-	 * If the option is an `INTEGER` or `NUMBER` type, the minimum value permitted.
+	 * If the option is an `INTEGER` or `NUMBER` type, the maximum value permitted.
 	 */
 	max_value?: number;
 }

--- a/deno/payloads/v8/_interactions/_applicationCommands/_chatInput/integer.ts
+++ b/deno/payloads/v8/_interactions/_applicationCommands/_chatInput/integer.ts
@@ -15,7 +15,7 @@ interface APIApplicationCommandIntegerOptionBase
 	 */
 	min_value?: number;
 	/**
-	 * If the option is an `INTEGER` or `NUMBER` type, the minimum value permitted.
+	 * If the option is an `INTEGER` or `NUMBER` type, the maximum value permitted.
 	 */
 	max_value?: number;
 }

--- a/deno/payloads/v8/_interactions/_applicationCommands/_chatInput/number.ts
+++ b/deno/payloads/v8/_interactions/_applicationCommands/_chatInput/number.ts
@@ -15,7 +15,7 @@ interface APIApplicationCommandNumberOptionBase
 	 */
 	min_value?: number;
 	/**
-	 * If the option is an `INTEGER` or `NUMBER` type, the minimum value permitted.
+	 * If the option is an `INTEGER` or `NUMBER` type, the maximum value permitted.
 	 */
 	max_value?: number;
 }

--- a/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/integer.ts
+++ b/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/integer.ts
@@ -12,7 +12,7 @@ interface APIApplicationCommandIntegerOptionBase
 	 */
 	min_value?: number;
 	/**
-	 * If the option is an `INTEGER` or `NUMBER` type, the minimum value permitted.
+	 * If the option is an `INTEGER` or `NUMBER` type, the maximum value permitted.
 	 */
 	max_value?: number;
 }

--- a/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/number.ts
+++ b/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/number.ts
@@ -12,7 +12,7 @@ interface APIApplicationCommandNumberOptionBase
 	 */
 	min_value?: number;
 	/**
-	 * If the option is an `INTEGER` or `NUMBER` type, the minimum value permitted.
+	 * If the option is an `INTEGER` or `NUMBER` type, the maximum value permitted.
 	 */
 	max_value?: number;
 }

--- a/payloads/v10/_interactions/_applicationCommands/_chatInput/integer.ts
+++ b/payloads/v10/_interactions/_applicationCommands/_chatInput/integer.ts
@@ -12,7 +12,7 @@ interface APIApplicationCommandIntegerOptionBase
 	 */
 	min_value?: number;
 	/**
-	 * If the option is an `INTEGER` or `NUMBER` type, the minimum value permitted.
+	 * If the option is an `INTEGER` or `NUMBER` type, the maximum value permitted.
 	 */
 	max_value?: number;
 }

--- a/payloads/v10/_interactions/_applicationCommands/_chatInput/number.ts
+++ b/payloads/v10/_interactions/_applicationCommands/_chatInput/number.ts
@@ -12,7 +12,7 @@ interface APIApplicationCommandNumberOptionBase
 	 */
 	min_value?: number;
 	/**
-	 * If the option is an `INTEGER` or `NUMBER` type, the minimum value permitted.
+	 * If the option is an `INTEGER` or `NUMBER` type, the maximum value permitted.
 	 */
 	max_value?: number;
 }

--- a/payloads/v8/_interactions/_applicationCommands/_chatInput/integer.ts
+++ b/payloads/v8/_interactions/_applicationCommands/_chatInput/integer.ts
@@ -15,7 +15,7 @@ interface APIApplicationCommandIntegerOptionBase
 	 */
 	min_value?: number;
 	/**
-	 * If the option is an `INTEGER` or `NUMBER` type, the minimum value permitted.
+	 * If the option is an `INTEGER` or `NUMBER` type, the maximum value permitted.
 	 */
 	max_value?: number;
 }

--- a/payloads/v8/_interactions/_applicationCommands/_chatInput/number.ts
+++ b/payloads/v8/_interactions/_applicationCommands/_chatInput/number.ts
@@ -15,7 +15,7 @@ interface APIApplicationCommandNumberOptionBase
 	 */
 	min_value?: number;
 	/**
-	 * If the option is an `INTEGER` or `NUMBER` type, the minimum value permitted.
+	 * If the option is an `INTEGER` or `NUMBER` type, the maximum value permitted.
 	 */
 	max_value?: number;
 }

--- a/payloads/v9/_interactions/_applicationCommands/_chatInput/integer.ts
+++ b/payloads/v9/_interactions/_applicationCommands/_chatInput/integer.ts
@@ -12,7 +12,7 @@ interface APIApplicationCommandIntegerOptionBase
 	 */
 	min_value?: number;
 	/**
-	 * If the option is an `INTEGER` or `NUMBER` type, the minimum value permitted.
+	 * If the option is an `INTEGER` or `NUMBER` type, the maximum value permitted.
 	 */
 	max_value?: number;
 }

--- a/payloads/v9/_interactions/_applicationCommands/_chatInput/number.ts
+++ b/payloads/v9/_interactions/_applicationCommands/_chatInput/number.ts
@@ -12,7 +12,7 @@ interface APIApplicationCommandNumberOptionBase
 	 */
 	min_value?: number;
 	/**
-	 * If the option is an `INTEGER` or `NUMBER` type, the minimum value permitted.
+	 * If the option is an `INTEGER` or `NUMBER` type, the maximum value permitted.
 	 */
 	max_value?: number;
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes a typo on `Number` and `Integer` application command options, in the `max_value` field description (repeated word).

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
