### PR TITLE
feat: add `RESTRateLimit`

### DIFF
--- a/deno/payloads/common.ts
+++ b/deno/payloads/common.ts
@@ -78,3 +78,21 @@ export interface RESTErrorGroupWrapper {
 }
 
 export type RESTErrorData = RESTErrorGroupWrapper | RESTErrorFieldInformation | { [k: string]: RESTErrorData } | string;
+
+/**
+ * https://discord.com/developers/docs/topics/rate-limits#exceeding-a-rate-limit-rate-limit-response-structure
+ */
+export interface RESTRateLimit {
+	/**
+	 * A value indicating if you are being globally rate limited or not
+	 */
+	global: boolean;
+	/**
+	 * A message saying you are being rate limited.
+	 */
+	message: string;
+	/**
+	 * The number of seconds to wait before submitting another request.
+	 */
+	retry_after: number;
+}

--- a/payloads/common.ts
+++ b/payloads/common.ts
@@ -78,3 +78,21 @@ export interface RESTErrorGroupWrapper {
 }
 
 export type RESTErrorData = RESTErrorGroupWrapper | RESTErrorFieldInformation | { [k: string]: RESTErrorData } | string;
+
+/**
+ * https://discord.com/developers/docs/topics/rate-limits#exceeding-a-rate-limit-rate-limit-response-structure
+ */
+export interface RESTRateLimit {
+	/**
+	 * A value indicating if you are being globally rate limited or not
+	 */
+	global: boolean;
+	/**
+	 * A message saying you are being rate limited.
+	 */
+	message: string;
+	/**
+	 * The number of seconds to wait before submitting another request.
+	 */
+	retry_after: number;
+}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Adds the structure of a rate limit JSON response
https://discord.com/developers/docs/topics/rate-limits#exceeding-a-rate-limit-rate-limit-response-structure

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
