### PR TITLE
fix: export v10 json payloads and correct automod route types

### DIFF
--- a/deno/rest/v10/mod.ts
+++ b/deno/rest/v10/mod.ts
@@ -2,6 +2,7 @@ import type { Snowflake } from '../../globals.ts';
 
 export * from '../common.ts';
 export * from './auditLog.ts';
+export * from './autoModeration.ts';
 export * from './channel.ts';
 export * from './emoji.ts';
 export * from './gateway.ts';
@@ -26,7 +27,7 @@ export const Routes = {
 	 * - POST `/guilds/{guild.id}/auto-moderation/rules`
 	 */
 	guildAutoModerationRules(guildId: Snowflake) {
-		return `/guilds/${guildId}/auto-moderation/rules`;
+		return `/guilds/${guildId}/auto-moderation/rules` as const;
 	},
 
 	/**
@@ -36,7 +37,7 @@ export const Routes = {
 	 * - DELETE `/guilds/{guild.id}/auto-moderation/rules/{rule.id}`
 	 */
 	guildAutoModerationRule(guildId: Snowflake, ruleId: Snowflake) {
-		return `/guilds/${guildId}/auto-moderation/rules/${ruleId}`;
+		return `/guilds/${guildId}/auto-moderation/rules/${ruleId}` as const;
 	},
 
 	/**

--- a/deno/rest/v9/mod.ts
+++ b/deno/rest/v9/mod.ts
@@ -27,7 +27,7 @@ export const Routes = {
 	 * - POST `/guilds/{guild.id}/auto-moderation/rules`
 	 */
 	guildAutoModerationRules(guildId: Snowflake) {
-		return `/guilds/${guildId}/auto-moderation/rules`;
+		return `/guilds/${guildId}/auto-moderation/rules` as const;
 	},
 
 	/**
@@ -37,7 +37,7 @@ export const Routes = {
 	 * - DELETE `/guilds/{guild.id}/auto-moderation/rules/{rule.id}`
 	 */
 	guildAutoModerationRule(guildId: Snowflake, ruleId: Snowflake) {
-		return `/guilds/${guildId}/auto-moderation/rules/${ruleId}`;
+		return `/guilds/${guildId}/auto-moderation/rules/${ruleId}` as const;
 	},
 
 	/**

--- a/rest/v10/index.ts
+++ b/rest/v10/index.ts
@@ -2,6 +2,7 @@ import type { Snowflake } from '../../globals';
 
 export * from '../common';
 export * from './auditLog';
+export * from './autoModeration';
 export * from './channel';
 export * from './emoji';
 export * from './gateway';
@@ -26,7 +27,7 @@ export const Routes = {
 	 * - POST `/guilds/{guild.id}/auto-moderation/rules`
 	 */
 	guildAutoModerationRules(guildId: Snowflake) {
-		return `/guilds/${guildId}/auto-moderation/rules`;
+		return `/guilds/${guildId}/auto-moderation/rules` as const;
 	},
 
 	/**
@@ -36,7 +37,7 @@ export const Routes = {
 	 * - DELETE `/guilds/{guild.id}/auto-moderation/rules/{rule.id}`
 	 */
 	guildAutoModerationRule(guildId: Snowflake, ruleId: Snowflake) {
-		return `/guilds/${guildId}/auto-moderation/rules/${ruleId}`;
+		return `/guilds/${guildId}/auto-moderation/rules/${ruleId}` as const;
 	},
 
 	/**

--- a/rest/v9/index.ts
+++ b/rest/v9/index.ts
@@ -27,7 +27,7 @@ export const Routes = {
 	 * - POST `/guilds/{guild.id}/auto-moderation/rules`
 	 */
 	guildAutoModerationRules(guildId: Snowflake) {
-		return `/guilds/${guildId}/auto-moderation/rules`;
+		return `/guilds/${guildId}/auto-moderation/rules` as const;
 	},
 
 	/**
@@ -37,7 +37,7 @@ export const Routes = {
 	 * - DELETE `/guilds/{guild.id}/auto-moderation/rules/{rule.id}`
 	 */
 	guildAutoModerationRule(guildId: Snowflake, ruleId: Snowflake) {
-		return `/guilds/${guildId}/auto-moderation/rules/${ruleId}`;
+		return `/guilds/${guildId}/auto-moderation/rules/${ruleId}` as const;
 	},
 
 	/**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Makes automod routes types compatible with `REST` by returning `as const` and adds missing reexport for automod json payloads for v10.
