### PR TITLE
docs: Link `Quarantined` to article

### DIFF
--- a/deno/payloads/v10/user.ts
+++ b/deno/payloads/v10/user.ts
@@ -152,7 +152,7 @@ export enum UserFlags {
 	 */
 	ActiveDeveloper = 1 << 22,
 	/**
-	 * User's account has been quarantined based on recent activity
+	 * User's account has been [quarantined](https://support.discord.com/hc/en-us/articles/6461420677527) based on recent activity
 	 *
 	 * @unstable This user flag is currently not documented by Discord but has a known value which we will try to keep up to date.
 	 *

--- a/deno/payloads/v8/user.ts
+++ b/deno/payloads/v8/user.ts
@@ -150,11 +150,15 @@ export enum UserFlags {
 	 */
 	Spammer = 1 << 20,
 	/**
-	 * User's account has been quarantined based on recent activity
+	 * User's account has been [quarantined](https://support.discord.com/hc/en-us/articles/6461420677527) based on recent activity
 	 *
 	 * @unstable This user flag is currently not documented by Discord but has a known value which we will try to keep up to date.
+	 *
+	 * @privateRemarks
+	 *
+	 * This value would be 1 << 44, but bit shifting above 1 << 30 requires bigints
 	 */
-	Quarantined = Math.pow(2, 44),
+	Quarantined = 17592186044416,
 }
 
 /**

--- a/deno/payloads/v9/user.ts
+++ b/deno/payloads/v9/user.ts
@@ -152,7 +152,7 @@ export enum UserFlags {
 	 */
 	ActiveDeveloper = 1 << 22,
 	/**
-	 * User's account has been quarantined based on recent activity
+	 * User's account has been [quarantined](https://support.discord.com/hc/en-us/articles/6461420677527) based on recent activity
 	 *
 	 * @unstable This user flag is currently not documented by Discord but has a known value which we will try to keep up to date.
 	 *

--- a/payloads/v10/user.ts
+++ b/payloads/v10/user.ts
@@ -152,7 +152,7 @@ export enum UserFlags {
 	 */
 	ActiveDeveloper = 1 << 22,
 	/**
-	 * User's account has been quarantined based on recent activity
+	 * User's account has been [quarantined](https://support.discord.com/hc/en-us/articles/6461420677527) based on recent activity
 	 *
 	 * @unstable This user flag is currently not documented by Discord but has a known value which we will try to keep up to date.
 	 *

--- a/payloads/v8/user.ts
+++ b/payloads/v8/user.ts
@@ -150,11 +150,15 @@ export enum UserFlags {
 	 */
 	Spammer = 1 << 20,
 	/**
-	 * User's account has been quarantined based on recent activity
+	 * User's account has been [quarantined](https://support.discord.com/hc/en-us/articles/6461420677527) based on recent activity
 	 *
 	 * @unstable This user flag is currently not documented by Discord but has a known value which we will try to keep up to date.
+	 *
+	 * @privateRemarks
+	 *
+	 * This value would be 1 << 44, but bit shifting above 1 << 30 requires bigints
 	 */
-	Quarantined = Math.pow(2, 44),
+	Quarantined = 17592186044416,
 }
 
 /**

--- a/payloads/v9/user.ts
+++ b/payloads/v9/user.ts
@@ -152,7 +152,7 @@ export enum UserFlags {
 	 */
 	ActiveDeveloper = 1 << 22,
 	/**
-	 * User's account has been quarantined based on recent activity
+	 * User's account has been [quarantined](https://support.discord.com/hc/en-us/articles/6461420677527) based on recent activity
 	 *
 	 * @unstable This user flag is currently not documented by Discord but has a known value which we will try to keep up to date.
 	 *


### PR DESCRIPTION
This PR links the `Quarantined` UserFlag to the [related support article](https://support.discord.com/hc/en-us/articles/6461420677527). It also corrects the v8 value (see #624).