### PR TITLE
refactor(APIAuditLogOptions): Use `AuditLogRuleTriggerType` for `auto_moderation_rule_trigger_type`

### DIFF
--- a/deno/payloads/v10/auditLog.ts
+++ b/deno/payloads/v10/auditLog.ts
@@ -223,7 +223,7 @@ export interface APIAuditLogOptions {
 	 * - AUTO_MODERATION_FLAG_TO_CHANNEL
 	 * - AUTO_MODERATION_USER_COMMUNICATION_DISABLED
 	 */
-	auto_moderation_rule_trigger_type?: AutoModerationRuleTriggerType;
+	auto_moderation_rule_trigger_type?: AuditLogRuleTriggerType;
 	/**
 	 * Number of days after which inactive members were kicked
 	 *

--- a/deno/payloads/v10/auditLog.ts
+++ b/deno/payloads/v10/auditLog.ts
@@ -223,7 +223,7 @@ export interface APIAuditLogOptions {
 	 * - AUTO_MODERATION_FLAG_TO_CHANNEL
 	 * - AUTO_MODERATION_USER_COMMUNICATION_DISABLED
 	 */
-	auto_moderation_rule_trigger_type?: string;
+	auto_moderation_rule_trigger_type?: AutoModerationRuleTriggerType;
 	/**
 	 * Number of days after which inactive members were kicked
 	 *
@@ -315,6 +315,8 @@ export enum AuditLogOptionsType {
 	Role = '0',
 	Member = '1',
 }
+
+export type AuditLogRuleTriggerType = `${AutoModerationRuleTriggerType}`;
 
 /**
  * https://discord.com/developers/docs/resources/audit-log#audit-log-change-object-audit-log-change-structure

--- a/deno/payloads/v9/auditLog.ts
+++ b/deno/payloads/v9/auditLog.ts
@@ -223,7 +223,7 @@ export interface APIAuditLogOptions {
 	 * - AUTO_MODERATION_FLAG_TO_CHANNEL
 	 * - AUTO_MODERATION_USER_COMMUNICATION_DISABLED
 	 */
-	auto_moderation_rule_trigger_type?: AutoModerationRuleTriggerType;
+	auto_moderation_rule_trigger_type?: AuditLogRuleTriggerType;
 	/**
 	 * Number of days after which inactive members were kicked
 	 *

--- a/deno/payloads/v9/auditLog.ts
+++ b/deno/payloads/v9/auditLog.ts
@@ -223,7 +223,7 @@ export interface APIAuditLogOptions {
 	 * - AUTO_MODERATION_FLAG_TO_CHANNEL
 	 * - AUTO_MODERATION_USER_COMMUNICATION_DISABLED
 	 */
-	auto_moderation_rule_trigger_type?: string;
+	auto_moderation_rule_trigger_type?: AutoModerationRuleTriggerType;
 	/**
 	 * Number of days after which inactive members were kicked
 	 *
@@ -315,6 +315,8 @@ export enum AuditLogOptionsType {
 	Role = '0',
 	Member = '1',
 }
+
+export type AuditLogRuleTriggerType = `${AutoModerationRuleTriggerType}`;
 
 /**
  * https://discord.com/developers/docs/resources/audit-log#audit-log-change-object-audit-log-change-structure

--- a/payloads/v10/auditLog.ts
+++ b/payloads/v10/auditLog.ts
@@ -223,7 +223,7 @@ export interface APIAuditLogOptions {
 	 * - AUTO_MODERATION_FLAG_TO_CHANNEL
 	 * - AUTO_MODERATION_USER_COMMUNICATION_DISABLED
 	 */
-	auto_moderation_rule_trigger_type?: AutoModerationRuleTriggerType;
+	auto_moderation_rule_trigger_type?: AuditLogRuleTriggerType;
 	/**
 	 * Number of days after which inactive members were kicked
 	 *

--- a/payloads/v10/auditLog.ts
+++ b/payloads/v10/auditLog.ts
@@ -223,7 +223,7 @@ export interface APIAuditLogOptions {
 	 * - AUTO_MODERATION_FLAG_TO_CHANNEL
 	 * - AUTO_MODERATION_USER_COMMUNICATION_DISABLED
 	 */
-	auto_moderation_rule_trigger_type?: string;
+	auto_moderation_rule_trigger_type?: AutoModerationRuleTriggerType;
 	/**
 	 * Number of days after which inactive members were kicked
 	 *
@@ -315,6 +315,8 @@ export enum AuditLogOptionsType {
 	Role = '0',
 	Member = '1',
 }
+
+export type AuditLogRuleTriggerType = `${AutoModerationRuleTriggerType}`;
 
 /**
  * https://discord.com/developers/docs/resources/audit-log#audit-log-change-object-audit-log-change-structure

--- a/payloads/v9/auditLog.ts
+++ b/payloads/v9/auditLog.ts
@@ -223,7 +223,7 @@ export interface APIAuditLogOptions {
 	 * - AUTO_MODERATION_FLAG_TO_CHANNEL
 	 * - AUTO_MODERATION_USER_COMMUNICATION_DISABLED
 	 */
-	auto_moderation_rule_trigger_type?: AutoModerationRuleTriggerType;
+	auto_moderation_rule_trigger_type?: AuditLogRuleTriggerType;
 	/**
 	 * Number of days after which inactive members were kicked
 	 *

--- a/payloads/v9/auditLog.ts
+++ b/payloads/v9/auditLog.ts
@@ -223,7 +223,7 @@ export interface APIAuditLogOptions {
 	 * - AUTO_MODERATION_FLAG_TO_CHANNEL
 	 * - AUTO_MODERATION_USER_COMMUNICATION_DISABLED
 	 */
-	auto_moderation_rule_trigger_type?: string;
+	auto_moderation_rule_trigger_type?: AutoModerationRuleTriggerType;
 	/**
 	 * Number of days after which inactive members were kicked
 	 *
@@ -315,6 +315,8 @@ export enum AuditLogOptionsType {
 	Role = '0',
 	Member = '1',
 }
+
+export type AuditLogRuleTriggerType = `${AutoModerationRuleTriggerType}`;
 
 /**
  * https://discord.com/developers/docs/resources/audit-log#audit-log-change-object-audit-log-change-structure


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`auto_moderation_rule_trigger_type` in the `APIAuditLogOptions` is a stringified version of `AutoModerationRuleTriggerType`. The typings have been more accurately reflected for this.