### PR TITLE
docs: add notes about `MESSAGE_CONTENT` intent in affected data fields

### DIFF
--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -345,8 +345,7 @@ export interface APIMessage {
 	/**
 	 * Contents of the message
 	 *
-	 * `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent for verified apps,
-	 * this intent is required to receive a non-empty value from this field
+	 * The `MESSAGE_CONTENT` (`1 << 15`) privileged gateway intent is required for verified applications, to receive a non-empty value from this field
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
@@ -400,8 +399,7 @@ export interface APIMessage {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#attachment-object
 	 *
-	 * `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent for verified apps,
-	 * this intent is required to receive a non-empty value from this field
+	 * The `MESSAGE_CONTENT` (`1 << 15`) privileged gateway intent is required for verified applications, to receive a non-empty value from this field
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
@@ -411,8 +409,7 @@ export interface APIMessage {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#embed-object
 	 *
-	 * `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent for verified apps,
-	 * this intent is required to receive a non-empty value from this field
+	 * The `MESSAGE_CONTENT` (`1 << 15`) privileged gateway intent is required for verified applications, to receive a non-empty value from this field
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
@@ -499,8 +496,7 @@ export interface APIMessage {
 	/**
 	 * Sent if the message contains components like buttons, action rows, or other interactive components
 	 *
-	 * `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent for verified apps,
-	 * this intent is required to receive a non-empty value from this field
+	 * The `MESSAGE_CONTENT` (`1 << 15`) privileged gateway intent is required for verified applications, to receive a non-empty value from this field
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */

--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -345,7 +345,7 @@ export interface APIMessage {
 	/**
 	 * Contents of the message
 	 *
-	 * After August 31, 2022, `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent to verified apps,
+	 * `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent for verified apps,
 	 * this intent is required to receive a non-empty value from this field
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
@@ -400,7 +400,7 @@ export interface APIMessage {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#attachment-object
 	 *
-	 * After August 31, 2022, `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent to verified apps,
+	 * `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent for verified apps,
 	 * this intent is required to receive a non-empty value from this field
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
@@ -411,7 +411,7 @@ export interface APIMessage {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#embed-object
 	 *
-	 * After August 31, 2022, `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent to verified apps,
+	 * `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent for verified apps,
 	 * this intent is required to receive a non-empty value from this field
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
@@ -499,7 +499,7 @@ export interface APIMessage {
 	/**
 	 * Sent if the message contains components like buttons, action rows, or other interactive components
 	 *
-	 * After August 31, 2022, `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent to verified apps,
+	 * `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent for verified apps,
 	 * this intent is required to receive a non-empty value from this field
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055

--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -344,6 +344,11 @@ export interface APIMessage {
 	author: APIUser;
 	/**
 	 * Contents of the message
+	 *
+	 * After August 31, 2022, `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent to verified apps,
+	 * this intent is required to receive a non-empty value from this field
+	 *
+	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
 	content: string;
 	/**
@@ -394,12 +399,22 @@ export interface APIMessage {
 	 * Any attached files
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#attachment-object
+	 *
+	 * After August 31, 2022, `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent to verified apps,
+	 * this intent is required to receive a non-empty value from this field
+	 *
+	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
 	attachments: APIAttachment[];
 	/**
 	 * Any embedded content
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#embed-object
+	 *
+	 * After August 31, 2022, `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent to verified apps,
+	 * this intent is required to receive a non-empty value from this field
+	 *
+	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
 	embeds: APIEmbed[];
 	/**
@@ -483,6 +498,11 @@ export interface APIMessage {
 	thread?: APIChannel;
 	/**
 	 * Sent if the message contains components like buttons, action rows, or other interactive components
+	 *
+	 * After August 31, 2022, `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent to verified apps,
+	 * this intent is required to receive a non-empty value from this field
+	 *
+	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
 	components?: APIActionRowComponent<APIMessageActionRowComponent>[];
 	/**

--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -345,10 +345,10 @@ export interface APIMessage {
 	/**
 	 * Contents of the message
 	 *
-	 * The **`MESSAGE_CONTENT`** privileged gateway intent is required for verified applications to receive a non-empty value from this field
+	 * The `MESSAGE_CONTENT` privileged gateway intent is required for verified applications to receive a non-empty value from this field
 	 *
-	 * In Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**.
-	 * You also need to specify the intent bit value  (**`1 << 15`**) if you are connecting to the gateway
+	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**.
+	 * You also need to specify the intent bit value (`1 << 15`) if you are connecting to the gateway
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
@@ -402,10 +402,10 @@ export interface APIMessage {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#attachment-object
 	 *
-	 * The **`MESSAGE_CONTENT`** privileged gateway intent is required for verified applications to receive a non-empty value from this field
+	 * The `MESSAGE_CONTENT` privileged gateway intent is required for verified applications to receive a non-empty value from this field
 	 *
-	 * In Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**.
-	 * You also need to specify the intent bit value  (**`1 << 15`**) if you are connecting to the gateway
+	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**.
+	 * You also need to specify the intent bit value (`1 << 15`) if you are connecting to the gateway
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
@@ -415,10 +415,10 @@ export interface APIMessage {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#embed-object
 	 *
-	 * The **`MESSAGE_CONTENT`** privileged gateway intent is required for verified applications to receive a non-empty value from this field
+	 * The `MESSAGE_CONTENT` privileged gateway intent is required for verified applications to receive a non-empty value from this field
 	 *
-	 * In Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**.
-	 * You also need to specify the intent bit value  (**`1 << 15`**) if you are connecting to the gateway
+	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**.
+	 * You also need to specify the intent bit value (`1 << 15`) if you are connecting to the gateway
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
@@ -505,10 +505,10 @@ export interface APIMessage {
 	/**
 	 * Sent if the message contains components like buttons, action rows, or other interactive components
 	 *
-	 * The **`MESSAGE_CONTENT`** privileged gateway intent is required for verified applications to receive a non-empty value from this field
+	 * The `MESSAGE_CONTENT` privileged gateway intent is required for verified applications to receive a non-empty value from this field
 	 *
-	 * In Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**.
-	 * You also need to specify the intent bit value  (**`1 << 15`**) if you are connecting to the gateway
+	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**.
+	 * You also need to specify the intent bit value (`1 << 15`) if you are connecting to the gateway
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */

--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -345,7 +345,10 @@ export interface APIMessage {
 	/**
 	 * Contents of the message
 	 *
-	 * The `MESSAGE_CONTENT` (`1 << 15`) privileged gateway intent is required for verified applications, to receive a non-empty value from this field
+	 * The **`MESSAGE_CONTENT`** privileged gateway intent is required for verified applications to receive a non-empty value from this field
+	 *
+	 * In Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**.
+	 * You also need to specify the intent bit value  (**`1 << 15`**) if you are connecting to the gateway
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
@@ -399,7 +402,10 @@ export interface APIMessage {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#attachment-object
 	 *
-	 * The `MESSAGE_CONTENT` (`1 << 15`) privileged gateway intent is required for verified applications, to receive a non-empty value from this field
+	 * The **`MESSAGE_CONTENT`** privileged gateway intent is required for verified applications to receive a non-empty value from this field
+	 *
+	 * In Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**.
+	 * You also need to specify the intent bit value  (**`1 << 15`**) if you are connecting to the gateway
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
@@ -409,7 +415,10 @@ export interface APIMessage {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#embed-object
 	 *
-	 * The `MESSAGE_CONTENT` (`1 << 15`) privileged gateway intent is required for verified applications, to receive a non-empty value from this field
+	 * The **`MESSAGE_CONTENT`** privileged gateway intent is required for verified applications to receive a non-empty value from this field
+	 *
+	 * In Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**.
+	 * You also need to specify the intent bit value  (**`1 << 15`**) if you are connecting to the gateway
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
@@ -496,7 +505,10 @@ export interface APIMessage {
 	/**
 	 * Sent if the message contains components like buttons, action rows, or other interactive components
 	 *
-	 * The `MESSAGE_CONTENT` (`1 << 15`) privileged gateway intent is required for verified applications, to receive a non-empty value from this field
+	 * The **`MESSAGE_CONTENT`** privileged gateway intent is required for verified applications to receive a non-empty value from this field
+	 *
+	 * In Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**.
+	 * You also need to specify the intent bit value  (**`1 << 15`**) if you are connecting to the gateway
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -345,8 +345,7 @@ export interface APIMessage {
 	/**
 	 * Contents of the message
 	 *
-	 * `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent for verified apps,
-	 * this intent is required to receive a non-empty value from this field
+	 * The `MESSAGE_CONTENT` (`1 << 15`) privileged gateway intent will become required after August 31, 2022 for verified applications, to receive a non-empty value from this field
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
@@ -400,8 +399,7 @@ export interface APIMessage {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#attachment-object
 	 *
-	 * `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent for verified apps,
-	 * this intent is required to receive a non-empty value from this field
+	 * The `MESSAGE_CONTENT` (`1 << 15`) privileged gateway intent will become required after August 31, 2022 for verified applications, to receive a non-empty value from this field
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
@@ -411,8 +409,7 @@ export interface APIMessage {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#embed-object
 	 *
-	 * `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent for verified apps,
-	 * this intent is required to receive a non-empty value from this field
+	 * The `MESSAGE_CONTENT` (`1 << 15`) privileged gateway intent will become required after August 31, 2022 for verified applications, to receive a non-empty value from this field
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
@@ -499,8 +496,7 @@ export interface APIMessage {
 	/**
 	 * Sent if the message contains components like buttons, action rows, or other interactive components
 	 *
-	 * `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent for verified apps,
-	 * this intent is required to receive a non-empty value from this field
+	 * The `MESSAGE_CONTENT` (`1 << 15`) privileged gateway intent will become required after August 31, 2022 for verified applications, to receive a non-empty value from this field
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -345,7 +345,9 @@ export interface APIMessage {
 	/**
 	 * Contents of the message
 	 *
-	 * The `MESSAGE_CONTENT` (`1 << 15`) privileged gateway intent will become required after August 31, 2022 for verified applications, to receive a non-empty value from this field
+	 * The **`MESSAGE_CONTENT`** privileged gateway intent will become required after **August 31, 2022** for verified applications to receive a non-empty value from this field
+	 *
+	 * In Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
@@ -399,7 +401,9 @@ export interface APIMessage {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#attachment-object
 	 *
-	 * The `MESSAGE_CONTENT` (`1 << 15`) privileged gateway intent will become required after August 31, 2022 for verified applications, to receive a non-empty value from this field
+	 * The **`MESSAGE_CONTENT`** privileged gateway intent will become required after **August 31, 2022** for verified applications to receive a non-empty value from this field
+	 *
+	 * In Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
@@ -409,7 +413,9 @@ export interface APIMessage {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#embed-object
 	 *
-	 * The `MESSAGE_CONTENT` (`1 << 15`) privileged gateway intent will become required after August 31, 2022 for verified applications, to receive a non-empty value from this field
+	 * The **`MESSAGE_CONTENT`** privileged gateway intent will become required after **August 31, 2022** for verified applications to receive a non-empty value from this field
+	 *
+	 * In Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
@@ -496,7 +502,9 @@ export interface APIMessage {
 	/**
 	 * Sent if the message contains components like buttons, action rows, or other interactive components
 	 *
-	 * The `MESSAGE_CONTENT` (`1 << 15`) privileged gateway intent will become required after August 31, 2022 for verified applications, to receive a non-empty value from this field
+	 * The **`MESSAGE_CONTENT`** privileged gateway intent will become required after **August 31, 2022** for verified applications to receive a non-empty value from this field
+	 *
+	 * In Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -345,7 +345,7 @@ export interface APIMessage {
 	/**
 	 * Contents of the message
 	 *
-	 * After August 31, 2022, `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent to verified apps,
+	 * `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent for verified apps,
 	 * this intent is required to receive a non-empty value from this field
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
@@ -400,7 +400,7 @@ export interface APIMessage {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#attachment-object
 	 *
-	 * After August 31, 2022, `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent to verified apps,
+	 * `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent for verified apps,
 	 * this intent is required to receive a non-empty value from this field
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
@@ -411,7 +411,7 @@ export interface APIMessage {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#embed-object
 	 *
-	 * After August 31, 2022, `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent to verified apps,
+	 * `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent for verified apps,
 	 * this intent is required to receive a non-empty value from this field
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
@@ -499,7 +499,7 @@ export interface APIMessage {
 	/**
 	 * Sent if the message contains components like buttons, action rows, or other interactive components
 	 *
-	 * After August 31, 2022, `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent to verified apps,
+	 * `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent for verified apps,
 	 * this intent is required to receive a non-empty value from this field
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -344,6 +344,11 @@ export interface APIMessage {
 	author: APIUser;
 	/**
 	 * Contents of the message
+	 *
+	 * After August 31, 2022, `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent to verified apps,
+	 * this intent is required to receive a non-empty value from this field
+	 *
+	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
 	content: string;
 	/**
@@ -394,12 +399,22 @@ export interface APIMessage {
 	 * Any attached files
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#attachment-object
+	 *
+	 * After August 31, 2022, `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent to verified apps,
+	 * this intent is required to receive a non-empty value from this field
+	 *
+	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
 	attachments: APIAttachment[];
 	/**
 	 * Any embedded content
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#embed-object
+	 *
+	 * After August 31, 2022, `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent to verified apps,
+	 * this intent is required to receive a non-empty value from this field
+	 *
+	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
 	embeds: APIEmbed[];
 	/**
@@ -483,6 +498,11 @@ export interface APIMessage {
 	thread?: APIChannel;
 	/**
 	 * Sent if the message contains components like buttons, action rows, or other interactive components
+	 *
+	 * After August 31, 2022, `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent to verified apps,
+	 * this intent is required to receive a non-empty value from this field
+	 *
+	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
 	components?: APIActionRowComponent<APIMessageActionRowComponent>[];
 	/**

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -345,9 +345,9 @@ export interface APIMessage {
 	/**
 	 * Contents of the message
 	 *
-	 * The **`MESSAGE_CONTENT`** privileged gateway intent will become required after **August 31, 2022** for verified applications to receive a non-empty value from this field
+	 * The `MESSAGE_CONTENT` privileged gateway intent will become required after **August 31, 2022** for verified applications to receive a non-empty value from this field
 	 *
-	 * In Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**
+	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
@@ -401,9 +401,9 @@ export interface APIMessage {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#attachment-object
 	 *
-	 * The **`MESSAGE_CONTENT`** privileged gateway intent will become required after **August 31, 2022** for verified applications to receive a non-empty value from this field
+	 * The `MESSAGE_CONTENT` privileged gateway intent will become required after **August 31, 2022** for verified applications to receive a non-empty value from this field
 	 *
-	 * In Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**
+	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
@@ -413,9 +413,9 @@ export interface APIMessage {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#embed-object
 	 *
-	 * The **`MESSAGE_CONTENT`** privileged gateway intent will become required after **August 31, 2022** for verified applications to receive a non-empty value from this field
+	 * The `MESSAGE_CONTENT` privileged gateway intent will become required after **August 31, 2022** for verified applications to receive a non-empty value from this field
 	 *
-	 * In Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**
+	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
@@ -502,9 +502,9 @@ export interface APIMessage {
 	/**
 	 * Sent if the message contains components like buttons, action rows, or other interactive components
 	 *
-	 * The **`MESSAGE_CONTENT`** privileged gateway intent will become required after **August 31, 2022** for verified applications to receive a non-empty value from this field
+	 * The `MESSAGE_CONTENT` privileged gateway intent will become required after **August 31, 2022** for verified applications to receive a non-empty value from this field
 	 *
-	 * In Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**
+	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */

--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -345,8 +345,7 @@ export interface APIMessage {
 	/**
 	 * Contents of the message
 	 *
-	 * `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent for verified apps,
-	 * this intent is required to receive a non-empty value from this field
+	 * The `MESSAGE_CONTENT` (`1 << 15`) privileged gateway intent is required for verified applications, to receive a non-empty value from this field
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
@@ -400,8 +399,7 @@ export interface APIMessage {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#attachment-object
 	 *
-	 * `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent for verified apps,
-	 * this intent is required to receive a non-empty value from this field
+	 * The `MESSAGE_CONTENT` (`1 << 15`) privileged gateway intent is required for verified applications, to receive a non-empty value from this field
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
@@ -411,8 +409,7 @@ export interface APIMessage {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#embed-object
 	 *
-	 * `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent for verified apps,
-	 * this intent is required to receive a non-empty value from this field
+	 * The `MESSAGE_CONTENT` (`1 << 15`) privileged gateway intent is required for verified applications, to receive a non-empty value from this field
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
@@ -499,8 +496,7 @@ export interface APIMessage {
 	/**
 	 * Sent if the message contains components like buttons, action rows, or other interactive components
 	 *
-	 * `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent for verified apps,
-	 * this intent is required to receive a non-empty value from this field
+	 * The `MESSAGE_CONTENT` (`1 << 15`) privileged gateway intent is required for verified applications, to receive a non-empty value from this field
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */

--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -345,7 +345,7 @@ export interface APIMessage {
 	/**
 	 * Contents of the message
 	 *
-	 * After August 31, 2022, `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent to verified apps,
+	 * `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent for verified apps,
 	 * this intent is required to receive a non-empty value from this field
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
@@ -400,7 +400,7 @@ export interface APIMessage {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#attachment-object
 	 *
-	 * After August 31, 2022, `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent to verified apps,
+	 * `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent for verified apps,
 	 * this intent is required to receive a non-empty value from this field
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
@@ -411,7 +411,7 @@ export interface APIMessage {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#embed-object
 	 *
-	 * After August 31, 2022, `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent to verified apps,
+	 * `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent for verified apps,
 	 * this intent is required to receive a non-empty value from this field
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
@@ -499,7 +499,7 @@ export interface APIMessage {
 	/**
 	 * Sent if the message contains components like buttons, action rows, or other interactive components
 	 *
-	 * After August 31, 2022, `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent to verified apps,
+	 * `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent for verified apps,
 	 * this intent is required to receive a non-empty value from this field
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055

--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -344,6 +344,11 @@ export interface APIMessage {
 	author: APIUser;
 	/**
 	 * Contents of the message
+	 *
+	 * After August 31, 2022, `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent to verified apps,
+	 * this intent is required to receive a non-empty value from this field
+	 *
+	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
 	content: string;
 	/**
@@ -394,12 +399,22 @@ export interface APIMessage {
 	 * Any attached files
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#attachment-object
+	 *
+	 * After August 31, 2022, `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent to verified apps,
+	 * this intent is required to receive a non-empty value from this field
+	 *
+	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
 	attachments: APIAttachment[];
 	/**
 	 * Any embedded content
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#embed-object
+	 *
+	 * After August 31, 2022, `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent to verified apps,
+	 * this intent is required to receive a non-empty value from this field
+	 *
+	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
 	embeds: APIEmbed[];
 	/**
@@ -483,6 +498,11 @@ export interface APIMessage {
 	thread?: APIChannel;
 	/**
 	 * Sent if the message contains components like buttons, action rows, or other interactive components
+	 *
+	 * After August 31, 2022, `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent to verified apps,
+	 * this intent is required to receive a non-empty value from this field
+	 *
+	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
 	components?: APIActionRowComponent<APIMessageActionRowComponent>[];
 	/**

--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -345,10 +345,10 @@ export interface APIMessage {
 	/**
 	 * Contents of the message
 	 *
-	 * The **`MESSAGE_CONTENT`** privileged gateway intent is required for verified applications to receive a non-empty value from this field
+	 * The `MESSAGE_CONTENT` privileged gateway intent is required for verified applications to receive a non-empty value from this field
 	 *
-	 * In Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**.
-	 * You also need to specify the intent bit value  (**`1 << 15`**) if you are connecting to the gateway
+	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**.
+	 * You also need to specify the intent bit value (`1 << 15`) if you are connecting to the gateway
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
@@ -402,10 +402,10 @@ export interface APIMessage {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#attachment-object
 	 *
-	 * The **`MESSAGE_CONTENT`** privileged gateway intent is required for verified applications to receive a non-empty value from this field
+	 * The `MESSAGE_CONTENT` privileged gateway intent is required for verified applications to receive a non-empty value from this field
 	 *
-	 * In Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**.
-	 * You also need to specify the intent bit value  (**`1 << 15`**) if you are connecting to the gateway
+	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**.
+	 * You also need to specify the intent bit value (`1 << 15`) if you are connecting to the gateway
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
@@ -415,10 +415,10 @@ export interface APIMessage {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#embed-object
 	 *
-	 * The **`MESSAGE_CONTENT`** privileged gateway intent is required for verified applications to receive a non-empty value from this field
+	 * The `MESSAGE_CONTENT` privileged gateway intent is required for verified applications to receive a non-empty value from this field
 	 *
-	 * In Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**.
-	 * You also need to specify the intent bit value  (**`1 << 15`**) if you are connecting to the gateway
+	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**.
+	 * You also need to specify the intent bit value (`1 << 15`) if you are connecting to the gateway
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
@@ -505,10 +505,10 @@ export interface APIMessage {
 	/**
 	 * Sent if the message contains components like buttons, action rows, or other interactive components
 	 *
-	 * The **`MESSAGE_CONTENT`** privileged gateway intent is required for verified applications to receive a non-empty value from this field
+	 * The `MESSAGE_CONTENT` privileged gateway intent is required for verified applications to receive a non-empty value from this field
 	 *
-	 * In Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**.
-	 * You also need to specify the intent bit value  (**`1 << 15`**) if you are connecting to the gateway
+	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**.
+	 * You also need to specify the intent bit value (`1 << 15`) if you are connecting to the gateway
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */

--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -345,7 +345,10 @@ export interface APIMessage {
 	/**
 	 * Contents of the message
 	 *
-	 * The `MESSAGE_CONTENT` (`1 << 15`) privileged gateway intent is required for verified applications, to receive a non-empty value from this field
+	 * The **`MESSAGE_CONTENT`** privileged gateway intent is required for verified applications to receive a non-empty value from this field
+	 *
+	 * In Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**.
+	 * You also need to specify the intent bit value  (**`1 << 15`**) if you are connecting to the gateway
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
@@ -399,7 +402,10 @@ export interface APIMessage {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#attachment-object
 	 *
-	 * The `MESSAGE_CONTENT` (`1 << 15`) privileged gateway intent is required for verified applications, to receive a non-empty value from this field
+	 * The **`MESSAGE_CONTENT`** privileged gateway intent is required for verified applications to receive a non-empty value from this field
+	 *
+	 * In Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**.
+	 * You also need to specify the intent bit value  (**`1 << 15`**) if you are connecting to the gateway
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
@@ -409,7 +415,10 @@ export interface APIMessage {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#embed-object
 	 *
-	 * The `MESSAGE_CONTENT` (`1 << 15`) privileged gateway intent is required for verified applications, to receive a non-empty value from this field
+	 * The **`MESSAGE_CONTENT`** privileged gateway intent is required for verified applications to receive a non-empty value from this field
+	 *
+	 * In Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**.
+	 * You also need to specify the intent bit value  (**`1 << 15`**) if you are connecting to the gateway
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
@@ -496,7 +505,10 @@ export interface APIMessage {
 	/**
 	 * Sent if the message contains components like buttons, action rows, or other interactive components
 	 *
-	 * The `MESSAGE_CONTENT` (`1 << 15`) privileged gateway intent is required for verified applications, to receive a non-empty value from this field
+	 * The **`MESSAGE_CONTENT`** privileged gateway intent is required for verified applications to receive a non-empty value from this field
+	 *
+	 * In Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**.
+	 * You also need to specify the intent bit value  (**`1 << 15`**) if you are connecting to the gateway
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -345,8 +345,7 @@ export interface APIMessage {
 	/**
 	 * Contents of the message
 	 *
-	 * `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent for verified apps,
-	 * this intent is required to receive a non-empty value from this field
+	 * The `MESSAGE_CONTENT` (`1 << 15`) privileged gateway intent will become required after August 31, 2022 for verified applications, to receive a non-empty value from this field
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
@@ -400,8 +399,7 @@ export interface APIMessage {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#attachment-object
 	 *
-	 * `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent for verified apps,
-	 * this intent is required to receive a non-empty value from this field
+	 * The `MESSAGE_CONTENT` (`1 << 15`) privileged gateway intent will become required after August 31, 2022 for verified applications, to receive a non-empty value from this field
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
@@ -411,8 +409,7 @@ export interface APIMessage {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#embed-object
 	 *
-	 * `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent for verified apps,
-	 * this intent is required to receive a non-empty value from this field
+	 * The `MESSAGE_CONTENT` (`1 << 15`) privileged gateway intent will become required after August 31, 2022 for verified applications, to receive a non-empty value from this field
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
@@ -499,8 +496,7 @@ export interface APIMessage {
 	/**
 	 * Sent if the message contains components like buttons, action rows, or other interactive components
 	 *
-	 * `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent for verified apps,
-	 * this intent is required to receive a non-empty value from this field
+	 * The `MESSAGE_CONTENT` (`1 << 15`) privileged gateway intent will become required after August 31, 2022 for verified applications, to receive a non-empty value from this field
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -345,7 +345,9 @@ export interface APIMessage {
 	/**
 	 * Contents of the message
 	 *
-	 * The `MESSAGE_CONTENT` (`1 << 15`) privileged gateway intent will become required after August 31, 2022 for verified applications, to receive a non-empty value from this field
+	 * The **`MESSAGE_CONTENT`** privileged gateway intent will become required after **August 31, 2022** for verified applications to receive a non-empty value from this field
+	 *
+	 * In Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
@@ -399,7 +401,9 @@ export interface APIMessage {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#attachment-object
 	 *
-	 * The `MESSAGE_CONTENT` (`1 << 15`) privileged gateway intent will become required after August 31, 2022 for verified applications, to receive a non-empty value from this field
+	 * The **`MESSAGE_CONTENT`** privileged gateway intent will become required after **August 31, 2022** for verified applications to receive a non-empty value from this field
+	 *
+	 * In Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
@@ -409,7 +413,9 @@ export interface APIMessage {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#embed-object
 	 *
-	 * The `MESSAGE_CONTENT` (`1 << 15`) privileged gateway intent will become required after August 31, 2022 for verified applications, to receive a non-empty value from this field
+	 * The **`MESSAGE_CONTENT`** privileged gateway intent will become required after **August 31, 2022** for verified applications to receive a non-empty value from this field
+	 *
+	 * In Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
@@ -496,7 +502,9 @@ export interface APIMessage {
 	/**
 	 * Sent if the message contains components like buttons, action rows, or other interactive components
 	 *
-	 * The `MESSAGE_CONTENT` (`1 << 15`) privileged gateway intent will become required after August 31, 2022 for verified applications, to receive a non-empty value from this field
+	 * The **`MESSAGE_CONTENT`** privileged gateway intent will become required after **August 31, 2022** for verified applications to receive a non-empty value from this field
+	 *
+	 * In Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -345,7 +345,7 @@ export interface APIMessage {
 	/**
 	 * Contents of the message
 	 *
-	 * After August 31, 2022, `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent to verified apps,
+	 * `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent for verified apps,
 	 * this intent is required to receive a non-empty value from this field
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
@@ -400,7 +400,7 @@ export interface APIMessage {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#attachment-object
 	 *
-	 * After August 31, 2022, `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent to verified apps,
+	 * `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent for verified apps,
 	 * this intent is required to receive a non-empty value from this field
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
@@ -411,7 +411,7 @@ export interface APIMessage {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#embed-object
 	 *
-	 * After August 31, 2022, `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent to verified apps,
+	 * `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent for verified apps,
 	 * this intent is required to receive a non-empty value from this field
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
@@ -499,7 +499,7 @@ export interface APIMessage {
 	/**
 	 * Sent if the message contains components like buttons, action rows, or other interactive components
 	 *
-	 * After August 31, 2022, `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent to verified apps,
+	 * `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent for verified apps,
 	 * this intent is required to receive a non-empty value from this field
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -344,6 +344,11 @@ export interface APIMessage {
 	author: APIUser;
 	/**
 	 * Contents of the message
+	 *
+	 * After August 31, 2022, `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent to verified apps,
+	 * this intent is required to receive a non-empty value from this field
+	 *
+	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
 	content: string;
 	/**
@@ -394,12 +399,22 @@ export interface APIMessage {
 	 * Any attached files
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#attachment-object
+	 *
+	 * After August 31, 2022, `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent to verified apps,
+	 * this intent is required to receive a non-empty value from this field
+	 *
+	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
 	attachments: APIAttachment[];
 	/**
 	 * Any embedded content
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#embed-object
+	 *
+	 * After August 31, 2022, `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent to verified apps,
+	 * this intent is required to receive a non-empty value from this field
+	 *
+	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
 	embeds: APIEmbed[];
 	/**
@@ -483,6 +498,11 @@ export interface APIMessage {
 	thread?: APIChannel;
 	/**
 	 * Sent if the message contains components like buttons, action rows, or other interactive components
+	 *
+	 * After August 31, 2022, `MESSAGE_CONTENT` (`1 << 15`) will be a privileged intent to verified apps,
+	 * this intent is required to receive a non-empty value from this field
+	 *
+	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
 	components?: APIActionRowComponent<APIMessageActionRowComponent>[];
 	/**

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -345,9 +345,9 @@ export interface APIMessage {
 	/**
 	 * Contents of the message
 	 *
-	 * The **`MESSAGE_CONTENT`** privileged gateway intent will become required after **August 31, 2022** for verified applications to receive a non-empty value from this field
+	 * The `MESSAGE_CONTENT` privileged gateway intent will become required after **August 31, 2022** for verified applications to receive a non-empty value from this field
 	 *
-	 * In Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**
+	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
@@ -401,9 +401,9 @@ export interface APIMessage {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#attachment-object
 	 *
-	 * The **`MESSAGE_CONTENT`** privileged gateway intent will become required after **August 31, 2022** for verified applications to receive a non-empty value from this field
+	 * The `MESSAGE_CONTENT` privileged gateway intent will become required after **August 31, 2022** for verified applications to receive a non-empty value from this field
 	 *
-	 * In Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**
+	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
@@ -413,9 +413,9 @@ export interface APIMessage {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#embed-object
 	 *
-	 * The **`MESSAGE_CONTENT`** privileged gateway intent will become required after **August 31, 2022** for verified applications to receive a non-empty value from this field
+	 * The `MESSAGE_CONTENT` privileged gateway intent will become required after **August 31, 2022** for verified applications to receive a non-empty value from this field
 	 *
-	 * In Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**
+	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */
@@ -502,9 +502,9 @@ export interface APIMessage {
 	/**
 	 * Sent if the message contains components like buttons, action rows, or other interactive components
 	 *
-	 * The **`MESSAGE_CONTENT`** privileged gateway intent will become required after **August 31, 2022** for verified applications to receive a non-empty value from this field
+	 * The `MESSAGE_CONTENT` privileged gateway intent will become required after **August 31, 2022** for verified applications to receive a non-empty value from this field
 	 *
-	 * In Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**
+	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**
 	 *
 	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
 	 */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Adds notes about the `MESSAGE_CONTENT` intent, which will be [privileged for verified apps after August 31, 2022](https://support-dev.discord.com/hc/en-us/articles/4404772028055).
There are affected fields in `APIMessage`, which are `content`, `embeds`, `attachments`, and `components`.

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
