### PR TITLE
feat(RESTPutAPIApplicationGuildCommandsJSONBody): add missing `id`

### DIFF
--- a/deno/rest/v10/interactions.ts
+++ b/deno/rest/v10/interactions.ts
@@ -129,9 +129,10 @@ export type RESTPatchAPIApplicationGuildCommandResult = Omit<APIApplicationComma
  * https://discord.com/developers/docs/interactions/application-commands#bulk-overwrite-guild-application-commands
  */
 export type RESTPutAPIApplicationGuildCommandsJSONBody = (
-	| Omit<RESTPostAPIChatInputApplicationCommandsJSONBody, 'dm_permission'>
-	| Omit<RESTPostAPIContextMenuApplicationCommandsJSONBody, 'dm_permission'>
-	| Pick<Partial<APIApplicationCommand>, 'id'>
+	| (Omit<RESTPostAPIChatInputApplicationCommandsJSONBody, 'dm_permission'> &
+			Pick<Partial<APIApplicationCommand>, 'id'>)
+	| (Omit<RESTPostAPIContextMenuApplicationCommandsJSONBody, 'dm_permission'> &
+			Pick<Partial<APIApplicationCommand>, 'id'>)
 )[];
 
 /**

--- a/deno/rest/v10/interactions.ts
+++ b/deno/rest/v10/interactions.ts
@@ -131,6 +131,7 @@ export type RESTPatchAPIApplicationGuildCommandResult = Omit<APIApplicationComma
 export type RESTPutAPIApplicationGuildCommandsJSONBody = (
 	| Omit<RESTPostAPIChatInputApplicationCommandsJSONBody, 'dm_permission'>
 	| Omit<RESTPostAPIContextMenuApplicationCommandsJSONBody, 'dm_permission'>
+	| Pick<Partial<APIApplicationCommand>, 'id'>
 )[];
 
 /**

--- a/deno/rest/v9/interactions.ts
+++ b/deno/rest/v9/interactions.ts
@@ -129,9 +129,10 @@ export type RESTPatchAPIApplicationGuildCommandResult = Omit<APIApplicationComma
  * https://discord.com/developers/docs/interactions/application-commands#bulk-overwrite-guild-application-commands
  */
 export type RESTPutAPIApplicationGuildCommandsJSONBody = (
-	| Omit<RESTPostAPIChatInputApplicationCommandsJSONBody, 'dm_permission'>
-	| Omit<RESTPostAPIContextMenuApplicationCommandsJSONBody, 'dm_permission'>
-	| Pick<Partial<APIApplicationCommand>, 'id'>
+	| (Omit<RESTPostAPIChatInputApplicationCommandsJSONBody, 'dm_permission'> &
+			Pick<Partial<APIApplicationCommand>, 'id'>)
+	| (Omit<RESTPostAPIContextMenuApplicationCommandsJSONBody, 'dm_permission'> &
+			Pick<Partial<APIApplicationCommand>, 'id'>)
 )[];
 
 /**

--- a/deno/rest/v9/interactions.ts
+++ b/deno/rest/v9/interactions.ts
@@ -131,6 +131,7 @@ export type RESTPatchAPIApplicationGuildCommandResult = Omit<APIApplicationComma
 export type RESTPutAPIApplicationGuildCommandsJSONBody = (
 	| Omit<RESTPostAPIChatInputApplicationCommandsJSONBody, 'dm_permission'>
 	| Omit<RESTPostAPIContextMenuApplicationCommandsJSONBody, 'dm_permission'>
+	| Pick<Partial<APIApplicationCommand>, 'id'>
 )[];
 
 /**

--- a/rest/v10/interactions.ts
+++ b/rest/v10/interactions.ts
@@ -129,9 +129,10 @@ export type RESTPatchAPIApplicationGuildCommandResult = Omit<APIApplicationComma
  * https://discord.com/developers/docs/interactions/application-commands#bulk-overwrite-guild-application-commands
  */
 export type RESTPutAPIApplicationGuildCommandsJSONBody = (
-	| Omit<RESTPostAPIChatInputApplicationCommandsJSONBody, 'dm_permission'>
-	| Omit<RESTPostAPIContextMenuApplicationCommandsJSONBody, 'dm_permission'>
-	| Pick<Partial<APIApplicationCommand>, 'id'>
+	| (Omit<RESTPostAPIChatInputApplicationCommandsJSONBody, 'dm_permission'> &
+			Pick<Partial<APIApplicationCommand>, 'id'>)
+	| (Omit<RESTPostAPIContextMenuApplicationCommandsJSONBody, 'dm_permission'> &
+			Pick<Partial<APIApplicationCommand>, 'id'>)
 )[];
 
 /**

--- a/rest/v10/interactions.ts
+++ b/rest/v10/interactions.ts
@@ -131,6 +131,7 @@ export type RESTPatchAPIApplicationGuildCommandResult = Omit<APIApplicationComma
 export type RESTPutAPIApplicationGuildCommandsJSONBody = (
 	| Omit<RESTPostAPIChatInputApplicationCommandsJSONBody, 'dm_permission'>
 	| Omit<RESTPostAPIContextMenuApplicationCommandsJSONBody, 'dm_permission'>
+	| Pick<Partial<APIApplicationCommand>, 'id'>
 )[];
 
 /**

--- a/rest/v9/interactions.ts
+++ b/rest/v9/interactions.ts
@@ -129,9 +129,10 @@ export type RESTPatchAPIApplicationGuildCommandResult = Omit<APIApplicationComma
  * https://discord.com/developers/docs/interactions/application-commands#bulk-overwrite-guild-application-commands
  */
 export type RESTPutAPIApplicationGuildCommandsJSONBody = (
-	| Omit<RESTPostAPIChatInputApplicationCommandsJSONBody, 'dm_permission'>
-	| Omit<RESTPostAPIContextMenuApplicationCommandsJSONBody, 'dm_permission'>
-	| Pick<Partial<APIApplicationCommand>, 'id'>
+	| (Omit<RESTPostAPIChatInputApplicationCommandsJSONBody, 'dm_permission'> &
+			Pick<Partial<APIApplicationCommand>, 'id'>)
+	| (Omit<RESTPostAPIContextMenuApplicationCommandsJSONBody, 'dm_permission'> &
+			Pick<Partial<APIApplicationCommand>, 'id'>)
 )[];
 
 /**

--- a/rest/v9/interactions.ts
+++ b/rest/v9/interactions.ts
@@ -131,6 +131,7 @@ export type RESTPatchAPIApplicationGuildCommandResult = Omit<APIApplicationComma
 export type RESTPutAPIApplicationGuildCommandsJSONBody = (
 	| Omit<RESTPostAPIChatInputApplicationCommandsJSONBody, 'dm_permission'>
 	| Omit<RESTPostAPIContextMenuApplicationCommandsJSONBody, 'dm_permission'>
+	| Pick<Partial<APIApplicationCommand>, 'id'>
 )[];
 
 /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Adds mssing optional `id` property into `RESTPutAPIApplicationGuildCommandsJSONBody`.

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
- https://github.com/discord/discord-api-docs/pull/5171
