### PR TITLE
feat: add RESTJSONErrorCode `40062` and RESTRateLimit.code

### DIFF
--- a/deno/payloads/common.ts
+++ b/deno/payloads/common.ts
@@ -83,6 +83,7 @@ export type RESTErrorData = RESTErrorGroupWrapper | RESTErrorFieldInformation | 
  * https://discord.com/developers/docs/topics/rate-limits#exceeding-a-rate-limit-rate-limit-response-structure
  */
 export interface RESTRateLimit {
+	code?: number;
 	/**
 	 * A value indicating if you are being globally rate limited or not
 	 */

--- a/deno/payloads/common.ts
+++ b/deno/payloads/common.ts
@@ -83,6 +83,11 @@ export type RESTErrorData = RESTErrorGroupWrapper | RESTErrorFieldInformation | 
  * https://discord.com/developers/docs/topics/rate-limits#exceeding-a-rate-limit-rate-limit-response-structure
  */
 export interface RESTRateLimit {
+	/**
+	 * An error code for some limits
+	 *
+	 * {@link RESTJSONErrorCodes}
+	 */
 	code?: number;
 	/**
 	 * A value indicating if you are being globally rate limited or not

--- a/deno/rest/common.ts
+++ b/deno/rest/common.ts
@@ -141,6 +141,7 @@ export enum RESTJSONErrorCodes {
 
 	InteractionHasAlreadyBeenAcknowledged = 40060,
 	TagNamesMustBeUnique,
+	ServiceResourceIsBeingRateLimited,
 
 	ThereAreNoTagsAvailableThatCanBeSetByNonModerators = 40066,
 	TagRequiredToCreateAForumPostInThisChannel,

--- a/payloads/common.ts
+++ b/payloads/common.ts
@@ -83,6 +83,7 @@ export type RESTErrorData = RESTErrorGroupWrapper | RESTErrorFieldInformation | 
  * https://discord.com/developers/docs/topics/rate-limits#exceeding-a-rate-limit-rate-limit-response-structure
  */
 export interface RESTRateLimit {
+	code?: number;
 	/**
 	 * A value indicating if you are being globally rate limited or not
 	 */

--- a/payloads/common.ts
+++ b/payloads/common.ts
@@ -83,6 +83,11 @@ export type RESTErrorData = RESTErrorGroupWrapper | RESTErrorFieldInformation | 
  * https://discord.com/developers/docs/topics/rate-limits#exceeding-a-rate-limit-rate-limit-response-structure
  */
 export interface RESTRateLimit {
+	/**
+	 * An error code for some limits
+	 *
+	 * {@link RESTJSONErrorCodes}
+	 */
 	code?: number;
 	/**
 	 * A value indicating if you are being globally rate limited or not

--- a/rest/common.ts
+++ b/rest/common.ts
@@ -141,6 +141,7 @@ export enum RESTJSONErrorCodes {
 
 	InteractionHasAlreadyBeenAcknowledged = 40060,
 	TagNamesMustBeUnique,
+	ServiceResourceIsBeingRateLimited,
 
 	ThereAreNoTagsAvailableThatCanBeSetByNonModerators = 40066,
 	TagRequiredToCreateAForumPostInThisChannel,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

```json
{
    "code": 40062,
    "global": false,
    "message": "Service resource is being rate limited.",
    "retry_after": 3
}
```
**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
* https://github.com/discord/discord-api-docs/pull/5574