### PR TITLE
refactor(RESTJSONErrorCodes): use `MaximumThreadParticipantsReached` instead in error code 30033

### DIFF
--- a/deno/rest/common.ts
+++ b/deno/rest/common.ts
@@ -102,7 +102,7 @@ export enum RESTJSONErrorCodes {
 
 	GuildAlreadyHasTemplate = 30031,
 	MaximumNumberOfApplicationCommandsReached,
-	MaximumThreadParticipants,
+	MaximumThreadParticipantsReached,
 	MaximumDailyApplicationCommandCreatesReached,
 	MaximumNumberOfNonGuildMemberBansHasBeenExceeded,
 

--- a/rest/common.ts
+++ b/rest/common.ts
@@ -102,7 +102,7 @@ export enum RESTJSONErrorCodes {
 
 	GuildAlreadyHasTemplate = 30031,
 	MaximumNumberOfApplicationCommandsReached,
-	MaximumThreadParticipants,
+	MaximumThreadParticipantsReached,
 	MaximumDailyApplicationCommandCreatesReached,
 	MaximumNumberOfNonGuildMemberBansHasBeenExceeded,
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Changes the name of the error code 30033, which is `MaximumThreadParticipants`, to `MaximumThreadParticipantsReached`.

This is to have more coherence according to the error message: "Max number of thread participants has been reached (1000)". 

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
