### PR TITLE
feat(APIAutoMod): add support for regex matching

### DIFF
--- a/deno/payloads/v10/autoModeration.ts
+++ b/deno/payloads/v10/autoModeration.ts
@@ -105,6 +105,14 @@ export interface APIAutoModerationRuleTriggerMetadata {
 	 */
 	allow_list?: string[];
 	/**
+	 * Regular expression patterns which will be matched against content (Maximum of 10)
+	 *
+	 * Only Rust flavored regex is currently supported
+	 *
+	 * Associated trigger type: {@link AutoModerationRuleTriggerType.Keyword}
+	 */
+	regex_patterns?: string[];
+	/**
 	 * Total number of mentions (role & user) allowed per message (Maximum of 50)
 	 *
 	 * Associated trigger type: {@link AutoModerationRuleTriggerType.MentionSpam}

--- a/deno/payloads/v10/autoModeration.ts
+++ b/deno/payloads/v10/autoModeration.ts
@@ -107,7 +107,7 @@ export interface APIAutoModerationRuleTriggerMetadata {
 	/**
 	 * Regular expression patterns which will be matched against content (Maximum of 10)
 	 *
-	 * Only Rust flavored regex is currently supported
+	 * Only Rust flavored regex is currently supported (Maximum of 75 characters)
 	 *
 	 * Associated trigger type: {@link AutoModerationRuleTriggerType.Keyword}
 	 */

--- a/deno/payloads/v9/autoModeration.ts
+++ b/deno/payloads/v9/autoModeration.ts
@@ -105,6 +105,14 @@ export interface APIAutoModerationRuleTriggerMetadata {
 	 */
 	allow_list?: string[];
 	/**
+	 * Regular expression patterns which will be matched against content (Maximum of 10)
+	 *
+	 * Only Rust flavored regex is currently supported
+	 *
+	 * Associated trigger type: {@link AutoModerationRuleTriggerType.Keyword}
+	 */
+	regex_patterns?: string[];
+	/**
 	 * Total number of mentions (role & user) allowed per message (Maximum of 50)
 	 *
 	 * Associated trigger type: {@link AutoModerationRuleTriggerType.MentionSpam}

--- a/deno/payloads/v9/autoModeration.ts
+++ b/deno/payloads/v9/autoModeration.ts
@@ -107,7 +107,7 @@ export interface APIAutoModerationRuleTriggerMetadata {
 	/**
 	 * Regular expression patterns which will be matched against content (Maximum of 10)
 	 *
-	 * Only Rust flavored regex is currently supported
+	 * Only Rust flavored regex is currently supported (Maximum of 75 characters)
 	 *
 	 * Associated trigger type: {@link AutoModerationRuleTriggerType.Keyword}
 	 */

--- a/payloads/v10/autoModeration.ts
+++ b/payloads/v10/autoModeration.ts
@@ -105,6 +105,14 @@ export interface APIAutoModerationRuleTriggerMetadata {
 	 */
 	allow_list?: string[];
 	/**
+	 * Regular expression patterns which will be matched against content (Maximum of 10)
+	 *
+	 * Only Rust flavored regex is currently supported
+	 *
+	 * Associated trigger type: {@link AutoModerationRuleTriggerType.Keyword}
+	 */
+	regex_patterns?: string[];
+	/**
 	 * Total number of mentions (role & user) allowed per message (Maximum of 50)
 	 *
 	 * Associated trigger type: {@link AutoModerationRuleTriggerType.MentionSpam}

--- a/payloads/v10/autoModeration.ts
+++ b/payloads/v10/autoModeration.ts
@@ -107,7 +107,7 @@ export interface APIAutoModerationRuleTriggerMetadata {
 	/**
 	 * Regular expression patterns which will be matched against content (Maximum of 10)
 	 *
-	 * Only Rust flavored regex is currently supported
+	 * Only Rust flavored regex is currently supported (Maximum of 75 characters)
 	 *
 	 * Associated trigger type: {@link AutoModerationRuleTriggerType.Keyword}
 	 */

--- a/payloads/v9/autoModeration.ts
+++ b/payloads/v9/autoModeration.ts
@@ -105,6 +105,14 @@ export interface APIAutoModerationRuleTriggerMetadata {
 	 */
 	allow_list?: string[];
 	/**
+	 * Regular expression patterns which will be matched against content (Maximum of 10)
+	 *
+	 * Only Rust flavored regex is currently supported
+	 *
+	 * Associated trigger type: {@link AutoModerationRuleTriggerType.Keyword}
+	 */
+	regex_patterns?: string[];
+	/**
 	 * Total number of mentions (role & user) allowed per message (Maximum of 50)
 	 *
 	 * Associated trigger type: {@link AutoModerationRuleTriggerType.MentionSpam}

--- a/payloads/v9/autoModeration.ts
+++ b/payloads/v9/autoModeration.ts
@@ -107,7 +107,7 @@ export interface APIAutoModerationRuleTriggerMetadata {
 	/**
 	 * Regular expression patterns which will be matched against content (Maximum of 10)
 	 *
-	 * Only Rust flavored regex is currently supported
+	 * Only Rust flavored regex is currently supported (Maximum of 75 characters)
 	 *
 	 * Associated trigger type: {@link AutoModerationRuleTriggerType.Keyword}
 	 */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds support for regex matching in auto moderation.

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
- https://github.com/discord/discord-api-docs/pull/5504
