### PR TITLE
docs: fix wrong reference links

### DIFF
--- a/deno/payloads/v10/_interactions/_applicationCommands/chatInput.ts
+++ b/deno/payloads/v10/_interactions/_applicationCommands/chatInput.ts
@@ -108,7 +108,7 @@ export type APIApplicationCommandInteractionDataBasicOption =
 	| APIApplicationCommandInteractionDataAttachmentOption;
 
 /**
- * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data-structure
+ * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data
  */
 export interface APIChatInputApplicationCommandInteractionData
 	extends APIBaseApplicationCommandInteractionData<ApplicationCommandType.ChatInput> {

--- a/deno/payloads/v10/_interactions/_applicationCommands/contextMenu.ts
+++ b/deno/payloads/v10/_interactions/_applicationCommands/contextMenu.ts
@@ -10,7 +10,7 @@ import type {
 import type { APIDMInteractionWrapper, APIGuildInteractionWrapper } from '../base.ts';
 
 /**
- * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data-structure
+ * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data
  */
 export interface APIUserApplicationCommandInteractionData
 	extends APIBaseApplicationCommandInteractionData<ApplicationCommandType.User> {
@@ -27,7 +27,7 @@ export interface APIUserApplicationCommandInteractionDataResolved {
 }
 
 /**
- * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data-structure
+ * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data
  */
 export interface APIMessageApplicationCommandInteractionData
 	extends APIBaseApplicationCommandInteractionData<ApplicationCommandType.Message> {
@@ -43,7 +43,7 @@ export interface APIMessageApplicationCommandInteractionDataResolved {
 }
 
 /**
- * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data-structure
+ * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data
  */
 export type APIContextMenuInteractionData =
 	| APIUserApplicationCommandInteractionData

--- a/deno/payloads/v10/_interactions/applicationCommands.ts
+++ b/deno/payloads/v10/_interactions/applicationCommands.ts
@@ -101,7 +101,7 @@ export enum ApplicationCommandType {
 }
 
 /**
- * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data-structure
+ * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data
  */
 export type APIApplicationCommandInteractionData =
 	| APIChatInputApplicationCommandInteractionData

--- a/deno/payloads/v10/application.ts
+++ b/deno/payloads/v10/application.ts
@@ -62,7 +62,7 @@ export interface APIApplication {
 	/**
 	 * The hexadecimal encoded key for verification in interactions and the GameSDK's GetTicket function
 	 *
-	 * See https://discord.com/developers/docs/game-sdk/applications#get-ticket
+	 * See https://discord.com/developers/docs/game-sdk/applications#getticket
 	 */
 	verify_key: string;
 	/**

--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -438,7 +438,7 @@ export interface APIMessage {
 	/**
 	 * Sent with Rich Presence-related chat embeds
 	 *
-	 * See https://discord.com/developers/docs/resources/channel#message-object-message-application-structure
+	 * See https://discord.com/developers/docs/resources/application#application-object
 	 */
 	application?: Partial<APIApplication>;
 	/**
@@ -1160,7 +1160,7 @@ export interface APIBaseComponent<T extends ComponentType> {
 }
 
 /**
- * https://discord.com/developers/docs/interactions/message-components#component-types
+ * https://discord.com/developers/docs/interactions/message-components#component-object-component-types
  */
 export enum ComponentType {
 	/**

--- a/deno/payloads/v10/guild.ts
+++ b/deno/payloads/v10/guild.ts
@@ -769,7 +769,7 @@ export interface APIBan {
 }
 
 /**
- * https://discord.com/developers/docs/resources/guild#get-guild-widget-example-get-guild-widget
+ * https://discord.com/developers/docs/resources/guild#guild-widget-object
  */
 export interface APIGuildWidget {
 	id: Snowflake;
@@ -781,7 +781,7 @@ export interface APIGuildWidget {
 }
 
 /**
- * https://discord.com/developers/docs/resources/guild#get-guild-widget-example-get-guild-widget
+ * https://discord.com/developers/docs/resources/guild#guild-widget-object-example-guild-widget
  */
 export interface APIGuildWidgetChannel {
 	id: Snowflake;
@@ -790,7 +790,7 @@ export interface APIGuildWidgetChannel {
 }
 
 /**
- * https://discord.com/developers/docs/resources/guild#get-guild-widget-example-get-guild-widget
+ * https://discord.com/developers/docs/resources/guild#guild-widget-object-example-guild-widget
  */
 export interface APIGuildWidgetMember {
 	id: string;

--- a/deno/payloads/v10/invite.ts
+++ b/deno/payloads/v10/invite.ts
@@ -53,7 +53,7 @@ export interface APIInvite {
 	/**
 	 * The type of target for this voice channel invite
 	 *
-	 * See https://discord.com/developers/docs/resources/invite#invite-object-target-user-types
+	 * See https://discord.com/developers/docs/resources/invite#invite-object-invite-target-types
 	 */
 	target_type?: InviteTargetType;
 	/**
@@ -65,7 +65,7 @@ export interface APIInvite {
 	/**
 	 * The embedded application to open for this voice channel embedded application invite
 	 *
-	 * See https://discord.com/developers/docs/topics/oauth2#application
+	 * See https://discord.com/developers/docs/resources/application#application-object
 	 */
 	target_application?: Partial<APIApplication>;
 	/**

--- a/deno/payloads/v10/teams.ts
+++ b/deno/payloads/v10/teams.ts
@@ -32,7 +32,7 @@ export interface APITeam {
 }
 
 /**
- * https://discord.com/developers/docs/topics/teams#data-models-team-members-object
+ * https://discord.com/developers/docs/topics/teams#data-models-team-member-object
  */
 export interface APITeamMember {
 	/**

--- a/deno/payloads/v10/template.ts
+++ b/deno/payloads/v10/template.ts
@@ -1,5 +1,5 @@
 /**
- * Types extracted from https://discord.com/developers/docs/resources/template
+ * Types extracted from https://discord.com/developers/docs/resources/guild-template
  */
 
 import type { APIUser } from './user.ts';
@@ -7,7 +7,7 @@ import type { Snowflake } from '../../globals.ts';
 import type { RESTPostAPIGuildsJSONBody } from '../../rest/v10/mod.ts';
 
 /**
- * https://discord.com/developers/docs/resources/template#template-object
+ * https://discord.com/developers/docs/resources/guild-template#guild-template-object
  */
 export interface APITemplate {
 	/**

--- a/deno/payloads/v9/_interactions/_applicationCommands/chatInput.ts
+++ b/deno/payloads/v9/_interactions/_applicationCommands/chatInput.ts
@@ -108,7 +108,7 @@ export type APIApplicationCommandInteractionDataBasicOption =
 	| APIApplicationCommandInteractionDataAttachmentOption;
 
 /**
- * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data-structure
+ * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data
  */
 export interface APIChatInputApplicationCommandInteractionData
 	extends APIBaseApplicationCommandInteractionData<ApplicationCommandType.ChatInput> {

--- a/deno/payloads/v9/_interactions/_applicationCommands/contextMenu.ts
+++ b/deno/payloads/v9/_interactions/_applicationCommands/contextMenu.ts
@@ -10,7 +10,7 @@ import type {
 import type { APIDMInteractionWrapper, APIGuildInteractionWrapper } from '../base.ts';
 
 /**
- * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data-structure
+ * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data
  */
 export interface APIUserApplicationCommandInteractionData
 	extends APIBaseApplicationCommandInteractionData<ApplicationCommandType.User> {
@@ -27,7 +27,7 @@ export interface APIUserApplicationCommandInteractionDataResolved {
 }
 
 /**
- * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data-structure
+ * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data
  */
 export interface APIMessageApplicationCommandInteractionData
 	extends APIBaseApplicationCommandInteractionData<ApplicationCommandType.Message> {
@@ -43,7 +43,7 @@ export interface APIMessageApplicationCommandInteractionDataResolved {
 }
 
 /**
- * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data-structure
+ * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data
  */
 export type APIContextMenuInteractionData =
 	| APIUserApplicationCommandInteractionData

--- a/deno/payloads/v9/_interactions/applicationCommands.ts
+++ b/deno/payloads/v9/_interactions/applicationCommands.ts
@@ -101,7 +101,7 @@ export enum ApplicationCommandType {
 }
 
 /**
- * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data-structure
+ * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data
  */
 export type APIApplicationCommandInteractionData =
 	| APIChatInputApplicationCommandInteractionData

--- a/deno/payloads/v9/application.ts
+++ b/deno/payloads/v9/application.ts
@@ -62,7 +62,7 @@ export interface APIApplication {
 	/**
 	 * The hexadecimal encoded key for verification in interactions and the GameSDK's GetTicket function
 	 *
-	 * See https://discord.com/developers/docs/game-sdk/applications#get-ticket
+	 * See https://discord.com/developers/docs/game-sdk/applications#getticket
 	 */
 	verify_key: string;
 	/**

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -438,7 +438,7 @@ export interface APIMessage {
 	/**
 	 * Sent with Rich Presence-related chat embeds
 	 *
-	 * See https://discord.com/developers/docs/resources/channel#message-object-message-application-structure
+	 * See https://discord.com/developers/docs/resources/application#application-object
 	 */
 	application?: Partial<APIApplication>;
 	/**
@@ -1164,7 +1164,7 @@ export interface APIBaseComponent<T extends ComponentType> {
 }
 
 /**
- * https://discord.com/developers/docs/interactions/message-components#component-types
+ * https://discord.com/developers/docs/interactions/message-components#component-object-component-types
  */
 export enum ComponentType {
 	/**

--- a/deno/payloads/v9/guild.ts
+++ b/deno/payloads/v9/guild.ts
@@ -769,7 +769,7 @@ export interface APIBan {
 }
 
 /**
- * https://discord.com/developers/docs/resources/guild#get-guild-widget-example-get-guild-widget
+ * https://discord.com/developers/docs/resources/guild#guild-widget-object
  */
 export interface APIGuildWidget {
 	id: Snowflake;
@@ -781,7 +781,7 @@ export interface APIGuildWidget {
 }
 
 /**
- * https://discord.com/developers/docs/resources/guild#get-guild-widget-example-get-guild-widget
+ * https://discord.com/developers/docs/resources/guild#guild-widget-object-example-guild-widget
  */
 export interface APIGuildWidgetChannel {
 	id: Snowflake;
@@ -790,7 +790,7 @@ export interface APIGuildWidgetChannel {
 }
 
 /**
- * https://discord.com/developers/docs/resources/guild#get-guild-widget-example-get-guild-widget
+ * https://discord.com/developers/docs/resources/guild#guild-widget-object-example-guild-widget
  */
 export interface APIGuildWidgetMember {
 	id: string;

--- a/deno/payloads/v9/invite.ts
+++ b/deno/payloads/v9/invite.ts
@@ -53,7 +53,7 @@ export interface APIInvite {
 	/**
 	 * The type of target for this voice channel invite
 	 *
-	 * See https://discord.com/developers/docs/resources/invite#invite-object-target-user-types
+	 * See https://discord.com/developers/docs/resources/invite#invite-object-invite-target-types
 	 */
 	target_type?: InviteTargetType;
 	/**
@@ -65,7 +65,7 @@ export interface APIInvite {
 	/**
 	 * The embedded application to open for this voice channel embedded application invite
 	 *
-	 * See https://discord.com/developers/docs/topics/oauth2#application
+	 * See https://discord.com/developers/docs/resources/application#application-object
 	 */
 	target_application?: Partial<APIApplication>;
 	/**

--- a/deno/payloads/v9/teams.ts
+++ b/deno/payloads/v9/teams.ts
@@ -32,7 +32,7 @@ export interface APITeam {
 }
 
 /**
- * https://discord.com/developers/docs/topics/teams#data-models-team-members-object
+ * https://discord.com/developers/docs/topics/teams#data-models-team-member-object
  */
 export interface APITeamMember {
 	/**

--- a/deno/payloads/v9/template.ts
+++ b/deno/payloads/v9/template.ts
@@ -1,5 +1,5 @@
 /**
- * Types extracted from https://discord.com/developers/docs/resources/template
+ * Types extracted from https://discord.com/developers/docs/resources/guild-template
  */
 
 import type { APIUser } from './user.ts';
@@ -7,7 +7,7 @@ import type { Snowflake } from '../../globals.ts';
 import type { RESTPostAPIGuildsJSONBody } from '../../rest/v9/mod.ts';
 
 /**
- * https://discord.com/developers/docs/resources/template#template-object
+ * https://discord.com/developers/docs/resources/guild-template#template-object
  */
 export interface APITemplate {
 	/**

--- a/deno/rest/v10/guild.ts
+++ b/deno/rest/v10/guild.ts
@@ -357,7 +357,7 @@ export type RESTPatchAPIGuildChannelPositionsJSONBody = Array<
 export type RESTPatchAPIGuildChannelPositionsResult = never;
 
 /**
- * https://discord.com/developers/docs/resources/guild#list-active-threads
+ * https://discord.com/developers/docs/resources/guild#list-active-guild-threads
  */
 export type RESTGetAPIGuildThreadsResult = APIThreadList;
 

--- a/deno/rest/v9/guild.ts
+++ b/deno/rest/v9/guild.ts
@@ -357,7 +357,7 @@ export type RESTPatchAPIGuildChannelPositionsJSONBody = Array<
 export type RESTPatchAPIGuildChannelPositionsResult = never;
 
 /**
- * https://discord.com/developers/docs/resources/guild#list-active-threads
+ * https://discord.com/developers/docs/resources/guild#list-active-guild-threads
  */
 export type RESTGetAPIGuildThreadsResult = Omit<APIThreadList, 'has_more'>;
 

--- a/payloads/v10/_interactions/_applicationCommands/chatInput.ts
+++ b/payloads/v10/_interactions/_applicationCommands/chatInput.ts
@@ -108,7 +108,7 @@ export type APIApplicationCommandInteractionDataBasicOption =
 	| APIApplicationCommandInteractionDataAttachmentOption;
 
 /**
- * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data-structure
+ * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data
  */
 export interface APIChatInputApplicationCommandInteractionData
 	extends APIBaseApplicationCommandInteractionData<ApplicationCommandType.ChatInput> {

--- a/payloads/v10/_interactions/_applicationCommands/contextMenu.ts
+++ b/payloads/v10/_interactions/_applicationCommands/contextMenu.ts
@@ -10,7 +10,7 @@ import type {
 import type { APIDMInteractionWrapper, APIGuildInteractionWrapper } from '../base';
 
 /**
- * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data-structure
+ * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data
  */
 export interface APIUserApplicationCommandInteractionData
 	extends APIBaseApplicationCommandInteractionData<ApplicationCommandType.User> {
@@ -27,7 +27,7 @@ export interface APIUserApplicationCommandInteractionDataResolved {
 }
 
 /**
- * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data-structure
+ * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data
  */
 export interface APIMessageApplicationCommandInteractionData
 	extends APIBaseApplicationCommandInteractionData<ApplicationCommandType.Message> {
@@ -43,7 +43,7 @@ export interface APIMessageApplicationCommandInteractionDataResolved {
 }
 
 /**
- * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data-structure
+ * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data
  */
 export type APIContextMenuInteractionData =
 	| APIUserApplicationCommandInteractionData

--- a/payloads/v10/_interactions/applicationCommands.ts
+++ b/payloads/v10/_interactions/applicationCommands.ts
@@ -101,7 +101,7 @@ export enum ApplicationCommandType {
 }
 
 /**
- * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data-structure
+ * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data
  */
 export type APIApplicationCommandInteractionData =
 	| APIChatInputApplicationCommandInteractionData

--- a/payloads/v10/application.ts
+++ b/payloads/v10/application.ts
@@ -62,7 +62,7 @@ export interface APIApplication {
 	/**
 	 * The hexadecimal encoded key for verification in interactions and the GameSDK's GetTicket function
 	 *
-	 * See https://discord.com/developers/docs/game-sdk/applications#get-ticket
+	 * See https://discord.com/developers/docs/game-sdk/applications#getticket
 	 */
 	verify_key: string;
 	/**

--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -438,7 +438,7 @@ export interface APIMessage {
 	/**
 	 * Sent with Rich Presence-related chat embeds
 	 *
-	 * See https://discord.com/developers/docs/resources/channel#message-object-message-application-structure
+	 * See https://discord.com/developers/docs/resources/application#application-object
 	 */
 	application?: Partial<APIApplication>;
 	/**
@@ -1160,7 +1160,7 @@ export interface APIBaseComponent<T extends ComponentType> {
 }
 
 /**
- * https://discord.com/developers/docs/interactions/message-components#component-types
+ * https://discord.com/developers/docs/interactions/message-components#component-object-component-types
  */
 export enum ComponentType {
 	/**

--- a/payloads/v10/guild.ts
+++ b/payloads/v10/guild.ts
@@ -769,7 +769,7 @@ export interface APIBan {
 }
 
 /**
- * https://discord.com/developers/docs/resources/guild#get-guild-widget-example-get-guild-widget
+ * https://discord.com/developers/docs/resources/guild#guild-widget-object
  */
 export interface APIGuildWidget {
 	id: Snowflake;
@@ -781,7 +781,7 @@ export interface APIGuildWidget {
 }
 
 /**
- * https://discord.com/developers/docs/resources/guild#get-guild-widget-example-get-guild-widget
+ * https://discord.com/developers/docs/resources/guild#guild-widget-object-example-guild-widget
  */
 export interface APIGuildWidgetChannel {
 	id: Snowflake;
@@ -790,7 +790,7 @@ export interface APIGuildWidgetChannel {
 }
 
 /**
- * https://discord.com/developers/docs/resources/guild#get-guild-widget-example-get-guild-widget
+ * https://discord.com/developers/docs/resources/guild#guild-widget-object-example-guild-widget
  */
 export interface APIGuildWidgetMember {
 	id: string;

--- a/payloads/v10/invite.ts
+++ b/payloads/v10/invite.ts
@@ -53,7 +53,7 @@ export interface APIInvite {
 	/**
 	 * The type of target for this voice channel invite
 	 *
-	 * See https://discord.com/developers/docs/resources/invite#invite-object-target-user-types
+	 * See https://discord.com/developers/docs/resources/invite#invite-object-invite-target-types
 	 */
 	target_type?: InviteTargetType;
 	/**
@@ -65,7 +65,7 @@ export interface APIInvite {
 	/**
 	 * The embedded application to open for this voice channel embedded application invite
 	 *
-	 * See https://discord.com/developers/docs/topics/oauth2#application
+	 * See https://discord.com/developers/docs/resources/application#application-object
 	 */
 	target_application?: Partial<APIApplication>;
 	/**

--- a/payloads/v10/teams.ts
+++ b/payloads/v10/teams.ts
@@ -32,7 +32,7 @@ export interface APITeam {
 }
 
 /**
- * https://discord.com/developers/docs/topics/teams#data-models-team-members-object
+ * https://discord.com/developers/docs/topics/teams#data-models-team-member-object
  */
 export interface APITeamMember {
 	/**

--- a/payloads/v10/template.ts
+++ b/payloads/v10/template.ts
@@ -1,5 +1,5 @@
 /**
- * Types extracted from https://discord.com/developers/docs/resources/template
+ * Types extracted from https://discord.com/developers/docs/resources/guild-template
  */
 
 import type { APIUser } from './user';
@@ -7,7 +7,7 @@ import type { Snowflake } from '../../globals';
 import type { RESTPostAPIGuildsJSONBody } from '../../rest/v10/index';
 
 /**
- * https://discord.com/developers/docs/resources/template#template-object
+ * https://discord.com/developers/docs/resources/guild-template#guild-template-object
  */
 export interface APITemplate {
 	/**

--- a/payloads/v9/_interactions/_applicationCommands/chatInput.ts
+++ b/payloads/v9/_interactions/_applicationCommands/chatInput.ts
@@ -108,7 +108,7 @@ export type APIApplicationCommandInteractionDataBasicOption =
 	| APIApplicationCommandInteractionDataAttachmentOption;
 
 /**
- * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data-structure
+ * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data
  */
 export interface APIChatInputApplicationCommandInteractionData
 	extends APIBaseApplicationCommandInteractionData<ApplicationCommandType.ChatInput> {

--- a/payloads/v9/_interactions/_applicationCommands/contextMenu.ts
+++ b/payloads/v9/_interactions/_applicationCommands/contextMenu.ts
@@ -10,7 +10,7 @@ import type {
 import type { APIDMInteractionWrapper, APIGuildInteractionWrapper } from '../base';
 
 /**
- * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data-structure
+ * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data
  */
 export interface APIUserApplicationCommandInteractionData
 	extends APIBaseApplicationCommandInteractionData<ApplicationCommandType.User> {
@@ -27,7 +27,7 @@ export interface APIUserApplicationCommandInteractionDataResolved {
 }
 
 /**
- * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data-structure
+ * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data
  */
 export interface APIMessageApplicationCommandInteractionData
 	extends APIBaseApplicationCommandInteractionData<ApplicationCommandType.Message> {
@@ -43,7 +43,7 @@ export interface APIMessageApplicationCommandInteractionDataResolved {
 }
 
 /**
- * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data-structure
+ * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data
  */
 export type APIContextMenuInteractionData =
 	| APIUserApplicationCommandInteractionData

--- a/payloads/v9/_interactions/applicationCommands.ts
+++ b/payloads/v9/_interactions/applicationCommands.ts
@@ -101,7 +101,7 @@ export enum ApplicationCommandType {
 }
 
 /**
- * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data-structure
+ * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data
  */
 export type APIApplicationCommandInteractionData =
 	| APIChatInputApplicationCommandInteractionData

--- a/payloads/v9/application.ts
+++ b/payloads/v9/application.ts
@@ -62,7 +62,7 @@ export interface APIApplication {
 	/**
 	 * The hexadecimal encoded key for verification in interactions and the GameSDK's GetTicket function
 	 *
-	 * See https://discord.com/developers/docs/game-sdk/applications#get-ticket
+	 * See https://discord.com/developers/docs/game-sdk/applications#getticket
 	 */
 	verify_key: string;
 	/**

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -438,7 +438,7 @@ export interface APIMessage {
 	/**
 	 * Sent with Rich Presence-related chat embeds
 	 *
-	 * See https://discord.com/developers/docs/resources/channel#message-object-message-application-structure
+	 * See https://discord.com/developers/docs/resources/application#application-object
 	 */
 	application?: Partial<APIApplication>;
 	/**
@@ -1164,7 +1164,7 @@ export interface APIBaseComponent<T extends ComponentType> {
 }
 
 /**
- * https://discord.com/developers/docs/interactions/message-components#component-types
+ * https://discord.com/developers/docs/interactions/message-components#component-object-component-types
  */
 export enum ComponentType {
 	/**

--- a/payloads/v9/guild.ts
+++ b/payloads/v9/guild.ts
@@ -769,7 +769,7 @@ export interface APIBan {
 }
 
 /**
- * https://discord.com/developers/docs/resources/guild#get-guild-widget-example-get-guild-widget
+ * https://discord.com/developers/docs/resources/guild#guild-widget-object
  */
 export interface APIGuildWidget {
 	id: Snowflake;
@@ -781,7 +781,7 @@ export interface APIGuildWidget {
 }
 
 /**
- * https://discord.com/developers/docs/resources/guild#get-guild-widget-example-get-guild-widget
+ * https://discord.com/developers/docs/resources/guild#guild-widget-object-example-guild-widget
  */
 export interface APIGuildWidgetChannel {
 	id: Snowflake;
@@ -790,7 +790,7 @@ export interface APIGuildWidgetChannel {
 }
 
 /**
- * https://discord.com/developers/docs/resources/guild#get-guild-widget-example-get-guild-widget
+ * https://discord.com/developers/docs/resources/guild#guild-widget-object-example-guild-widget
  */
 export interface APIGuildWidgetMember {
 	id: string;

--- a/payloads/v9/invite.ts
+++ b/payloads/v9/invite.ts
@@ -53,7 +53,7 @@ export interface APIInvite {
 	/**
 	 * The type of target for this voice channel invite
 	 *
-	 * See https://discord.com/developers/docs/resources/invite#invite-object-target-user-types
+	 * See https://discord.com/developers/docs/resources/invite#invite-object-invite-target-types
 	 */
 	target_type?: InviteTargetType;
 	/**
@@ -65,7 +65,7 @@ export interface APIInvite {
 	/**
 	 * The embedded application to open for this voice channel embedded application invite
 	 *
-	 * See https://discord.com/developers/docs/topics/oauth2#application
+	 * See https://discord.com/developers/docs/resources/application#application-object
 	 */
 	target_application?: Partial<APIApplication>;
 	/**

--- a/payloads/v9/teams.ts
+++ b/payloads/v9/teams.ts
@@ -32,7 +32,7 @@ export interface APITeam {
 }
 
 /**
- * https://discord.com/developers/docs/topics/teams#data-models-team-members-object
+ * https://discord.com/developers/docs/topics/teams#data-models-team-member-object
  */
 export interface APITeamMember {
 	/**

--- a/payloads/v9/template.ts
+++ b/payloads/v9/template.ts
@@ -1,5 +1,5 @@
 /**
- * Types extracted from https://discord.com/developers/docs/resources/template
+ * Types extracted from https://discord.com/developers/docs/resources/guild-template
  */
 
 import type { APIUser } from './user';
@@ -7,7 +7,7 @@ import type { Snowflake } from '../../globals';
 import type { RESTPostAPIGuildsJSONBody } from '../../rest/v9/index';
 
 /**
- * https://discord.com/developers/docs/resources/template#template-object
+ * https://discord.com/developers/docs/resources/guild-template#template-object
  */
 export interface APITemplate {
 	/**

--- a/rest/v10/guild.ts
+++ b/rest/v10/guild.ts
@@ -357,7 +357,7 @@ export type RESTPatchAPIGuildChannelPositionsJSONBody = Array<
 export type RESTPatchAPIGuildChannelPositionsResult = never;
 
 /**
- * https://discord.com/developers/docs/resources/guild#list-active-threads
+ * https://discord.com/developers/docs/resources/guild#list-active-guild-threads
  */
 export type RESTGetAPIGuildThreadsResult = APIThreadList;
 

--- a/rest/v9/guild.ts
+++ b/rest/v9/guild.ts
@@ -357,7 +357,7 @@ export type RESTPatchAPIGuildChannelPositionsJSONBody = Array<
 export type RESTPatchAPIGuildChannelPositionsResult = never;
 
 /**
- * https://discord.com/developers/docs/resources/guild#list-active-threads
+ * https://discord.com/developers/docs/resources/guild#list-active-guild-threads
  */
 export type RESTGetAPIGuildThreadsResult = Omit<APIThreadList, 'has_more'>;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Replaces the wrong reference links from Discord API Docs that are mistyped/outdated.

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
