### PR TITLE
fix(OverwriteType): change from number to string

### DIFF
--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -690,8 +690,8 @@ export interface APIOverwrite {
 }
 
 export enum OverwriteType {
-	Role,
-	Member,
+	Role = '0',
+	Member = '1',
 }
 
 /**

--- a/payloads/v8/channel.ts
+++ b/payloads/v8/channel.ts
@@ -659,8 +659,8 @@ export interface APIOverwrite {
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
 export enum OverwriteType {
-	Role,
-	Member,
+	Role = '0',
+	Member = '1',
 }
 
 /**

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -690,8 +690,8 @@ export interface APIOverwrite {
 }
 
 export enum OverwriteType {
-	Role,
-	Member,
+	Role = '0',
+	Member = '1',
 }
 
 /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The API returns the overwrite type as strings, not numbers, already since v8.
https://discord.com/developers/docs/change-log#api-and-gateway-v8