### PR TITLE
fix(Interactions): make app_permissions required

### DIFF
--- a/deno/payloads/v10/_interactions/applicationCommands.ts
+++ b/deno/payloads/v10/_interactions/applicationCommands.ts
@@ -110,7 +110,9 @@ export type APIApplicationCommandInteractionData =
  */
 export type APIApplicationCommandInteractionWrapper<Data extends APIApplicationCommandInteractionData> =
 	APIBaseInteraction<InteractionType.ApplicationCommand, Data> &
-		Required<Pick<APIBaseInteraction<InteractionType.ApplicationCommand, Data>, 'channel_id' | 'data'>>;
+		Required<
+			Pick<APIBaseInteraction<InteractionType.ApplicationCommand, Data>, 'channel_id' | 'data' | 'app_permissions'>
+		>;
 
 /**
  * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object

--- a/deno/payloads/v10/_interactions/messageComponents.ts
+++ b/deno/payloads/v10/_interactions/messageComponents.ts
@@ -15,7 +15,7 @@ export type APIMessageComponentInteraction = APIBaseInteraction<
 	Required<
 		Pick<
 			APIBaseInteraction<InteractionType.MessageComponent, APIMessageComponentInteractionData>,
-			'channel_id' | 'data' | 'message'
+			'channel_id' | 'data' | 'app_permissions' | 'message'
 		>
 	>;
 
@@ -26,7 +26,7 @@ export type APIMessageComponentButtonInteraction = APIBaseInteraction<
 	Required<
 		Pick<
 			APIBaseInteraction<InteractionType.MessageComponent, APIMessageButtonInteractionData>,
-			'channel_id' | 'data' | 'message'
+			'channel_id' | 'data' | 'app_permissions' | 'message'
 		>
 	>;
 
@@ -37,7 +37,7 @@ export type APIMessageComponentSelectMenuInteraction = APIBaseInteraction<
 	Required<
 		Pick<
 			APIBaseInteraction<InteractionType.MessageComponent, APIMessageSelectMenuInteractionData>,
-			'channel_id' | 'data' | 'message'
+			'channel_id' | 'data' | 'app_permissions' | 'message'
 		>
 	>;
 

--- a/deno/payloads/v9/_interactions/applicationCommands.ts
+++ b/deno/payloads/v9/_interactions/applicationCommands.ts
@@ -110,7 +110,9 @@ export type APIApplicationCommandInteractionData =
  */
 export type APIApplicationCommandInteractionWrapper<Data extends APIApplicationCommandInteractionData> =
 	APIBaseInteraction<InteractionType.ApplicationCommand, Data> &
-		Required<Pick<APIBaseInteraction<InteractionType.ApplicationCommand, Data>, 'channel_id' | 'data'>>;
+		Required<
+			Pick<APIBaseInteraction<InteractionType.ApplicationCommand, Data>, 'channel_id' | 'data' | 'app_permissions'>
+		>;
 
 /**
  * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object

--- a/deno/payloads/v9/_interactions/messageComponents.ts
+++ b/deno/payloads/v9/_interactions/messageComponents.ts
@@ -15,7 +15,7 @@ export type APIMessageComponentInteraction = APIBaseInteraction<
 	Required<
 		Pick<
 			APIBaseInteraction<InteractionType.MessageComponent, APIMessageComponentInteractionData>,
-			'channel_id' | 'data' | 'message'
+			'channel_id' | 'data' | 'app_permissions' | 'message'
 		>
 	>;
 
@@ -26,7 +26,7 @@ export type APIMessageComponentButtonInteraction = APIBaseInteraction<
 	Required<
 		Pick<
 			APIBaseInteraction<InteractionType.MessageComponent, APIMessageButtonInteractionData>,
-			'channel_id' | 'data' | 'message'
+			'channel_id' | 'data' | 'app_permissions' | 'message'
 		>
 	>;
 
@@ -37,7 +37,7 @@ export type APIMessageComponentSelectMenuInteraction = APIBaseInteraction<
 	Required<
 		Pick<
 			APIBaseInteraction<InteractionType.MessageComponent, APIMessageSelectMenuInteractionData>,
-			'channel_id' | 'data' | 'message'
+			'channel_id' | 'data' | 'app_permissions' | 'message'
 		>
 	>;
 

--- a/payloads/v10/_interactions/applicationCommands.ts
+++ b/payloads/v10/_interactions/applicationCommands.ts
@@ -110,7 +110,9 @@ export type APIApplicationCommandInteractionData =
  */
 export type APIApplicationCommandInteractionWrapper<Data extends APIApplicationCommandInteractionData> =
 	APIBaseInteraction<InteractionType.ApplicationCommand, Data> &
-		Required<Pick<APIBaseInteraction<InteractionType.ApplicationCommand, Data>, 'channel_id' | 'data'>>;
+		Required<
+			Pick<APIBaseInteraction<InteractionType.ApplicationCommand, Data>, 'channel_id' | 'data' | 'app_permissions'>
+		>;
 
 /**
  * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object

--- a/payloads/v10/_interactions/messageComponents.ts
+++ b/payloads/v10/_interactions/messageComponents.ts
@@ -15,7 +15,7 @@ export type APIMessageComponentInteraction = APIBaseInteraction<
 	Required<
 		Pick<
 			APIBaseInteraction<InteractionType.MessageComponent, APIMessageComponentInteractionData>,
-			'channel_id' | 'data' | 'message'
+			'channel_id' | 'data' | 'app_permissions' | 'message'
 		>
 	>;
 
@@ -26,7 +26,7 @@ export type APIMessageComponentButtonInteraction = APIBaseInteraction<
 	Required<
 		Pick<
 			APIBaseInteraction<InteractionType.MessageComponent, APIMessageButtonInteractionData>,
-			'channel_id' | 'data' | 'message'
+			'channel_id' | 'data' | 'app_permissions' | 'message'
 		>
 	>;
 
@@ -37,7 +37,7 @@ export type APIMessageComponentSelectMenuInteraction = APIBaseInteraction<
 	Required<
 		Pick<
 			APIBaseInteraction<InteractionType.MessageComponent, APIMessageSelectMenuInteractionData>,
-			'channel_id' | 'data' | 'message'
+			'channel_id' | 'data' | 'app_permissions' | 'message'
 		>
 	>;
 

--- a/payloads/v9/_interactions/applicationCommands.ts
+++ b/payloads/v9/_interactions/applicationCommands.ts
@@ -110,7 +110,9 @@ export type APIApplicationCommandInteractionData =
  */
 export type APIApplicationCommandInteractionWrapper<Data extends APIApplicationCommandInteractionData> =
 	APIBaseInteraction<InteractionType.ApplicationCommand, Data> &
-		Required<Pick<APIBaseInteraction<InteractionType.ApplicationCommand, Data>, 'channel_id' | 'data'>>;
+		Required<
+			Pick<APIBaseInteraction<InteractionType.ApplicationCommand, Data>, 'channel_id' | 'data' | 'app_permissions'>
+		>;
 
 /**
  * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object

--- a/payloads/v9/_interactions/messageComponents.ts
+++ b/payloads/v9/_interactions/messageComponents.ts
@@ -15,7 +15,7 @@ export type APIMessageComponentInteraction = APIBaseInteraction<
 	Required<
 		Pick<
 			APIBaseInteraction<InteractionType.MessageComponent, APIMessageComponentInteractionData>,
-			'channel_id' | 'data' | 'message'
+			'channel_id' | 'data' | 'app_permissions' | 'message'
 		>
 	>;
 
@@ -26,7 +26,7 @@ export type APIMessageComponentButtonInteraction = APIBaseInteraction<
 	Required<
 		Pick<
 			APIBaseInteraction<InteractionType.MessageComponent, APIMessageButtonInteractionData>,
-			'channel_id' | 'data' | 'message'
+			'channel_id' | 'data' | 'app_permissions' | 'message'
 		>
 	>;
 
@@ -37,7 +37,7 @@ export type APIMessageComponentSelectMenuInteraction = APIBaseInteraction<
 	Required<
 		Pick<
 			APIBaseInteraction<InteractionType.MessageComponent, APIMessageSelectMenuInteractionData>,
-			'channel_id' | 'data' | 'message'
+			'channel_id' | 'data' | 'app_permissions' | 'message'
 		>
 	>;
 


### PR DESCRIPTION
This makes `app_permissions` required in application command and message component interactions, where `channel_id` and `data` are set to required.

Currently discord-api-types is very inconsistent about interaction required fields and more work should probably be done to fix that; this might be due to the docs also being inconsistent about these

locale is set as required in the interaction structure but then removed in ping
data is set as optional in the interaction structure but then set as required in all subinterfaces except ping
channel_id is set as optional in the interaction structure but then set as required for cmds and components, although it should also be required in autocomplete and modal submit

for now I just made autocomplete copy channel_id's current behavior as a quick fix, but this should be straightened out in general tbh. I'll see if we can get the docs cleaned up
