### PR TITLE
fix: `default_thread_rate_limit_per_user` is only for forum channels

### DIFF
--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -296,7 +296,7 @@ export interface APIGuildForumChannel extends APIGuildTextChannel<ChannelType.Gu
 	 */
 	available_tags: APIGuildForumTag[];
 	/**
-	 * The initial `rate_limit_per_user` to set on newly created threads in a channel.
+	 * The initial `rate_limit_per_user` to set on newly created threads in a forum channel.
 	 * This field is copied to the thread at creation time and does not live update
 	 */
 	default_thread_rate_limit_per_user?: number;

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -296,7 +296,7 @@ export interface APIGuildForumChannel extends APIGuildTextChannel<ChannelType.Gu
 	 */
 	available_tags: APIGuildForumTag[];
 	/**
-	 * The initial `rate_limit_per_user` to set on newly created threads in a channel.
+	 * The initial `rate_limit_per_user` to set on newly created threads in a forum channel.
 	 * This field is copied to the thread at creation time and does not live update
 	 */
 	default_thread_rate_limit_per_user?: number;

--- a/deno/rest/v10/channel.ts
+++ b/deno/rest/v10/channel.ts
@@ -160,7 +160,7 @@ export type RESTPatchAPIChannelJSONBody = AddUndefinedToPossiblyUndefinedPropert
 	 * The initial `rate_limit_per_user` to set on newly created threads in a channel.
 	 * This field is copied to the thread at creation time and does not live update
 	 *
-	 * Channel types: text, forum
+	 * Channel types: forum
 	 */
 	default_thread_rate_limit_per_user?: number | null;
 	/**

--- a/deno/rest/v9/channel.ts
+++ b/deno/rest/v9/channel.ts
@@ -160,7 +160,7 @@ export type RESTPatchAPIChannelJSONBody = AddUndefinedToPossiblyUndefinedPropert
 	 * The initial `rate_limit_per_user` to set on newly created threads in a channel.
 	 * This field is copied to the thread at creation time and does not live update
 	 *
-	 * Channel types: text, forum
+	 * Channel types: forum
 	 */
 	default_thread_rate_limit_per_user?: number | null;
 	/**

--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -296,7 +296,7 @@ export interface APIGuildForumChannel extends APIGuildTextChannel<ChannelType.Gu
 	 */
 	available_tags: APIGuildForumTag[];
 	/**
-	 * The initial `rate_limit_per_user` to set on newly created threads in a channel.
+	 * The initial `rate_limit_per_user` to set on newly created threads in a forum channel.
 	 * This field is copied to the thread at creation time and does not live update
 	 */
 	default_thread_rate_limit_per_user?: number;

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -296,7 +296,7 @@ export interface APIGuildForumChannel extends APIGuildTextChannel<ChannelType.Gu
 	 */
 	available_tags: APIGuildForumTag[];
 	/**
-	 * The initial `rate_limit_per_user` to set on newly created threads in a channel.
+	 * The initial `rate_limit_per_user` to set on newly created threads in a forum channel.
 	 * This field is copied to the thread at creation time and does not live update
 	 */
 	default_thread_rate_limit_per_user?: number;

--- a/rest/v10/channel.ts
+++ b/rest/v10/channel.ts
@@ -160,7 +160,7 @@ export type RESTPatchAPIChannelJSONBody = AddUndefinedToPossiblyUndefinedPropert
 	 * The initial `rate_limit_per_user` to set on newly created threads in a channel.
 	 * This field is copied to the thread at creation time and does not live update
 	 *
-	 * Channel types: text, forum
+	 * Channel types: forum
 	 */
 	default_thread_rate_limit_per_user?: number | null;
 	/**

--- a/rest/v9/channel.ts
+++ b/rest/v9/channel.ts
@@ -160,7 +160,7 @@ export type RESTPatchAPIChannelJSONBody = AddUndefinedToPossiblyUndefinedPropert
 	 * The initial `rate_limit_per_user` to set on newly created threads in a channel.
 	 * This field is copied to the thread at creation time and does not live update
 	 *
-	 * Channel types: text, forum
+	 * Channel types: forum
 	 */
 	default_thread_rate_limit_per_user?: number | null;
 	/**


### PR DESCRIPTION
* https://github.com/discord/discord-api-docs/pull/5514