### PR TITLE
feat(ApplicationCommand): export base chat input types

### DIFF
--- a/deno/payloads/v10/_interactions/_applicationCommands/chatInput.ts
+++ b/deno/payloads/v10/_interactions/_applicationCommands/chatInput.ts
@@ -54,7 +54,7 @@ import type {
 import type { APIDMInteractionWrapper, APIGuildInteractionWrapper } from '../base.ts';
 
 export * from './_chatInput/attachment.ts';
-export * from "./_chatInput/base.ts";
+export * from './_chatInput/base.ts';
 export * from './_chatInput/boolean.ts';
 export * from './_chatInput/channel.ts';
 export * from './_chatInput/integer.ts';

--- a/deno/payloads/v10/_interactions/_applicationCommands/chatInput.ts
+++ b/deno/payloads/v10/_interactions/_applicationCommands/chatInput.ts
@@ -54,6 +54,7 @@ import type {
 import type { APIDMInteractionWrapper, APIGuildInteractionWrapper } from '../base.ts';
 
 export * from './_chatInput/attachment.ts';
+export * from "./_chatInput/base.ts";
 export * from './_chatInput/boolean.ts';
 export * from './_chatInput/channel.ts';
 export * from './_chatInput/integer.ts';

--- a/deno/payloads/v9/_interactions/_applicationCommands/chatInput.ts
+++ b/deno/payloads/v9/_interactions/_applicationCommands/chatInput.ts
@@ -54,7 +54,7 @@ import type {
 import type { APIDMInteractionWrapper, APIGuildInteractionWrapper } from '../base.ts';
 
 export * from './_chatInput/attachment.ts';
-export * from "./_chatInput/base.ts";
+export * from "./_chatInput/base";
 export * from './_chatInput/boolean.ts';
 export * from './_chatInput/channel.ts';
 export * from './_chatInput/integer.ts';

--- a/deno/payloads/v9/_interactions/_applicationCommands/chatInput.ts
+++ b/deno/payloads/v9/_interactions/_applicationCommands/chatInput.ts
@@ -54,7 +54,7 @@ import type {
 import type { APIDMInteractionWrapper, APIGuildInteractionWrapper } from '../base.ts';
 
 export * from './_chatInput/attachment.ts';
-export * from "./_chatInput/base";
+export * from './_chatInput/base.ts';
 export * from './_chatInput/boolean.ts';
 export * from './_chatInput/channel.ts';
 export * from './_chatInput/integer.ts';

--- a/deno/payloads/v9/_interactions/_applicationCommands/chatInput.ts
+++ b/deno/payloads/v9/_interactions/_applicationCommands/chatInput.ts
@@ -54,6 +54,7 @@ import type {
 import type { APIDMInteractionWrapper, APIGuildInteractionWrapper } from '../base.ts';
 
 export * from './_chatInput/attachment.ts';
+export * from "./_chatInput/base.ts";
 export * from './_chatInput/boolean.ts';
 export * from './_chatInput/channel.ts';
 export * from './_chatInput/integer.ts';

--- a/payloads/v10/_interactions/_applicationCommands/chatInput.ts
+++ b/payloads/v10/_interactions/_applicationCommands/chatInput.ts
@@ -54,6 +54,7 @@ import type {
 import type { APIDMInteractionWrapper, APIGuildInteractionWrapper } from '../base';
 
 export * from './_chatInput/attachment';
+export * from './_chatInput/base';
 export * from './_chatInput/boolean';
 export * from './_chatInput/channel';
 export * from './_chatInput/integer';

--- a/payloads/v9/_interactions/_applicationCommands/chatInput.ts
+++ b/payloads/v9/_interactions/_applicationCommands/chatInput.ts
@@ -54,7 +54,7 @@ import type {
 import type { APIDMInteractionWrapper, APIGuildInteractionWrapper } from '../base';
 
 export * from './_chatInput/attachment';
-export * from "./_chatInput/base";
+export * from './_chatInput/base';
 export * from './_chatInput/boolean';
 export * from './_chatInput/channel';
 export * from './_chatInput/integer';

--- a/payloads/v9/_interactions/_applicationCommands/chatInput.ts
+++ b/payloads/v9/_interactions/_applicationCommands/chatInput.ts
@@ -54,6 +54,7 @@ import type {
 import type { APIDMInteractionWrapper, APIGuildInteractionWrapper } from '../base';
 
 export * from './_chatInput/attachment';
+export * from "./_chatInput/base";
 export * from './_chatInput/boolean';
 export * from './_chatInput/channel';
 export * from './_chatInput/integer';


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Allows for importing helpful types like `APIApplicationCommandOptionBase` (less helpful for applications, very helpful for libraries)

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
N/A