### PR TITLE
fix(channel): Add missing thread-related results

### DIFF
--- a/deno/rest/v10/channel.ts
+++ b/deno/rest/v10/channel.ts
@@ -695,6 +695,16 @@ export interface RESTGetAPIChannelThreadsArchivedQuery {
 }
 
 /**
+ * https://discord.com/developers/docs/resources/channel#list-public-archived-threads
+ */
+export type RESTGetAPIChannelThreadsArchivedPublicResult = RESTGetAPIChannelUsersThreadsArchivedResult;
+
+/**
+ * https://discord.com/developers/docs/resources/channel#list-private-archived-threads
+ */
+export type RESTGetAPIChannelThreadsArchivedPrivateResult = RESTGetAPIChannelUsersThreadsArchivedResult;
+
+/**
  * https://discord.com/developers/docs/resources/channel#list-joined-private-archived-threads
  */
 export interface RESTGetAPIChannelUsersThreadsArchivedResult extends APIThreadList {

--- a/deno/rest/v9/channel.ts
+++ b/deno/rest/v9/channel.ts
@@ -709,6 +709,16 @@ export interface RESTGetAPIChannelThreadsArchivedQuery {
 }
 
 /**
+ * https://discord.com/developers/docs/resources/channel#list-public-archived-threads
+ */
+export type RESTGetAPIChannelThreadsArchivedPublicResult = RESTGetAPIChannelUsersThreadsArchivedResult;
+
+/**
+ * https://discord.com/developers/docs/resources/channel#list-private-archived-threads
+ */
+export type RESTGetAPIChannelThreadsArchivedPrivateResult = RESTGetAPIChannelUsersThreadsArchivedResult;
+
+/**
  * https://discord.com/developers/docs/resources/channel#list-active-threads
  *
  * @deprecated Removed in API v10, use [List Active Guild Threads](https://discord.com/developers/docs/resources/guild#list-active-threads) instead.

--- a/rest/v10/channel.ts
+++ b/rest/v10/channel.ts
@@ -695,6 +695,16 @@ export interface RESTGetAPIChannelThreadsArchivedQuery {
 }
 
 /**
+ * https://discord.com/developers/docs/resources/channel#list-public-archived-threads
+ */
+export type RESTGetAPIChannelThreadsArchivedPublicResult = RESTGetAPIChannelUsersThreadsArchivedResult;
+
+/**
+ * https://discord.com/developers/docs/resources/channel#list-private-archived-threads
+ */
+export type RESTGetAPIChannelThreadsArchivedPrivateResult = RESTGetAPIChannelUsersThreadsArchivedResult;
+
+/**
  * https://discord.com/developers/docs/resources/channel#list-joined-private-archived-threads
  */
 export interface RESTGetAPIChannelUsersThreadsArchivedResult extends APIThreadList {

--- a/rest/v9/channel.ts
+++ b/rest/v9/channel.ts
@@ -709,6 +709,16 @@ export interface RESTGetAPIChannelThreadsArchivedQuery {
 }
 
 /**
+ * https://discord.com/developers/docs/resources/channel#list-public-archived-threads
+ */
+export type RESTGetAPIChannelThreadsArchivedPublicResult = RESTGetAPIChannelUsersThreadsArchivedResult;
+
+/**
+ * https://discord.com/developers/docs/resources/channel#list-private-archived-threads
+ */
+export type RESTGetAPIChannelThreadsArchivedPrivateResult = RESTGetAPIChannelUsersThreadsArchivedResult;
+
+/**
  * https://discord.com/developers/docs/resources/channel#list-active-threads
  *
  * @deprecated Removed in API v10, use [List Active Guild Threads](https://discord.com/developers/docs/resources/guild#list-active-threads) instead.


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Resolves #526:

- [`GET /channels/{channel.id}/threads/archived/public`](https://discord.com/developers/docs/resources/channel#list-public-archived-threads) is `RESTGetAPIChannelThreadsArchivedPublicResult`
- [`GET /channels/{channel.id}/threads/archived/private`](https://discord.com/developers/docs/resources/channel#list-private-archived-threads) is `RESTGetAPIChannelThreadsArchivedPrivateResult`
- [`GET /channels/{channel.id}/users/@me/threads/archived/private`](https://discord.com/developers/docs/resources/channel#list-joined-private-archived-threads) is `RESTGetAPIChannelUsersThreadsArchivedResult` (already exists)