### PR TITLE
fix(UserFlags): hardcode the value of `Quarantined`

### DIFF
--- a/deno/payloads/v10/user.ts
+++ b/deno/payloads/v10/user.ts
@@ -151,8 +151,12 @@ export enum UserFlags {
 	 * User's account has been quarantined based on recent activity
 	 *
 	 * @unstable This user flag is currently not documented by Discord but has a known value which we will try to keep up to date.
+	 *
+	 * @privateRemarks
+	 *
+	 * This value would be 1 << 44, but bit shifting above 1 << 30 requires bigints
 	 */
-	Quarantined = 17592186044416, // This value would be 1 << 44, but bit shifting above 1 << 30 requires bigints
+	Quarantined = 17592186044416,
 }
 
 /**

--- a/deno/payloads/v10/user.ts
+++ b/deno/payloads/v10/user.ts
@@ -152,7 +152,7 @@ export enum UserFlags {
 	 *
 	 * @unstable This user flag is currently not documented by Discord but has a known value which we will try to keep up to date.
 	 */
-	Quarantined = Math.pow(2, 44),
+	Quarantined = 17592186044416, // This value would be 1 << 44, but bit shifting above 1 << 30 requires bigints
 }
 
 /**

--- a/deno/payloads/v9/user.ts
+++ b/deno/payloads/v9/user.ts
@@ -152,7 +152,7 @@ export enum UserFlags {
 	 *
 	 * @unstable This user flag is currently not documented by Discord but has a known value which we will try to keep up to date.
 	 */
-	Quarantined = Math.pow(2, 44),
+	Quarantined = 17592186044416, // This value would be 1 << 44, but bit shifting above 1 << 30 requires bigints
 }
 
 /**

--- a/deno/payloads/v9/user.ts
+++ b/deno/payloads/v9/user.ts
@@ -150,9 +150,13 @@ export enum UserFlags {
 	/**
 	 * User's account has been quarantined based on recent activity
 	 *
-	 * @unstable This user flag is currently not documented by Discord but has a known value which we will try to keep up to date.
+	 * @unstable This user flag is currently not documented by Discord but has a known value which we will try to keep up to date.~
+	 *
+	 * @privateRemarks
+	 *
+	 * This value would be 1 << 44, but bit shifting above 1 << 30 requires bigints
 	 */
-	Quarantined = 17592186044416, // This value would be 1 << 44, but bit shifting above 1 << 30 requires bigints
+	Quarantined = 17592186044416,
 }
 
 /**

--- a/payloads/v10/user.ts
+++ b/payloads/v10/user.ts
@@ -151,8 +151,12 @@ export enum UserFlags {
 	 * User's account has been quarantined based on recent activity
 	 *
 	 * @unstable This user flag is currently not documented by Discord but has a known value which we will try to keep up to date.
+	 *
+	 * @privateRemarks
+	 *
+	 * This value would be 1 << 44, but bit shifting above 1 << 30 requires bigints
 	 */
-	Quarantined = 17592186044416, // This value would be 1 << 44, but bit shifting above 1 << 30 requires bigints
+	Quarantined = 17592186044416,
 }
 
 /**

--- a/payloads/v10/user.ts
+++ b/payloads/v10/user.ts
@@ -152,7 +152,7 @@ export enum UserFlags {
 	 *
 	 * @unstable This user flag is currently not documented by Discord but has a known value which we will try to keep up to date.
 	 */
-	Quarantined = Math.pow(2, 44),
+	Quarantined = 17592186044416, // This value would be 1 << 44, but bit shifting above 1 << 30 requires bigints
 }
 
 /**

--- a/payloads/v9/user.ts
+++ b/payloads/v9/user.ts
@@ -152,7 +152,7 @@ export enum UserFlags {
 	 *
 	 * @unstable This user flag is currently not documented by Discord but has a known value which we will try to keep up to date.
 	 */
-	Quarantined = Math.pow(2, 44),
+	Quarantined = 17592186044416, // This value would be 1 << 44, but bit shifting above 1 << 30 requires bigints
 }
 
 /**

--- a/payloads/v9/user.ts
+++ b/payloads/v9/user.ts
@@ -150,9 +150,13 @@ export enum UserFlags {
 	/**
 	 * User's account has been quarantined based on recent activity
 	 *
-	 * @unstable This user flag is currently not documented by Discord but has a known value which we will try to keep up to date.
+	 * @unstable This user flag is currently not documented by Discord but has a known value which we will try to keep up to date.~
+	 *
+	 * @privateRemarks
+	 *
+	 * This value would be 1 << 44, but bit shifting above 1 << 30 requires bigints
 	 */
-	Quarantined = 17592186044416, // This value would be 1 << 44, but bit shifting above 1 << 30 requires bigints
+	Quarantined = 17592186044416,
 }
 
 /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The tsc is not able to compute the value of `Math.pow(2, 44)` at compile-time, leaving the `Quarantined` enum member without an initializer in the .d.ts file, which prevents thing such as:
![image](https://user-images.githubusercontent.com/42935195/198383946-ab3204a9-face-4a7d-a3a1-156d4ff5bf2b.png)


**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
