### PR TITLE
feat(RESTPutAPIGuildBanJSONBody): add `delete_message_seconds`

### DIFF
--- a/deno/rest/v10/guild.ts
+++ b/deno/rest/v10/guild.ts
@@ -573,8 +573,14 @@ export type RESTGetAPIGuildBanResult = APIBan;
 export type RESTPutAPIGuildBanJSONBody = AddUndefinedToPossiblyUndefinedPropertiesOfInterface<{
 	/**
 	 * Number of days to delete messages for (0-7)
+	 *
+	 * @deprecated use `delete_message_seconds` instead
 	 */
 	delete_message_days?: number;
+	/**
+	 * Number of seconds to delete messages for, between 0 and 604800 (7 days)
+	 */
+	delete_message_seconds?: number;
 }>;
 
 /**

--- a/deno/rest/v9/guild.ts
+++ b/deno/rest/v9/guild.ts
@@ -573,8 +573,14 @@ export type RESTGetAPIGuildBanResult = APIBan;
 export type RESTPutAPIGuildBanJSONBody = AddUndefinedToPossiblyUndefinedPropertiesOfInterface<{
 	/**
 	 * Number of days to delete messages for (0-7)
+	 *
+	 * @deprecated use `delete_message_seconds` instead
 	 */
 	delete_message_days?: number;
+	/**
+	 * Number of seconds to delete messages for, between 0 and 604800 (7 days)
+	 */
+	delete_message_seconds?: number;
 	/**
 	 * Reason for the ban
 	 *

--- a/rest/v10/guild.ts
+++ b/rest/v10/guild.ts
@@ -573,8 +573,14 @@ export type RESTGetAPIGuildBanResult = APIBan;
 export type RESTPutAPIGuildBanJSONBody = AddUndefinedToPossiblyUndefinedPropertiesOfInterface<{
 	/**
 	 * Number of days to delete messages for (0-7)
+	 *
+	 * @deprecated use `delete_message_seconds` instead
 	 */
 	delete_message_days?: number;
+	/**
+	 * Number of seconds to delete messages for, between 0 and 604800 (7 days)
+	 */
+	delete_message_seconds?: number;
 }>;
 
 /**

--- a/rest/v9/guild.ts
+++ b/rest/v9/guild.ts
@@ -573,8 +573,14 @@ export type RESTGetAPIGuildBanResult = APIBan;
 export type RESTPutAPIGuildBanJSONBody = AddUndefinedToPossiblyUndefinedPropertiesOfInterface<{
 	/**
 	 * Number of days to delete messages for (0-7)
+	 *
+	 * @deprecated use `delete_message_seconds` instead
 	 */
 	delete_message_days?: number;
+	/**
+	 * Number of seconds to delete messages for, between 0 and 604800 (7 days)
+	 */
+	delete_message_seconds?: number;
 	/**
 	 * Reason for the ban
 	 *


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
* Added `delete_message_seconds`
* Marked `delete_message_days` as deprecated

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
* https://github.com/discord/discord-api-docs/pull/5219