### PR TITLE
fix(RESTPatchAPIGuildVoiceStateCurrentMemberJSONBody): `channel_id` is optional

### DIFF
--- a/deno/rest/v10/guild.ts
+++ b/deno/rest/v10/guild.ts
@@ -855,7 +855,7 @@ export type RESTPatchAPIGuildVoiceStateCurrentMemberJSONBody = AddUndefinedToPos
 	/**
 	 * The id of the channel the user is currently in
 	 */
-	channel_id: Snowflake;
+	channel_id?: Snowflake;
 	/**
 	 * Toggles the user's suppress state
 	 */

--- a/deno/rest/v9/guild.ts
+++ b/deno/rest/v9/guild.ts
@@ -861,7 +861,7 @@ export type RESTPatchAPIGuildVoiceStateCurrentMemberJSONBody = AddUndefinedToPos
 	/**
 	 * The id of the channel the user is currently in
 	 */
-	channel_id: Snowflake;
+	channel_id?: Snowflake;
 	/**
 	 * Toggles the user's suppress state
 	 */

--- a/rest/v10/guild.ts
+++ b/rest/v10/guild.ts
@@ -855,7 +855,7 @@ export type RESTPatchAPIGuildVoiceStateCurrentMemberJSONBody = AddUndefinedToPos
 	/**
 	 * The id of the channel the user is currently in
 	 */
-	channel_id: Snowflake;
+	channel_id?: Snowflake;
 	/**
 	 * Toggles the user's suppress state
 	 */

--- a/rest/v9/guild.ts
+++ b/rest/v9/guild.ts
@@ -861,7 +861,7 @@ export type RESTPatchAPIGuildVoiceStateCurrentMemberJSONBody = AddUndefinedToPos
 	/**
 	 * The id of the channel the user is currently in
 	 */
-	channel_id: Snowflake;
+	channel_id?: Snowflake;
 	/**
 	 * Toggles the user's suppress state
 	 */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
- https://github.com/discord/discord-api-docs/pull/5261
