### PR TITLE
feat(RESTJSONErrorCodes): add 50039 error

### DIFF
--- a/deno/rest/common.ts
+++ b/deno/rest/common.ts
@@ -179,6 +179,8 @@ export enum RESTJSONErrorCodes {
 	InvalidFormBodyOrContentType,
 	InviteAcceptedToGuildWithoutTheBotBeingIn,
 
+	InvalidActivityAction = 50039,
+
 	InvalidAPIVersion = 50041,
 
 	FileUploadedExceedsMaximumSize = 50045,

--- a/rest/common.ts
+++ b/rest/common.ts
@@ -179,6 +179,8 @@ export enum RESTJSONErrorCodes {
 	InvalidFormBodyOrContentType,
 	InviteAcceptedToGuildWithoutTheBotBeingIn,
 
+	InvalidActivityAction = 50039,
+
 	InvalidAPIVersion = 50041,
 
 	FileUploadedExceedsMaximumSize = 50045,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds the error `InvalidActivityAction` (50039) to `RESTJSONErrorCodes`.

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
- https://github.com/discord/discord-api-docs/pull/5548
