### PR TITLE
docs: update discord channel name

### DIFF
--- a/website/docs/Contributing.mdx
+++ b/website/docs/Contributing.mdx
@@ -18,7 +18,7 @@ We recommend you contribute either through locally editing the files on your des
 
 :::info Still can't figure it out?
 
-No problem! We await you with open hands in our [`Discord Server`](https://discord.gg/djs) in the `#discord-api-types`
+No problem! We await you with open hands in our [`Discord Server`](https://discord.gg/djs) in the `#discord-api-types-help`
 channel (under the `Miscellaneous` category)
 
 :::


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
technically not `#discord-api-types` anymore :mmlol:

![image](https://user-images.githubusercontent.com/53496941/177360867-83e79b77-df69-4abf-a80e-81ecf2dd07c5.png)
