### PR TITLE
fix(RESTGetAPIChannelUsersThreadsArchivedResult): add `has_more` missing field

### DIFF
--- a/deno/rest/v10/channel.ts
+++ b/deno/rest/v10/channel.ts
@@ -669,5 +669,5 @@ export interface RESTGetAPIChannelUsersThreadsArchivedResult extends APIThreadLi
 	/**
 	 * Whether there are potentially additional threads
 	 */
-	has_more: boolean;	
+	has_more: boolean;
 }

--- a/deno/rest/v10/channel.ts
+++ b/deno/rest/v10/channel.ts
@@ -665,4 +665,9 @@ export interface RESTGetAPIChannelThreadsArchivedQuery {
 /**
  * https://discord.com/developers/docs/resources/channel#list-joined-private-archived-threads
  */
-export type RESTGetAPIChannelUsersThreadsArchivedResult = APIThreadList;
+export interface RESTGetAPIChannelUsersThreadsArchivedResult extends APIThreadList {
+	/**
+	 * Whether there are potentially additional threads
+	 */
+	has_more: boolean;	
+}

--- a/rest/v10/channel.ts
+++ b/rest/v10/channel.ts
@@ -669,5 +669,5 @@ export interface RESTGetAPIChannelUsersThreadsArchivedResult extends APIThreadLi
 	/**
 	 * Whether there are potentially additional threads
 	 */
-	has_more: boolean;	
+	has_more: boolean;
 }

--- a/rest/v10/channel.ts
+++ b/rest/v10/channel.ts
@@ -665,4 +665,9 @@ export interface RESTGetAPIChannelThreadsArchivedQuery {
 /**
  * https://discord.com/developers/docs/resources/channel#list-joined-private-archived-threads
  */
-export type RESTGetAPIChannelUsersThreadsArchivedResult = APIThreadList;
+export interface RESTGetAPIChannelUsersThreadsArchivedResult extends APIThreadList {
+	/**
+	 * Whether there are potentially additional threads
+	 */
+	has_more: boolean;	
+}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Adds `has_more` missing field to `RESTGetAPIChannelUsersThreadsArchivedResult`.
In an older PR, the property `has_more` was deleted in `APIThreadList`, which is the value of this route type.

According to [`GET /channels/{channel.id}/users/@me/threads/archived/private`](https://discord.com/developers/docs/resources/channel#list-joined-private-archived-threads), the response body has the `has_more` field.

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
