### PR TITLE
fix: export `RESTGetAPIVoiceRegionsResult` with the correct name

### DIFF
--- a/deno/rest/v10/voice.ts
+++ b/deno/rest/v10/voice.ts
@@ -3,4 +3,9 @@ import type { APIVoiceRegion } from '../../payloads/v10/mod.ts';
 /**
  * https://discord.com/developers/docs/resources/voice#list-voice-regions
  */
-export type GetAPIVoiceRegionsResult = APIVoiceRegion[];
+export type RESTGetAPIVoiceRegionsResult = APIVoiceRegion[];
+
+/**
+ * @deprecated This was exported with the wrong name, use `RESTGetAPIVoiceRegionsResult` instead
+ */
+export type GetAPIVoiceRegionsResult = RESTGetAPIVoiceRegionsResult;

--- a/deno/rest/v9/voice.ts
+++ b/deno/rest/v9/voice.ts
@@ -3,4 +3,9 @@ import type { APIVoiceRegion } from '../../payloads/v9/mod.ts';
 /**
  * https://discord.com/developers/docs/resources/voice#list-voice-regions
  */
-export type GetAPIVoiceRegionsResult = APIVoiceRegion[];
+export type RESTGetAPIVoiceRegionsResult = APIVoiceRegion[];
+
+/**
+ * @deprecated This was exported with the wrong name, use `RESTGetAPIVoiceRegionsResult` instead
+ */
+export type GetAPIVoiceRegionsResult = RESTGetAPIVoiceRegionsResult;

--- a/rest/v10/voice.ts
+++ b/rest/v10/voice.ts
@@ -3,4 +3,9 @@ import type { APIVoiceRegion } from '../../payloads/v10/index';
 /**
  * https://discord.com/developers/docs/resources/voice#list-voice-regions
  */
-export type GetAPIVoiceRegionsResult = APIVoiceRegion[];
+export type RESTGetAPIVoiceRegionsResult = APIVoiceRegion[];
+
+/**
+ * @deprecated This was exported with the wrong name, use `RESTGetAPIVoiceRegionsResult` instead
+ */
+export type GetAPIVoiceRegionsResult = RESTGetAPIVoiceRegionsResult;

--- a/rest/v9/voice.ts
+++ b/rest/v9/voice.ts
@@ -3,4 +3,9 @@ import type { APIVoiceRegion } from '../../payloads/v9/index';
 /**
  * https://discord.com/developers/docs/resources/voice#list-voice-regions
  */
-export type GetAPIVoiceRegionsResult = APIVoiceRegion[];
+export type RESTGetAPIVoiceRegionsResult = APIVoiceRegion[];
+
+/**
+ * @deprecated This was exported with the wrong name, use `RESTGetAPIVoiceRegionsResult` instead
+ */
+export type GetAPIVoiceRegionsResult = RESTGetAPIVoiceRegionsResult;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Thanks @IanMitchell for the report

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
