### PR TITLE
feat: add common JSON error types

### DIFF
--- a/deno/payloads/common.ts
+++ b/deno/payloads/common.ts
@@ -58,3 +58,23 @@ export const PermissionFlagsBits = {
 Object.freeze(PermissionFlagsBits);
 
 export type LocalizationMap = Partial<Record<LocaleString, string | null>>;
+
+/**
+ * https://discord.com/developers/docs/topics/opcodes-and-status-codes#json
+ */
+export interface DiscordErrorData {
+	code: number;
+	message: string;
+	errors?: DiscordError;
+}
+
+interface DiscordErrorFieldInformation {
+	code: string;
+	message: string;
+}
+
+interface DiscordErrorGroupWrapper {
+	_errors: DiscordError[];
+}
+
+type DiscordError = DiscordErrorGroupWrapper | DiscordErrorFieldInformation | { [k: string]: DiscordError } | string;

--- a/deno/payloads/common.ts
+++ b/deno/payloads/common.ts
@@ -62,7 +62,7 @@ export type LocalizationMap = Partial<Record<LocaleString, string | null>>;
 /**
  * https://discord.com/developers/docs/topics/opcodes-and-status-codes#json
  */
-export interface DiscordErrorData {
+export interface DiscordAPIError {
 	code: number;
 	message: string;
 	errors?: DiscordError;

--- a/deno/payloads/common.ts
+++ b/deno/payloads/common.ts
@@ -68,12 +68,12 @@ export interface APIError {
 	errors?: DiscordError;
 }
 
-interface DiscordErrorFieldInformation {
+export interface DiscordErrorFieldInformation {
 	code: string;
 	message: string;
 }
 
-interface DiscordErrorGroupWrapper {
+export interface DiscordErrorGroupWrapper {
 	_errors: DiscordError[];
 }
 

--- a/deno/payloads/common.ts
+++ b/deno/payloads/common.ts
@@ -62,23 +62,19 @@ export type LocalizationMap = Partial<Record<LocaleString, string | null>>;
 /**
  * https://discord.com/developers/docs/topics/opcodes-and-status-codes#json
  */
-export interface APIError {
+export interface RESTError {
 	code: number;
 	message: string;
-	errors?: DiscordError;
+	errors?: RESTErrorData;
 }
 
-export interface DiscordErrorFieldInformation {
+export interface RESTErrorFieldInformation {
 	code: string;
 	message: string;
 }
 
-export interface DiscordErrorGroupWrapper {
-	_errors: DiscordError[];
+export interface RESTErrorGroupWrapper {
+	_errors: RESTErrorData[];
 }
 
-export type DiscordError =
-	| DiscordErrorGroupWrapper
-	| DiscordErrorFieldInformation
-	| { [k: string]: DiscordError }
-	| string;
+export type RESTErrorData = RESTErrorGroupWrapper | RESTErrorFieldInformation | { [k: string]: RESTErrorData } | string;

--- a/deno/payloads/common.ts
+++ b/deno/payloads/common.ts
@@ -77,4 +77,8 @@ interface DiscordErrorGroupWrapper {
 	_errors: DiscordError[];
 }
 
-type DiscordError = DiscordErrorGroupWrapper | DiscordErrorFieldInformation | { [k: string]: DiscordError } | string;
+export type DiscordError =
+	| DiscordErrorGroupWrapper
+	| DiscordErrorFieldInformation
+	| { [k: string]: DiscordError }
+	| string;

--- a/deno/payloads/common.ts
+++ b/deno/payloads/common.ts
@@ -62,7 +62,7 @@ export type LocalizationMap = Partial<Record<LocaleString, string | null>>;
 /**
  * https://discord.com/developers/docs/topics/opcodes-and-status-codes#json
  */
-export interface DiscordAPIError {
+export interface APIError {
 	code: number;
 	message: string;
 	errors?: DiscordError;

--- a/payloads/common.ts
+++ b/payloads/common.ts
@@ -58,3 +58,23 @@ export const PermissionFlagsBits = {
 Object.freeze(PermissionFlagsBits);
 
 export type LocalizationMap = Partial<Record<LocaleString, string | null>>;
+
+/**
+ * https://discord.com/developers/docs/topics/opcodes-and-status-codes#json
+ */
+export interface DiscordErrorData {
+	code: number;
+	message: string;
+	errors?: DiscordError;
+}
+
+interface DiscordErrorFieldInformation {
+	code: string;
+	message: string;
+}
+
+interface DiscordErrorGroupWrapper {
+	_errors: DiscordError[];
+}
+
+type DiscordError = DiscordErrorGroupWrapper | DiscordErrorFieldInformation | { [k: string]: DiscordError } | string;

--- a/payloads/common.ts
+++ b/payloads/common.ts
@@ -62,7 +62,7 @@ export type LocalizationMap = Partial<Record<LocaleString, string | null>>;
 /**
  * https://discord.com/developers/docs/topics/opcodes-and-status-codes#json
  */
-export interface DiscordErrorData {
+export interface DiscordAPIError {
 	code: number;
 	message: string;
 	errors?: DiscordError;

--- a/payloads/common.ts
+++ b/payloads/common.ts
@@ -68,12 +68,12 @@ export interface APIError {
 	errors?: DiscordError;
 }
 
-interface DiscordErrorFieldInformation {
+export interface DiscordErrorFieldInformation {
 	code: string;
 	message: string;
 }
 
-interface DiscordErrorGroupWrapper {
+export interface DiscordErrorGroupWrapper {
 	_errors: DiscordError[];
 }
 

--- a/payloads/common.ts
+++ b/payloads/common.ts
@@ -62,23 +62,19 @@ export type LocalizationMap = Partial<Record<LocaleString, string | null>>;
 /**
  * https://discord.com/developers/docs/topics/opcodes-and-status-codes#json
  */
-export interface APIError {
+export interface RESTError {
 	code: number;
 	message: string;
-	errors?: DiscordError;
+	errors?: RESTErrorData;
 }
 
-export interface DiscordErrorFieldInformation {
+export interface RESTErrorFieldInformation {
 	code: string;
 	message: string;
 }
 
-export interface DiscordErrorGroupWrapper {
-	_errors: DiscordError[];
+export interface RESTErrorGroupWrapper {
+	_errors: RESTErrorData[];
 }
 
-export type DiscordError =
-	| DiscordErrorGroupWrapper
-	| DiscordErrorFieldInformation
-	| { [k: string]: DiscordError }
-	| string;
+export type RESTErrorData = RESTErrorGroupWrapper | RESTErrorFieldInformation | { [k: string]: RESTErrorData } | string;

--- a/payloads/common.ts
+++ b/payloads/common.ts
@@ -77,4 +77,8 @@ interface DiscordErrorGroupWrapper {
 	_errors: DiscordError[];
 }
 
-type DiscordError = DiscordErrorGroupWrapper | DiscordErrorFieldInformation | { [k: string]: DiscordError } | string;
+export type DiscordError =
+	| DiscordErrorGroupWrapper
+	| DiscordErrorFieldInformation
+	| { [k: string]: DiscordError }
+	| string;

--- a/payloads/common.ts
+++ b/payloads/common.ts
@@ -62,7 +62,7 @@ export type LocalizationMap = Partial<Record<LocaleString, string | null>>;
 /**
  * https://discord.com/developers/docs/topics/opcodes-and-status-codes#json
  */
-export interface DiscordAPIError {
+export interface APIError {
 	code: number;
 	message: string;
 	errors?: DiscordError;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Adds common JSON error types from discordjs/rest. Should be merged because there's currently no error types.

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**

https://github.com/discordjs/discord.js/blob/e475b63f257f6261d73cb89fee9ecbcdd84e2a6b/packages/rest/src/lib/errors/DiscordAPIError.ts#L3-L18

https://discord.com/developers/docs/topics/opcodes-and-status-codes#json