### PR TITLE
feat: add some missing REST types

### DIFF
--- a/deno/rest/v10/guild.ts
+++ b/deno/rest/v10/guild.ts
@@ -895,6 +895,11 @@ export type RESTPatchAPIGuildVoiceStateUserJSONBody = AddUndefinedToPossiblyUnde
 }>;
 
 /**
+ * https://discord.com/developers/docs/resources/guild#modify-user-voice-state
+ */
+export type RESTPatchAPIGuildVoiceStateUserResult = never;
+
+/**
  * https://discord.com/developers/docs/resources/guild#get-guild-welcome-screen
  */
 export type RESTGetAPIGuildWelcomeScreenResult = APIGuildWelcomeScreen;

--- a/deno/rest/v10/interactions.ts
+++ b/deno/rest/v10/interactions.ts
@@ -106,6 +106,11 @@ export type RESTPutAPIApplicationCommandsResult = APIApplicationCommand[];
 /**
  * https://discord.com/developers/docs/interactions/application-commands#get-guild-application-commands
  */
+export type RESTGetAPIApplicationGuildCommandsQuery = RESTGetAPIApplicationCommandsQuery;
+
+/**
+ * https://discord.com/developers/docs/interactions/application-commands#get-guild-application-commands
+ */
 export type RESTGetAPIApplicationGuildCommandsResult = Omit<APIApplicationCommand, 'dm_permission'>[];
 
 /**

--- a/deno/rest/v10/interactions.ts
+++ b/deno/rest/v10/interactions.ts
@@ -19,6 +19,19 @@ import type { AddUndefinedToPossiblyUndefinedPropertiesOfInterface, StrictPartia
 /**
  * https://discord.com/developers/docs/interactions/application-commands#get-global-application-commands
  */
+export interface RESTGetAPIApplicationCommandsQuery {
+	/**
+	 * Whether to include full localization dictionaries (name_localizations and description_localizations)
+	 * in the returned objects, instead of the name_localized and description_localized fields.
+	 *
+	 * @default false
+	 */
+	with_localizations?: boolean;
+}
+
+/**
+ * https://discord.com/developers/docs/interactions/application-commands#get-global-application-commands
+ */
 export type RESTGetAPIApplicationCommandsResult = APIApplicationCommand[];
 
 /**

--- a/deno/rest/v9/guild.ts
+++ b/deno/rest/v9/guild.ts
@@ -901,6 +901,11 @@ export type RESTPatchAPIGuildVoiceStateUserJSONBody = AddUndefinedToPossiblyUnde
 }>;
 
 /**
+ * https://discord.com/developers/docs/resources/guild#modify-user-voice-state
+ */
+export type RESTPatchAPIGuildVoiceStateUserResult = never;
+
+/**
  * https://discord.com/developers/docs/resources/guild#get-guild-welcome-screen
  */
 export type RESTGetAPIGuildWelcomeScreenResult = APIGuildWelcomeScreen;

--- a/deno/rest/v9/interactions.ts
+++ b/deno/rest/v9/interactions.ts
@@ -106,6 +106,11 @@ export type RESTPutAPIApplicationCommandsResult = APIApplicationCommand[];
 /**
  * https://discord.com/developers/docs/interactions/application-commands#get-guild-application-commands
  */
+export type RESTGetAPIApplicationGuildCommandsQuery = RESTGetAPIApplicationCommandsQuery;
+
+/**
+ * https://discord.com/developers/docs/interactions/application-commands#get-guild-application-commands
+ */
 export type RESTGetAPIApplicationGuildCommandsResult = Omit<APIApplicationCommand, 'dm_permission'>[];
 
 /**

--- a/deno/rest/v9/interactions.ts
+++ b/deno/rest/v9/interactions.ts
@@ -19,6 +19,19 @@ import type { AddUndefinedToPossiblyUndefinedPropertiesOfInterface, StrictPartia
 /**
  * https://discord.com/developers/docs/interactions/application-commands#get-global-application-commands
  */
+export interface RESTGetAPIApplicationCommandsQuery {
+	/**
+	 * Whether to include full localization dictionaries (name_localizations and description_localizations)
+	 * in the returned objects, instead of the name_localized and description_localized fields.
+	 *
+	 * @default false
+	 */
+	with_localizations?: boolean;
+}
+
+/**
+ * https://discord.com/developers/docs/interactions/application-commands#get-global-application-commands
+ */
 export type RESTGetAPIApplicationCommandsResult = APIApplicationCommand[];
 
 /**

--- a/rest/v10/guild.ts
+++ b/rest/v10/guild.ts
@@ -895,6 +895,11 @@ export type RESTPatchAPIGuildVoiceStateUserJSONBody = AddUndefinedToPossiblyUnde
 }>;
 
 /**
+ * https://discord.com/developers/docs/resources/guild#modify-user-voice-state
+ */
+export type RESTPatchAPIGuildVoiceStateUserResult = never;
+
+/**
  * https://discord.com/developers/docs/resources/guild#get-guild-welcome-screen
  */
 export type RESTGetAPIGuildWelcomeScreenResult = APIGuildWelcomeScreen;

--- a/rest/v10/interactions.ts
+++ b/rest/v10/interactions.ts
@@ -106,6 +106,11 @@ export type RESTPutAPIApplicationCommandsResult = APIApplicationCommand[];
 /**
  * https://discord.com/developers/docs/interactions/application-commands#get-guild-application-commands
  */
+export type RESTGetAPIApplicationGuildCommandsQuery = RESTGetAPIApplicationCommandsQuery;
+
+/**
+ * https://discord.com/developers/docs/interactions/application-commands#get-guild-application-commands
+ */
 export type RESTGetAPIApplicationGuildCommandsResult = Omit<APIApplicationCommand, 'dm_permission'>[];
 
 /**

--- a/rest/v10/interactions.ts
+++ b/rest/v10/interactions.ts
@@ -19,6 +19,19 @@ import type { AddUndefinedToPossiblyUndefinedPropertiesOfInterface, StrictPartia
 /**
  * https://discord.com/developers/docs/interactions/application-commands#get-global-application-commands
  */
+export interface RESTGetAPIApplicationCommandsQuery {
+	/**
+	 * Whether to include full localization dictionaries (name_localizations and description_localizations)
+	 * in the returned objects, instead of the name_localized and description_localized fields.
+	 *
+	 * @default false
+	 */
+	with_localizations?: boolean;
+}
+
+/**
+ * https://discord.com/developers/docs/interactions/application-commands#get-global-application-commands
+ */
 export type RESTGetAPIApplicationCommandsResult = APIApplicationCommand[];
 
 /**

--- a/rest/v9/guild.ts
+++ b/rest/v9/guild.ts
@@ -901,6 +901,11 @@ export type RESTPatchAPIGuildVoiceStateUserJSONBody = AddUndefinedToPossiblyUnde
 }>;
 
 /**
+ * https://discord.com/developers/docs/resources/guild#modify-user-voice-state
+ */
+export type RESTPatchAPIGuildVoiceStateUserResult = never;
+
+/**
  * https://discord.com/developers/docs/resources/guild#get-guild-welcome-screen
  */
 export type RESTGetAPIGuildWelcomeScreenResult = APIGuildWelcomeScreen;

--- a/rest/v9/interactions.ts
+++ b/rest/v9/interactions.ts
@@ -106,6 +106,11 @@ export type RESTPutAPIApplicationCommandsResult = APIApplicationCommand[];
 /**
  * https://discord.com/developers/docs/interactions/application-commands#get-guild-application-commands
  */
+export type RESTGetAPIApplicationGuildCommandsQuery = RESTGetAPIApplicationCommandsQuery;
+
+/**
+ * https://discord.com/developers/docs/interactions/application-commands#get-guild-application-commands
+ */
 export type RESTGetAPIApplicationGuildCommandsResult = Omit<APIApplicationCommand, 'dm_permission'>[];
 
 /**

--- a/rest/v9/interactions.ts
+++ b/rest/v9/interactions.ts
@@ -19,6 +19,19 @@ import type { AddUndefinedToPossiblyUndefinedPropertiesOfInterface, StrictPartia
 /**
  * https://discord.com/developers/docs/interactions/application-commands#get-global-application-commands
  */
+export interface RESTGetAPIApplicationCommandsQuery {
+	/**
+	 * Whether to include full localization dictionaries (name_localizations and description_localizations)
+	 * in the returned objects, instead of the name_localized and description_localized fields.
+	 *
+	 * @default false
+	 */
+	with_localizations?: boolean;
+}
+
+/**
+ * https://discord.com/developers/docs/interactions/application-commands#get-global-application-commands
+ */
 export type RESTGetAPIApplicationCommandsResult = APIApplicationCommand[];
 
 /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Adds the following:
- `RESTGetAPIApplicationCommandsQuery`: query string of `GET /applications/{application.id}/commands`
- `RESTGetAPIApplicationGuildCommandsQuery`: query string of `GET /applications/{application.id}/guilds/{guild.id}/commands`
- `RESTPatchAPIGuildVoiceStateUserResult`: return type of `PATCH /guilds/{guild.id}/voice-states/{user.id}`

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
