### PR TITLE
fix(GatewayGuildMembersChunkDispatchData): make chunk pagination properties mandatory

### DIFF
--- a/deno/gateway/v10.ts
+++ b/deno/gateway/v10.ts
@@ -821,11 +821,11 @@ export interface GatewayGuildMembersChunkDispatchData {
 	/**
 	 * The chunk index in the expected chunks for this response (`0 <= chunk_index < chunk_count`)
 	 */
-	chunk_index?: number;
+	chunk_index: number;
 	/**
 	 * The total number of expected chunks for this response
 	 */
-	chunk_count?: number;
+	chunk_count: number;
 	/**
 	 * If passing an invalid id to `REQUEST_GUILD_MEMBERS`, it will be returned here
 	 */

--- a/deno/gateway/v9.ts
+++ b/deno/gateway/v9.ts
@@ -820,11 +820,11 @@ export interface GatewayGuildMembersChunkDispatchData {
 	/**
 	 * The chunk index in the expected chunks for this response (`0 <= chunk_index < chunk_count`)
 	 */
-	chunk_index?: number;
+	chunk_index: number;
 	/**
 	 * The total number of expected chunks for this response
 	 */
-	chunk_count?: number;
+	chunk_count: number;
 	/**
 	 * If passing an invalid id to `REQUEST_GUILD_MEMBERS`, it will be returned here
 	 */

--- a/gateway/v10.ts
+++ b/gateway/v10.ts
@@ -821,11 +821,11 @@ export interface GatewayGuildMembersChunkDispatchData {
 	/**
 	 * The chunk index in the expected chunks for this response (`0 <= chunk_index < chunk_count`)
 	 */
-	chunk_index?: number;
+	chunk_index: number;
 	/**
 	 * The total number of expected chunks for this response
 	 */
-	chunk_count?: number;
+	chunk_count: number;
 	/**
 	 * If passing an invalid id to `REQUEST_GUILD_MEMBERS`, it will be returned here
 	 */

--- a/gateway/v9.ts
+++ b/gateway/v9.ts
@@ -820,11 +820,11 @@ export interface GatewayGuildMembersChunkDispatchData {
 	/**
 	 * The chunk index in the expected chunks for this response (`0 <= chunk_index < chunk_count`)
 	 */
-	chunk_index?: number;
+	chunk_index: number;
 	/**
 	 * The total number of expected chunks for this response
 	 */
-	chunk_count?: number;
+	chunk_count: number;
 	/**
 	 * If passing an invalid id to `REQUEST_GUILD_MEMBERS`, it will be returned here
 	 */


### PR DESCRIPTION
…perties mandatory

properties are listed as required on the documentation: https://discord.com/developers/docs/topics/gateway#guild-members-chunk
and seem to be regardless of nonce
```
2022-08-09 14:54:18.513  INFO  [src/shard/guild-member-handler.ts:58] sending guild member request 
{
  guild_id: '917075127139717200',
  query: 'a',
  limit: 1
}
2022-08-09 14:54:18.650  INFO  [src/shard/guild-member-handler.ts:25] received chunk 
{
  members: [
    {
      // ...
    }
  ],
  guild_id: '917075127139717200',
  chunk_index: 0,
  chunk_count: 1
}
2022-08-09 14:54:33.672  INFO  [src/shard/guild-member-handler.ts:58] sending guild member request 
{
  guild_id: '917075127139717200',
  query: 'a',
  limit: 1,
  nonce: '_a'
}
2022-08-09 14:54:33.819  INFO  [src/shard/guild-member-handler.ts:25] received chunk 
{
  nonce: '_a',
  members: [
    {
      // ...
    }
  ],
  guild_id: '917075127139717200',
  chunk_index: 0,
  chunk_count: 1
}
2022-08-09 14:54:51.037  INFO  [src/shard/guild-member-handler.ts:58] sending guild member request 
{
  guild_id: '917075127139717200',
  user_ids: [
    '284122164582416385'
  ]
}
2022-08-09 14:54:51.158  INFO  [src/shard/guild-member-handler.ts:25] received chunk 
{
  not_found: [],
  members: [
    {
      // ...
    }
  ],
  guild_id: '917075127139717200',
  chunk_index: 0,
  chunk_count: 1
}
2022-08-09 14:54:55.655  INFO  [src/shard/guild-member-handler.ts:58] sending guild member request 
{
  guild_id: '917075127139717200',
  user_ids: [
    '284122164582416385'
  ],
  nonce: '_b'
}
2022-08-09 14:54:55.777  INFO  [src/shard/guild-member-handler.ts:25] received chunk 
{
  not_found: [],
  nonce: '_b',
  members: [
    {
      // ...
    }
  ],
  guild_id: '917075127139717200',
  chunk_index: 0,
  chunk_count: 1
}
```