### PR TITLE
fix(APIGuildChannel): make position of guild channel non optional

### DIFF
--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -83,7 +83,7 @@ export interface APIGuildChannel<T extends ChannelType> extends APIChannelBase<T
 	/**
 	 * Sorting position of the channel
 	 */
-	position?: number;
+	position: number;
 	/**
 	 * ID of the parent category for a channel (each parent category can contain up to 50 channels)
 	 *

--- a/deno/payloads/v8/channel.ts
+++ b/deno/payloads/v8/channel.ts
@@ -86,7 +86,7 @@ export interface APIGuildChannel<T extends ChannelType> extends APIChannelBase<T
 	/**
 	 * Sorting position of the channel
 	 */
-	position?: number;
+	position: number;
 	/**
 	 * ID of the parent category for a channel (each parent category can contain up to 50 channels)
 	 */

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -83,7 +83,7 @@ export interface APIGuildChannel<T extends ChannelType> extends APIChannelBase<T
 	/**
 	 * Sorting position of the channel
 	 */
-	position?: number;
+	position: number;
 	/**
 	 * ID of the parent category for a channel (each parent category can contain up to 50 channels)
 	 *

--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -83,7 +83,7 @@ export interface APIGuildChannel<T extends ChannelType> extends APIChannelBase<T
 	/**
 	 * Sorting position of the channel
 	 */
-	position?: number;
+	position: number;
 	/**
 	 * ID of the parent category for a channel (each parent category can contain up to 50 channels)
 	 *

--- a/payloads/v8/channel.ts
+++ b/payloads/v8/channel.ts
@@ -86,7 +86,7 @@ export interface APIGuildChannel<T extends ChannelType> extends APIChannelBase<T
 	/**
 	 * Sorting position of the channel
 	 */
-	position?: number;
+	position: number;
 	/**
 	 * ID of the parent category for a channel (each parent category can contain up to 50 channels)
 	 */

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -83,7 +83,7 @@ export interface APIGuildChannel<T extends ChannelType> extends APIChannelBase<T
 	/**
 	 * Sorting position of the channel
 	 */
-	position?: number;
+	position: number;
 	/**
 	 * ID of the parent category for a channel (each parent category can contain up to 50 channels)
 	 *


### PR DESCRIPTION
To my understanding, the position on a guild channel should never be missing or undefined, therefore it should not be marked as such. This PR marks the property as always present.
