### PR TITLE
feat(FormattingPatterns): add `ApplicationCommand`

### DIFF
--- a/deno/globals.ts
+++ b/deno/globals.ts
@@ -46,6 +46,12 @@ export const FormattingPatterns = {
 	 */
 	Role: /<@&(?<id>\d{17,20})>/,
 	/**
+	 * Regular expression for matching a application command mention
+	 *
+	 * The `name` and `id` group properties is present on the `exec` result of this expression
+	 */
+	ApplicationCommand: /<\/(?<name>\w{2,32}):(?<id>\d{17,20})>/,
+	/**
 	 * Regular expression for matching a custom emoji, either static or animated
 	 *
 	 * The `animated`, `name` and `id` group properties are present on the `exec` result of this expression

--- a/deno/globals.ts
+++ b/deno/globals.ts
@@ -48,9 +48,10 @@ export const FormattingPatterns = {
 	/**
 	 * Regular expression for matching a application command mention
 	 *
-	 * The `name` and `id` group properties is present on the `exec` result of this expression
+	 * The `fullName` (possibly including `name`, `subcommandOrGroup` and `subcommand`) and `id` group properties is present on the `exec` result of this expression
 	 */
-	ApplicationCommand: /<\/(?<name>\w{1,32}):(?<id>\d{17,20})>/,
+	ApplicationCommand:
+		/<\/(?<fullName>(?<name>[\w-]{1,32})(?: (?<subcommandOrGroup>[\w-]{1,32}))?(?: (?<subcommand>[\w-]{1,32}))?):(?<id>\d{17,20})>/,
 	/**
 	 * Regular expression for matching a custom emoji, either static or animated
 	 *

--- a/deno/globals.ts
+++ b/deno/globals.ts
@@ -50,7 +50,7 @@ export const FormattingPatterns = {
 	 *
 	 * The `fullName` (possibly including `name`, `subcommandOrGroup` and `subcommand`) and `id` group properties is present on the `exec` result of this expression
 	 */
-	ApplicationCommand:
+	SlashCommand:
 		/<\/(?<fullName>(?<name>[\w-]{1,32})(?: (?<subcommandOrGroup>[\w-]{1,32}))?(?: (?<subcommand>[\w-]{1,32}))?):(?<id>\d{17,20})>/,
 	/**
 	 * Regular expression for matching a custom emoji, either static or animated

--- a/deno/globals.ts
+++ b/deno/globals.ts
@@ -50,7 +50,7 @@ export const FormattingPatterns = {
 	 *
 	 * The `name` and `id` group properties is present on the `exec` result of this expression
 	 */
-	ApplicationCommand: /<\/(?<name>\w{2,32}):(?<id>\d{17,20})>/,
+	ApplicationCommand: /<\/(?<name>\w{1,32}):(?<id>\d{17,20})>/,
 	/**
 	 * Regular expression for matching a custom emoji, either static or animated
 	 *

--- a/globals.ts
+++ b/globals.ts
@@ -48,9 +48,10 @@ export const FormattingPatterns = {
 	/**
 	 * Regular expression for matching a application command mention
 	 *
-	 * The `name` and `id` group properties is present on the `exec` result of this expression
+	 * The `fullName` (possibly including `name`, `subcommandOrGroup` and `subcommand`) and `id` group properties is present on the `exec` result of this expression
 	 */
-	ApplicationCommand: /<\/(?<fullName>(?<name>[\w-]{1,32})(?: (?<subcommandOrGroup>[\w-]{1,32}))?(?: (?<subcommand>[\w-]{1,32}))?):(?<id>\d{17,20})>/,
+	ApplicationCommand:
+		/<\/(?<fullName>(?<name>[\w-]{1,32})(?: (?<subcommandOrGroup>[\w-]{1,32}))?(?: (?<subcommand>[\w-]{1,32}))?):(?<id>\d{17,20})>/,
 	/**
 	 * Regular expression for matching a custom emoji, either static or animated
 	 *

--- a/globals.ts
+++ b/globals.ts
@@ -50,7 +50,7 @@ export const FormattingPatterns = {
 	 *
 	 * The `name` and `id` group properties is present on the `exec` result of this expression
 	 */
-	ApplicationCommand: /<\/(?<name>\w{1,32}):(?<id>\d{17,20})>/,
+	ApplicationCommand: /<\/(?<fullName>(?<name>[\w-]{1,32})(?: (?<subcommandOrGroup>[\w-]{1,32}))?(?: (?<subcommand>[\w-]{1,32}))?):(?<id>\d{17,20})>/,
 	/**
 	 * Regular expression for matching a custom emoji, either static or animated
 	 *

--- a/globals.ts
+++ b/globals.ts
@@ -46,6 +46,12 @@ export const FormattingPatterns = {
 	 */
 	Role: /<@&(?<id>\d{17,20})>/,
 	/**
+	 * Regular expression for matching a application command mention
+	 *
+	 * The `name` and `id` group properties is present on the `exec` result of this expression
+	 */
+	ApplicationCommand: /<\/(?<name>\w{2,32}):(?<id>\d{17,20})>/,
+	/**
 	 * Regular expression for matching a custom emoji, either static or animated
 	 *
 	 * The `animated`, `name` and `id` group properties are present on the `exec` result of this expression

--- a/globals.ts
+++ b/globals.ts
@@ -50,7 +50,7 @@ export const FormattingPatterns = {
 	 *
 	 * The `fullName` (possibly including `name`, `subcommandOrGroup` and `subcommand`) and `id` group properties is present on the `exec` result of this expression
 	 */
-	ApplicationCommand:
+	SlashCommand:
 		/<\/(?<fullName>(?<name>[\w-]{1,32})(?: (?<subcommandOrGroup>[\w-]{1,32}))?(?: (?<subcommand>[\w-]{1,32}))?):(?<id>\d{17,20})>/,
 	/**
 	 * Regular expression for matching a custom emoji, either static or animated

--- a/globals.ts
+++ b/globals.ts
@@ -50,7 +50,7 @@ export const FormattingPatterns = {
 	 *
 	 * The `name` and `id` group properties is present on the `exec` result of this expression
 	 */
-	ApplicationCommand: /<\/(?<name>\w{2,32}):(?<id>\d{17,20})>/,
+	ApplicationCommand: /<\/(?<name>\w{1,32}):(?<id>\d{17,20})>/,
 	/**
 	 * Regular expression for matching a custom emoji, either static or animated
 	 *


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Adds `ApplicationCommand` format to `FormattingPatterns` constant.

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
- https://github.com/discord/discord-api-docs/pull/5186
