### PR TITLE
feat(APIVoiceChannel): support text in voice, properties `last_message_id` and `rate_limit_per_user`

### DIFF
--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -39,7 +39,6 @@ export interface APIChannelBase<T extends ChannelType> extends APIPartialChannel
 	flags?: ChannelFlags;
 }
 
-// TODO: update when text in voice is released
 export type TextChannelType =
 	| ChannelType.DM
 	| ChannelType.GroupDM
@@ -48,7 +47,8 @@ export type TextChannelType =
 	| ChannelType.GuildPrivateThread
 	| ChannelType.GuildNewsThread
 	| ChannelType.GuildText
-	| ChannelType.GuildForum;
+	| ChannelType.GuildForum
+	| ChannelType.GuildVoice;
 
 export type GuildChannelType = Exclude<
 	TextChannelType | ChannelType.GuildVoice | ChannelType.GuildStageVoice | ChannelType.GuildNews,

--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -60,6 +60,16 @@ export interface APITextBasedChannel<T extends ChannelType> extends APIChannelBa
 	 * The id of the last message sent in this channel (may not point to an existing or valid message)
 	 */
 	last_message_id?: Snowflake | null;
+	/**
+	 * Amount of seconds a user has to wait before sending another message (0-21600);
+	 * bots, as well as users with the permission `MANAGE_MESSAGES` or `MANAGE_CHANNELS`, are unaffected
+	 *
+	 * `rate_limit_per_user` also applies to thread creation. Users can send one message and create one thread during each `rate_limit_per_user` interval.
+	 *
+	 * For thread channels, `rate_limit_per_user` is only returned if the field is set to a non-zero and non-null value.
+	 * The absence of this field in API calls and Gateway events should indicate that slowmode has been reset to the default value.
+	 */
+	rate_limit_per_user?: number;
 }
 
 export interface APIGuildChannel<T extends ChannelType> extends APIChannelBase<T> {
@@ -111,23 +121,11 @@ export interface APIGuildTextChannel<T extends GuildTextChannelType>
 	last_pin_timestamp?: string | null;
 }
 
-export interface APITextChannel extends APIGuildTextChannel<ChannelType.GuildText> {
-	/**
-	 * Amount of seconds a user has to wait before sending another message (0-21600);
-	 * bots, as well as users with the permission `MANAGE_MESSAGES` or `MANAGE_CHANNELS`, are unaffected
-	 *
-	 * `rate_limit_per_user` also applies to thread creation. Users can send one message and create one thread during each `rate_limit_per_user` interval.
-	 *
-	 * For thread channels, `rate_limit_per_user` is only returned if the field is set to a non-zero and non-null value.
-	 * The absence of this field in API calls and Gateway events should indicate that slowmode has been reset to the default value.
-	 */
-	rate_limit_per_user?: number;
-}
-
+export type APITextChannel = APIGuildTextChannel<ChannelType.GuildText>;
 export type APINewsChannel = APIGuildTextChannel<ChannelType.GuildNews>;
 export type APIGuildCategoryChannel = APIGuildChannel<ChannelType.GuildCategory>;
 
-export interface APIVoiceChannel extends APIGuildChannel<ChannelType.GuildStageVoice | ChannelType.GuildVoice> {
+export interface APIVoiceChannelBase extends APIGuildChannel<ChannelType.GuildStageVoice | ChannelType.GuildVoice> {
 	/**
 	 * The bitrate (in bits) of the voice channel
 	 */
@@ -150,7 +148,10 @@ export interface APIVoiceChannel extends APIGuildChannel<ChannelType.GuildStageV
 	video_quality_mode?: VideoQualityMode;
 }
 
-interface APIDMChannelBase<T extends ChannelType> extends APITextBasedChannel<T> {
+export type APIVoiceChannel = APIVoiceChannelBase & APITextBasedChannel<ChannelType.GuildVoice>;
+export type APIStageVoiceChannel = Omit<APIVoiceChannelBase, 'video_quality_mode'>;
+
+interface APIDMChannelBase<T extends ChannelType> extends Omit<APITextBasedChannel<T>, 'rate_limit_per_user'> {
 	/**
 	 * The recipients of the DM
 	 *

--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -125,7 +125,7 @@ export type APITextChannel = APIGuildTextChannel<ChannelType.GuildText>;
 export type APINewsChannel = APIGuildTextChannel<ChannelType.GuildNews>;
 export type APIGuildCategoryChannel = APIGuildChannel<ChannelType.GuildCategory>;
 
-export interface APIVoiceChannelBase extends APIGuildChannel<ChannelType.GuildStageVoice | ChannelType.GuildVoice> {
+export interface APIVoiceChannelBase<T extends ChannelType> extends APIGuildChannel<T> {
 	/**
 	 * The bitrate (in bits) of the voice channel
 	 */
@@ -140,6 +140,11 @@ export interface APIVoiceChannelBase extends APIGuildChannel<ChannelType.GuildSt
 	 * See https://discord.com/developers/docs/resources/voice#voice-region-object
 	 */
 	rtc_region?: string | null;
+}
+
+export interface APIGuildVoiceChannel
+	extends APIVoiceChannelBase<ChannelType.GuildVoice>,
+		APITextBasedChannel<ChannelType.GuildVoice> {
 	/**
 	 * The camera video quality mode of the voice channel, `1` when not present
 	 *
@@ -148,9 +153,7 @@ export interface APIVoiceChannelBase extends APIGuildChannel<ChannelType.GuildSt
 	video_quality_mode?: VideoQualityMode;
 }
 
-export type APIGuildVoiceChannel = APIVoiceChannelBase & APITextBasedChannel<ChannelType.GuildVoice>;
-
-export type APIGuildStageVoiceChannel = Omit<APIVoiceChannelBase, 'video_quality_mode'>;
+export type APIGuildStageVoiceChannel = APIVoiceChannelBase<ChannelType.GuildStageVoice>;
 
 export interface APIDMChannelBase<T extends ChannelType> extends Omit<APITextBasedChannel<T>, 'rate_limit_per_user'> {
 	/**

--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -243,7 +243,8 @@ export type APIChannel =
 	| APIDMChannel
 	| APITextChannel
 	| APINewsChannel
-	| APIVoiceChannel
+	| APIGuildVoiceChannel
+	| APIGuildStageVoiceChannel
 	| APIGuildCategoryChannel
 	| APIThreadChannel
 	| APINewsChannel

--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -125,7 +125,7 @@ export type APITextChannel = APIGuildTextChannel<ChannelType.GuildText>;
 export type APINewsChannel = APIGuildTextChannel<ChannelType.GuildNews>;
 export type APIGuildCategoryChannel = APIGuildChannel<ChannelType.GuildCategory>;
 
-export interface APIVoiceChannelBase extends APIGuildChannel<ChannelType.GuildStageVoice | ChannelType.GuildVoice> {
+interface APIVoiceChannelBase extends APIGuildChannel<ChannelType.GuildStageVoice | ChannelType.GuildVoice> {
 	/**
 	 * The bitrate (in bits) of the voice channel
 	 */
@@ -148,8 +148,8 @@ export interface APIVoiceChannelBase extends APIGuildChannel<ChannelType.GuildSt
 	video_quality_mode?: VideoQualityMode;
 }
 
-export type APIVoiceChannel = APIVoiceChannelBase & APITextBasedChannel<ChannelType.GuildVoice>;
-export type APIStageVoiceChannel = Omit<APIVoiceChannelBase, 'video_quality_mode'>;
+export type APIGuildVoiceChannel = APIVoiceChannelBase & APITextBasedChannel<ChannelType.GuildVoice>;
+export type APIGuildStageVoiceChannel = Omit<APIVoiceChannelBase, 'video_quality_mode'>;
 
 interface APIDMChannelBase<T extends ChannelType> extends Omit<APITextBasedChannel<T>, 'rate_limit_per_user'> {
 	/**

--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -125,7 +125,7 @@ export type APITextChannel = APIGuildTextChannel<ChannelType.GuildText>;
 export type APINewsChannel = APIGuildTextChannel<ChannelType.GuildNews>;
 export type APIGuildCategoryChannel = APIGuildChannel<ChannelType.GuildCategory>;
 
-interface APIVoiceChannelBase extends APIGuildChannel<ChannelType.GuildStageVoice | ChannelType.GuildVoice> {
+export interface APIVoiceChannelBase extends APIGuildChannel<ChannelType.GuildStageVoice | ChannelType.GuildVoice> {
 	/**
 	 * The bitrate (in bits) of the voice channel
 	 */
@@ -149,9 +149,10 @@ interface APIVoiceChannelBase extends APIGuildChannel<ChannelType.GuildStageVoic
 }
 
 export type APIGuildVoiceChannel = APIVoiceChannelBase & APITextBasedChannel<ChannelType.GuildVoice>;
+
 export type APIGuildStageVoiceChannel = Omit<APIVoiceChannelBase, 'video_quality_mode'>;
 
-interface APIDMChannelBase<T extends ChannelType> extends Omit<APITextBasedChannel<T>, 'rate_limit_per_user'> {
+export interface APIDMChannelBase<T extends ChannelType> extends Omit<APITextBasedChannel<T>, 'rate_limit_per_user'> {
 	/**
 	 * The recipients of the DM
 	 *

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -39,7 +39,6 @@ export interface APIChannelBase<T extends ChannelType> extends APIPartialChannel
 	flags?: ChannelFlags;
 }
 
-// TODO: update when text in voice is released
 export type TextChannelType =
 	| ChannelType.DM
 	| ChannelType.GroupDM
@@ -48,7 +47,8 @@ export type TextChannelType =
 	| ChannelType.GuildPrivateThread
 	| ChannelType.GuildNewsThread
 	| ChannelType.GuildText
-	| ChannelType.GuildForum;
+	| ChannelType.GuildForum
+	| ChannelType.GuildVoice;
 
 export type GuildChannelType = Exclude<
 	TextChannelType | ChannelType.GuildVoice | ChannelType.GuildStageVoice | ChannelType.GuildNews,

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -60,6 +60,16 @@ export interface APITextBasedChannel<T extends ChannelType> extends APIChannelBa
 	 * The id of the last message sent in this channel (may not point to an existing or valid message)
 	 */
 	last_message_id?: Snowflake | null;
+	/**
+	 * Amount of seconds a user has to wait before sending another message (0-21600);
+	 * bots, as well as users with the permission `MANAGE_MESSAGES` or `MANAGE_CHANNELS`, are unaffected
+	 *
+	 * `rate_limit_per_user` also applies to thread creation. Users can send one message and create one thread during each `rate_limit_per_user` interval.
+	 *
+	 * For thread channels, `rate_limit_per_user` is only returned if the field is set to a non-zero and non-null value.
+	 * The absence of this field in API calls and Gateway events should indicate that slowmode has been reset to the default value.
+	 */
+	rate_limit_per_user?: number;
 }
 
 export interface APIGuildChannel<T extends ChannelType> extends APIChannelBase<T> {
@@ -111,23 +121,11 @@ export interface APIGuildTextChannel<T extends GuildTextChannelType>
 	last_pin_timestamp?: string | null;
 }
 
-export interface APITextChannel extends APIGuildTextChannel<ChannelType.GuildText> {
-	/**
-	 * Amount of seconds a user has to wait before sending another message (0-21600);
-	 * bots, as well as users with the permission `MANAGE_MESSAGES` or `MANAGE_CHANNELS`, are unaffected
-	 *
-	 * `rate_limit_per_user` also applies to thread creation. Users can send one message and create one thread during each `rate_limit_per_user` interval.
-	 *
-	 * For thread channels, `rate_limit_per_user` is only returned if the field is set to a non-zero and non-null value.
-	 * The absence of this field in API calls and Gateway events should indicate that slowmode has been reset to the default value.
-	 */
-	rate_limit_per_user?: number;
-}
-
+export type APITextChannel = APIGuildTextChannel<ChannelType.GuildText>;
 export type APINewsChannel = APIGuildTextChannel<ChannelType.GuildNews>;
 export type APIGuildCategoryChannel = APIGuildChannel<ChannelType.GuildCategory>;
 
-export interface APIVoiceChannel extends APIGuildChannel<ChannelType.GuildStageVoice | ChannelType.GuildVoice> {
+export interface APIVoiceChannelBase extends APIGuildChannel<ChannelType.GuildStageVoice | ChannelType.GuildVoice> {
 	/**
 	 * The bitrate (in bits) of the voice channel
 	 */
@@ -150,7 +148,10 @@ export interface APIVoiceChannel extends APIGuildChannel<ChannelType.GuildStageV
 	video_quality_mode?: VideoQualityMode;
 }
 
-interface APIDMChannelBase<T extends ChannelType> extends APITextBasedChannel<T> {
+export type APIVoiceChannel = APIVoiceChannelBase & APITextBasedChannel<ChannelType.GuildVoice>;
+export type APIStageVoiceChannel = Omit<APIVoiceChannelBase, 'video_quality_mode'>;
+
+interface APIDMChannelBase<T extends ChannelType> extends Omit<APITextBasedChannel<T>, 'rate_limit_per_user'> {
 	/**
 	 * The recipients of the DM
 	 *

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -125,7 +125,7 @@ export type APITextChannel = APIGuildTextChannel<ChannelType.GuildText>;
 export type APINewsChannel = APIGuildTextChannel<ChannelType.GuildNews>;
 export type APIGuildCategoryChannel = APIGuildChannel<ChannelType.GuildCategory>;
 
-export interface APIVoiceChannelBase extends APIGuildChannel<ChannelType.GuildStageVoice | ChannelType.GuildVoice> {
+export interface APIVoiceChannelBase<T extends ChannelType> extends APIGuildChannel<T> {
 	/**
 	 * The bitrate (in bits) of the voice channel
 	 */
@@ -140,6 +140,11 @@ export interface APIVoiceChannelBase extends APIGuildChannel<ChannelType.GuildSt
 	 * See https://discord.com/developers/docs/resources/voice#voice-region-object
 	 */
 	rtc_region?: string | null;
+}
+
+export interface APIGuildVoiceChannel
+	extends APIVoiceChannelBase<ChannelType.GuildVoice>,
+		APITextBasedChannel<ChannelType.GuildVoice> {
 	/**
 	 * The camera video quality mode of the voice channel, `1` when not present
 	 *
@@ -148,9 +153,7 @@ export interface APIVoiceChannelBase extends APIGuildChannel<ChannelType.GuildSt
 	video_quality_mode?: VideoQualityMode;
 }
 
-export type APIGuildVoiceChannel = APIVoiceChannelBase & APITextBasedChannel<ChannelType.GuildVoice>;
-
-export type APIGuildStageVoiceChannel = Omit<APIVoiceChannelBase, 'video_quality_mode'>;
+export type APIGuildStageVoiceChannel = APIVoiceChannelBase<ChannelType.GuildStageVoice>;
 
 export interface APIDMChannelBase<T extends ChannelType> extends Omit<APITextBasedChannel<T>, 'rate_limit_per_user'> {
 	/**

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -243,7 +243,8 @@ export type APIChannel =
 	| APIDMChannel
 	| APITextChannel
 	| APINewsChannel
-	| APIVoiceChannel
+	| APIGuildVoiceChannel
+	| APIGuildStageVoiceChannel
 	| APIGuildCategoryChannel
 	| APIThreadChannel
 	| APINewsChannel

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -125,7 +125,7 @@ export type APITextChannel = APIGuildTextChannel<ChannelType.GuildText>;
 export type APINewsChannel = APIGuildTextChannel<ChannelType.GuildNews>;
 export type APIGuildCategoryChannel = APIGuildChannel<ChannelType.GuildCategory>;
 
-export interface APIVoiceChannelBase extends APIGuildChannel<ChannelType.GuildStageVoice | ChannelType.GuildVoice> {
+interface APIVoiceChannelBase extends APIGuildChannel<ChannelType.GuildStageVoice | ChannelType.GuildVoice> {
 	/**
 	 * The bitrate (in bits) of the voice channel
 	 */
@@ -148,8 +148,8 @@ export interface APIVoiceChannelBase extends APIGuildChannel<ChannelType.GuildSt
 	video_quality_mode?: VideoQualityMode;
 }
 
-export type APIVoiceChannel = APIVoiceChannelBase & APITextBasedChannel<ChannelType.GuildVoice>;
-export type APIStageVoiceChannel = Omit<APIVoiceChannelBase, 'video_quality_mode'>;
+export type APIGuildVoiceChannel = APIVoiceChannelBase & APITextBasedChannel<ChannelType.GuildVoice>;
+export type APIGuildStageVoiceChannel = Omit<APIVoiceChannelBase, 'video_quality_mode'>;
 
 interface APIDMChannelBase<T extends ChannelType> extends Omit<APITextBasedChannel<T>, 'rate_limit_per_user'> {
 	/**

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -125,7 +125,7 @@ export type APITextChannel = APIGuildTextChannel<ChannelType.GuildText>;
 export type APINewsChannel = APIGuildTextChannel<ChannelType.GuildNews>;
 export type APIGuildCategoryChannel = APIGuildChannel<ChannelType.GuildCategory>;
 
-interface APIVoiceChannelBase extends APIGuildChannel<ChannelType.GuildStageVoice | ChannelType.GuildVoice> {
+export interface APIVoiceChannelBase extends APIGuildChannel<ChannelType.GuildStageVoice | ChannelType.GuildVoice> {
 	/**
 	 * The bitrate (in bits) of the voice channel
 	 */
@@ -149,9 +149,10 @@ interface APIVoiceChannelBase extends APIGuildChannel<ChannelType.GuildStageVoic
 }
 
 export type APIGuildVoiceChannel = APIVoiceChannelBase & APITextBasedChannel<ChannelType.GuildVoice>;
+
 export type APIGuildStageVoiceChannel = Omit<APIVoiceChannelBase, 'video_quality_mode'>;
 
-interface APIDMChannelBase<T extends ChannelType> extends Omit<APITextBasedChannel<T>, 'rate_limit_per_user'> {
+export interface APIDMChannelBase<T extends ChannelType> extends Omit<APITextBasedChannel<T>, 'rate_limit_per_user'> {
 	/**
 	 * The recipients of the DM
 	 *

--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -39,7 +39,6 @@ export interface APIChannelBase<T extends ChannelType> extends APIPartialChannel
 	flags?: ChannelFlags;
 }
 
-// TODO: update when text in voice is released
 export type TextChannelType =
 	| ChannelType.DM
 	| ChannelType.GroupDM
@@ -48,7 +47,8 @@ export type TextChannelType =
 	| ChannelType.GuildPrivateThread
 	| ChannelType.GuildNewsThread
 	| ChannelType.GuildText
-	| ChannelType.GuildForum;
+	| ChannelType.GuildForum
+	| ChannelType.GuildVoice;
 
 export type GuildChannelType = Exclude<
 	TextChannelType | ChannelType.GuildVoice | ChannelType.GuildStageVoice | ChannelType.GuildNews,

--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -60,6 +60,16 @@ export interface APITextBasedChannel<T extends ChannelType> extends APIChannelBa
 	 * The id of the last message sent in this channel (may not point to an existing or valid message)
 	 */
 	last_message_id?: Snowflake | null;
+	/**
+	 * Amount of seconds a user has to wait before sending another message (0-21600);
+	 * bots, as well as users with the permission `MANAGE_MESSAGES` or `MANAGE_CHANNELS`, are unaffected
+	 *
+	 * `rate_limit_per_user` also applies to thread creation. Users can send one message and create one thread during each `rate_limit_per_user` interval.
+	 *
+	 * For thread channels, `rate_limit_per_user` is only returned if the field is set to a non-zero and non-null value.
+	 * The absence of this field in API calls and Gateway events should indicate that slowmode has been reset to the default value.
+	 */
+	rate_limit_per_user?: number;
 }
 
 export interface APIGuildChannel<T extends ChannelType> extends APIChannelBase<T> {
@@ -111,23 +121,11 @@ export interface APIGuildTextChannel<T extends GuildTextChannelType>
 	last_pin_timestamp?: string | null;
 }
 
-export interface APITextChannel extends APIGuildTextChannel<ChannelType.GuildText> {
-	/**
-	 * Amount of seconds a user has to wait before sending another message (0-21600);
-	 * bots, as well as users with the permission `MANAGE_MESSAGES` or `MANAGE_CHANNELS`, are unaffected
-	 *
-	 * `rate_limit_per_user` also applies to thread creation. Users can send one message and create one thread during each `rate_limit_per_user` interval.
-	 *
-	 * For thread channels, `rate_limit_per_user` is only returned if the field is set to a non-zero and non-null value.
-	 * The absence of this field in API calls and Gateway events should indicate that slowmode has been reset to the default value.
-	 */
-	rate_limit_per_user?: number;
-}
-
+export type APITextChannel = APIGuildTextChannel<ChannelType.GuildText>;
 export type APINewsChannel = APIGuildTextChannel<ChannelType.GuildNews>;
 export type APIGuildCategoryChannel = APIGuildChannel<ChannelType.GuildCategory>;
 
-export interface APIVoiceChannel extends APIGuildChannel<ChannelType.GuildStageVoice | ChannelType.GuildVoice> {
+export interface APIVoiceChannelBase extends APIGuildChannel<ChannelType.GuildStageVoice | ChannelType.GuildVoice> {
 	/**
 	 * The bitrate (in bits) of the voice channel
 	 */
@@ -150,7 +148,10 @@ export interface APIVoiceChannel extends APIGuildChannel<ChannelType.GuildStageV
 	video_quality_mode?: VideoQualityMode;
 }
 
-interface APIDMChannelBase<T extends ChannelType> extends APITextBasedChannel<T> {
+export type APIVoiceChannel = APIVoiceChannelBase & APITextBasedChannel<ChannelType.GuildVoice>;
+export type APIStageVoiceChannel = Omit<APIVoiceChannelBase, 'video_quality_mode'>;
+
+interface APIDMChannelBase<T extends ChannelType> extends Omit<APITextBasedChannel<T>, 'rate_limit_per_user'> {
 	/**
 	 * The recipients of the DM
 	 *

--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -125,7 +125,7 @@ export type APITextChannel = APIGuildTextChannel<ChannelType.GuildText>;
 export type APINewsChannel = APIGuildTextChannel<ChannelType.GuildNews>;
 export type APIGuildCategoryChannel = APIGuildChannel<ChannelType.GuildCategory>;
 
-export interface APIVoiceChannelBase extends APIGuildChannel<ChannelType.GuildStageVoice | ChannelType.GuildVoice> {
+export interface APIVoiceChannelBase<T extends ChannelType> extends APIGuildChannel<T> {
 	/**
 	 * The bitrate (in bits) of the voice channel
 	 */
@@ -140,6 +140,11 @@ export interface APIVoiceChannelBase extends APIGuildChannel<ChannelType.GuildSt
 	 * See https://discord.com/developers/docs/resources/voice#voice-region-object
 	 */
 	rtc_region?: string | null;
+}
+
+export interface APIGuildVoiceChannel
+	extends APIVoiceChannelBase<ChannelType.GuildVoice>,
+		APITextBasedChannel<ChannelType.GuildVoice> {
 	/**
 	 * The camera video quality mode of the voice channel, `1` when not present
 	 *
@@ -148,9 +153,7 @@ export interface APIVoiceChannelBase extends APIGuildChannel<ChannelType.GuildSt
 	video_quality_mode?: VideoQualityMode;
 }
 
-export type APIGuildVoiceChannel = APIVoiceChannelBase & APITextBasedChannel<ChannelType.GuildVoice>;
-
-export type APIGuildStageVoiceChannel = Omit<APIVoiceChannelBase, 'video_quality_mode'>;
+export type APIGuildStageVoiceChannel = APIVoiceChannelBase<ChannelType.GuildStageVoice>;
 
 export interface APIDMChannelBase<T extends ChannelType> extends Omit<APITextBasedChannel<T>, 'rate_limit_per_user'> {
 	/**

--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -243,7 +243,8 @@ export type APIChannel =
 	| APIDMChannel
 	| APITextChannel
 	| APINewsChannel
-	| APIVoiceChannel
+	| APIGuildVoiceChannel
+	| APIGuildStageVoiceChannel
 	| APIGuildCategoryChannel
 	| APIThreadChannel
 	| APINewsChannel

--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -125,7 +125,7 @@ export type APITextChannel = APIGuildTextChannel<ChannelType.GuildText>;
 export type APINewsChannel = APIGuildTextChannel<ChannelType.GuildNews>;
 export type APIGuildCategoryChannel = APIGuildChannel<ChannelType.GuildCategory>;
 
-export interface APIVoiceChannelBase extends APIGuildChannel<ChannelType.GuildStageVoice | ChannelType.GuildVoice> {
+interface APIVoiceChannelBase extends APIGuildChannel<ChannelType.GuildStageVoice | ChannelType.GuildVoice> {
 	/**
 	 * The bitrate (in bits) of the voice channel
 	 */
@@ -148,8 +148,8 @@ export interface APIVoiceChannelBase extends APIGuildChannel<ChannelType.GuildSt
 	video_quality_mode?: VideoQualityMode;
 }
 
-export type APIVoiceChannel = APIVoiceChannelBase & APITextBasedChannel<ChannelType.GuildVoice>;
-export type APIStageVoiceChannel = Omit<APIVoiceChannelBase, 'video_quality_mode'>;
+export type APIGuildVoiceChannel = APIVoiceChannelBase & APITextBasedChannel<ChannelType.GuildVoice>;
+export type APIGuildStageVoiceChannel = Omit<APIVoiceChannelBase, 'video_quality_mode'>;
 
 interface APIDMChannelBase<T extends ChannelType> extends Omit<APITextBasedChannel<T>, 'rate_limit_per_user'> {
 	/**

--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -125,7 +125,7 @@ export type APITextChannel = APIGuildTextChannel<ChannelType.GuildText>;
 export type APINewsChannel = APIGuildTextChannel<ChannelType.GuildNews>;
 export type APIGuildCategoryChannel = APIGuildChannel<ChannelType.GuildCategory>;
 
-interface APIVoiceChannelBase extends APIGuildChannel<ChannelType.GuildStageVoice | ChannelType.GuildVoice> {
+export interface APIVoiceChannelBase extends APIGuildChannel<ChannelType.GuildStageVoice | ChannelType.GuildVoice> {
 	/**
 	 * The bitrate (in bits) of the voice channel
 	 */
@@ -149,9 +149,10 @@ interface APIVoiceChannelBase extends APIGuildChannel<ChannelType.GuildStageVoic
 }
 
 export type APIGuildVoiceChannel = APIVoiceChannelBase & APITextBasedChannel<ChannelType.GuildVoice>;
+
 export type APIGuildStageVoiceChannel = Omit<APIVoiceChannelBase, 'video_quality_mode'>;
 
-interface APIDMChannelBase<T extends ChannelType> extends Omit<APITextBasedChannel<T>, 'rate_limit_per_user'> {
+export interface APIDMChannelBase<T extends ChannelType> extends Omit<APITextBasedChannel<T>, 'rate_limit_per_user'> {
 	/**
 	 * The recipients of the DM
 	 *

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -39,7 +39,6 @@ export interface APIChannelBase<T extends ChannelType> extends APIPartialChannel
 	flags?: ChannelFlags;
 }
 
-// TODO: update when text in voice is released
 export type TextChannelType =
 	| ChannelType.DM
 	| ChannelType.GroupDM
@@ -48,7 +47,8 @@ export type TextChannelType =
 	| ChannelType.GuildPrivateThread
 	| ChannelType.GuildNewsThread
 	| ChannelType.GuildText
-	| ChannelType.GuildForum;
+	| ChannelType.GuildForum
+	| ChannelType.GuildVoice;
 
 export type GuildChannelType = Exclude<
 	TextChannelType | ChannelType.GuildVoice | ChannelType.GuildStageVoice | ChannelType.GuildNews,

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -60,6 +60,16 @@ export interface APITextBasedChannel<T extends ChannelType> extends APIChannelBa
 	 * The id of the last message sent in this channel (may not point to an existing or valid message)
 	 */
 	last_message_id?: Snowflake | null;
+	/**
+	 * Amount of seconds a user has to wait before sending another message (0-21600);
+	 * bots, as well as users with the permission `MANAGE_MESSAGES` or `MANAGE_CHANNELS`, are unaffected
+	 *
+	 * `rate_limit_per_user` also applies to thread creation. Users can send one message and create one thread during each `rate_limit_per_user` interval.
+	 *
+	 * For thread channels, `rate_limit_per_user` is only returned if the field is set to a non-zero and non-null value.
+	 * The absence of this field in API calls and Gateway events should indicate that slowmode has been reset to the default value.
+	 */
+	rate_limit_per_user?: number;
 }
 
 export interface APIGuildChannel<T extends ChannelType> extends APIChannelBase<T> {
@@ -111,23 +121,11 @@ export interface APIGuildTextChannel<T extends GuildTextChannelType>
 	last_pin_timestamp?: string | null;
 }
 
-export interface APITextChannel extends APIGuildTextChannel<ChannelType.GuildText> {
-	/**
-	 * Amount of seconds a user has to wait before sending another message (0-21600);
-	 * bots, as well as users with the permission `MANAGE_MESSAGES` or `MANAGE_CHANNELS`, are unaffected
-	 *
-	 * `rate_limit_per_user` also applies to thread creation. Users can send one message and create one thread during each `rate_limit_per_user` interval.
-	 *
-	 * For thread channels, `rate_limit_per_user` is only returned if the field is set to a non-zero and non-null value.
-	 * The absence of this field in API calls and Gateway events should indicate that slowmode has been reset to the default value.
-	 */
-	rate_limit_per_user?: number;
-}
-
+export type APITextChannel = APIGuildTextChannel<ChannelType.GuildText>;
 export type APINewsChannel = APIGuildTextChannel<ChannelType.GuildNews>;
 export type APIGuildCategoryChannel = APIGuildChannel<ChannelType.GuildCategory>;
 
-export interface APIVoiceChannel extends APIGuildChannel<ChannelType.GuildStageVoice | ChannelType.GuildVoice> {
+export interface APIVoiceChannelBase extends APIGuildChannel<ChannelType.GuildStageVoice | ChannelType.GuildVoice> {
 	/**
 	 * The bitrate (in bits) of the voice channel
 	 */
@@ -150,7 +148,10 @@ export interface APIVoiceChannel extends APIGuildChannel<ChannelType.GuildStageV
 	video_quality_mode?: VideoQualityMode;
 }
 
-interface APIDMChannelBase<T extends ChannelType> extends APITextBasedChannel<T> {
+export type APIVoiceChannel = APIVoiceChannelBase & APITextBasedChannel<ChannelType.GuildVoice>;
+export type APIStageVoiceChannel = Omit<APIVoiceChannelBase, 'video_quality_mode'>;
+
+interface APIDMChannelBase<T extends ChannelType> extends Omit<APITextBasedChannel<T>, 'rate_limit_per_user'> {
 	/**
 	 * The recipients of the DM
 	 *

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -125,7 +125,7 @@ export type APITextChannel = APIGuildTextChannel<ChannelType.GuildText>;
 export type APINewsChannel = APIGuildTextChannel<ChannelType.GuildNews>;
 export type APIGuildCategoryChannel = APIGuildChannel<ChannelType.GuildCategory>;
 
-export interface APIVoiceChannelBase extends APIGuildChannel<ChannelType.GuildStageVoice | ChannelType.GuildVoice> {
+export interface APIVoiceChannelBase<T extends ChannelType> extends APIGuildChannel<T> {
 	/**
 	 * The bitrate (in bits) of the voice channel
 	 */
@@ -140,6 +140,11 @@ export interface APIVoiceChannelBase extends APIGuildChannel<ChannelType.GuildSt
 	 * See https://discord.com/developers/docs/resources/voice#voice-region-object
 	 */
 	rtc_region?: string | null;
+}
+
+export interface APIGuildVoiceChannel
+	extends APIVoiceChannelBase<ChannelType.GuildVoice>,
+		APITextBasedChannel<ChannelType.GuildVoice> {
 	/**
 	 * The camera video quality mode of the voice channel, `1` when not present
 	 *
@@ -148,9 +153,7 @@ export interface APIVoiceChannelBase extends APIGuildChannel<ChannelType.GuildSt
 	video_quality_mode?: VideoQualityMode;
 }
 
-export type APIGuildVoiceChannel = APIVoiceChannelBase & APITextBasedChannel<ChannelType.GuildVoice>;
-
-export type APIGuildStageVoiceChannel = Omit<APIVoiceChannelBase, 'video_quality_mode'>;
+export type APIGuildStageVoiceChannel = APIVoiceChannelBase<ChannelType.GuildStageVoice>;
 
 export interface APIDMChannelBase<T extends ChannelType> extends Omit<APITextBasedChannel<T>, 'rate_limit_per_user'> {
 	/**

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -243,7 +243,8 @@ export type APIChannel =
 	| APIDMChannel
 	| APITextChannel
 	| APINewsChannel
-	| APIVoiceChannel
+	| APIGuildVoiceChannel
+	| APIGuildStageVoiceChannel
 	| APIGuildCategoryChannel
 	| APIThreadChannel
 	| APINewsChannel

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -125,7 +125,7 @@ export type APITextChannel = APIGuildTextChannel<ChannelType.GuildText>;
 export type APINewsChannel = APIGuildTextChannel<ChannelType.GuildNews>;
 export type APIGuildCategoryChannel = APIGuildChannel<ChannelType.GuildCategory>;
 
-export interface APIVoiceChannelBase extends APIGuildChannel<ChannelType.GuildStageVoice | ChannelType.GuildVoice> {
+interface APIVoiceChannelBase extends APIGuildChannel<ChannelType.GuildStageVoice | ChannelType.GuildVoice> {
 	/**
 	 * The bitrate (in bits) of the voice channel
 	 */
@@ -148,8 +148,8 @@ export interface APIVoiceChannelBase extends APIGuildChannel<ChannelType.GuildSt
 	video_quality_mode?: VideoQualityMode;
 }
 
-export type APIVoiceChannel = APIVoiceChannelBase & APITextBasedChannel<ChannelType.GuildVoice>;
-export type APIStageVoiceChannel = Omit<APIVoiceChannelBase, 'video_quality_mode'>;
+export type APIGuildVoiceChannel = APIVoiceChannelBase & APITextBasedChannel<ChannelType.GuildVoice>;
+export type APIGuildStageVoiceChannel = Omit<APIVoiceChannelBase, 'video_quality_mode'>;
 
 interface APIDMChannelBase<T extends ChannelType> extends Omit<APITextBasedChannel<T>, 'rate_limit_per_user'> {
 	/**

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -125,7 +125,7 @@ export type APITextChannel = APIGuildTextChannel<ChannelType.GuildText>;
 export type APINewsChannel = APIGuildTextChannel<ChannelType.GuildNews>;
 export type APIGuildCategoryChannel = APIGuildChannel<ChannelType.GuildCategory>;
 
-interface APIVoiceChannelBase extends APIGuildChannel<ChannelType.GuildStageVoice | ChannelType.GuildVoice> {
+export interface APIVoiceChannelBase extends APIGuildChannel<ChannelType.GuildStageVoice | ChannelType.GuildVoice> {
 	/**
 	 * The bitrate (in bits) of the voice channel
 	 */
@@ -149,9 +149,10 @@ interface APIVoiceChannelBase extends APIGuildChannel<ChannelType.GuildStageVoic
 }
 
 export type APIGuildVoiceChannel = APIVoiceChannelBase & APITextBasedChannel<ChannelType.GuildVoice>;
+
 export type APIGuildStageVoiceChannel = Omit<APIVoiceChannelBase, 'video_quality_mode'>;
 
-interface APIDMChannelBase<T extends ChannelType> extends Omit<APITextBasedChannel<T>, 'rate_limit_per_user'> {
+export interface APIDMChannelBase<T extends ChannelType> extends Omit<APITextBasedChannel<T>, 'rate_limit_per_user'> {
 	/**
 	 * The recipients of the DM
 	 *


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Adds the missing properties to `APIVoiceChannel` (`last_message_id` and `rate_limit_per_user`) which were now included in the voice channel payload, with the "Text In Voice" feature, making it a text-based channel.

But to make it more dynamic takes `APIVoiceChannel` as a _base_ with the common properties in the voice channel types (Now it will be `APIVoiceChannelBase`) because a guild contains two types of voice channels: `GUILD_VOICE` and `GUILD_STAGE_VOICE`. 

So, this PR:

- Creates a type called **`APIGuildStageVoiceChannel`**, which covers the channel with the `GUILD_STAGE_VOICE` type.

- Adds `rate_limit_per_user` property to `APITextBasedChannel` (it already had the `last_message_id` property).

- Creates an interface called **`APIGuildVoiceChannel`**, which covers the channel with the `GUILD_VOICE` type, using `APIVoiceChannelBase` and `APITextBasedChannel`, adding the `video_quality_mode` property.

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
