### PR TITLE
refactor: `communication_disabled_until` isn't nullable

### DIFF
--- a/deno/rest/v10/guild.ts
+++ b/deno/rest/v10/guild.ts
@@ -480,7 +480,7 @@ export type RESTPatchAPIGuildMemberJSONBody = AddUndefinedToPossiblyUndefinedPro
 	/**
 	 * Timestamp of when the time out will be removed; until then, they cannot interact with the guild
 	 */
-	communication_disabled_until?: string | null;
+	communication_disabled_until?: string;
 }>;
 
 /**

--- a/deno/rest/v9/guild.ts
+++ b/deno/rest/v9/guild.ts
@@ -480,7 +480,7 @@ export type RESTPatchAPIGuildMemberJSONBody = AddUndefinedToPossiblyUndefinedPro
 	/**
 	 * Timestamp of when the time out will be removed; until then, they cannot interact with the guild
 	 */
-	communication_disabled_until?: string | null;
+	communication_disabled_until?: string;
 }>;
 
 /**

--- a/rest/v10/guild.ts
+++ b/rest/v10/guild.ts
@@ -480,7 +480,7 @@ export type RESTPatchAPIGuildMemberJSONBody = AddUndefinedToPossiblyUndefinedPro
 	/**
 	 * Timestamp of when the time out will be removed; until then, they cannot interact with the guild
 	 */
-	communication_disabled_until?: string | null;
+	communication_disabled_until?: string;
 }>;
 
 /**

--- a/rest/v9/guild.ts
+++ b/rest/v9/guild.ts
@@ -480,7 +480,7 @@ export type RESTPatchAPIGuildMemberJSONBody = AddUndefinedToPossiblyUndefinedPro
 	/**
 	 * Timestamp of when the time out will be removed; until then, they cannot interact with the guild
 	 */
-	communication_disabled_until?: string | null;
+	communication_disabled_until?: string;
 }>;
 
 /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
- https://github.com/discord/discord-api-docs/pull/5164