### PR TITLE
docs: Remove locales and titles in help center article links

### DIFF
--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -348,13 +348,13 @@ export enum ChannelType {
 	/**
 	 * An organizational category that contains up to 50 channels
 	 *
-	 * See https://support.discord.com/hc/en-us/articles/115001580171-Channel-Categories-101
+	 * See https://support.discord.com/hc/articles/115001580171-Channel-Categories-101
 	 */
 	GuildCategory,
 	/**
 	 * A channel that users can follow and crosspost into their own guild
 	 *
-	 * See https://support.discord.com/hc/en-us/articles/360032008192
+	 * See https://support.discord.com/hc/articles/360032008192
 	 */
 	GuildAnnouncement,
 	/**
@@ -372,13 +372,13 @@ export enum ChannelType {
 	/**
 	 * A voice channel for hosting events with an audience
 	 *
-	 * See https://support.discord.com/hc/en-us/articles/1500005513722
+	 * See https://support.discord.com/hc/articles/1500005513722
 	 */
 	GuildStageVoice,
 	/**
 	 * The channel in a Student Hub containing the listed servers
 	 *
-	 * See https://support.discord.com/hc/en-us/articles/4406046651927-Discord-Student-Hubs-FAQ
+	 * See https://support.discord.com/hc/articles/4406046651927-Discord-Student-Hubs-FAQ
 	 */
 	GuildDirectory,
 	/**
@@ -393,7 +393,7 @@ export enum ChannelType {
 	 *
 	 * @deprecated This is the old name for {@apilink ChannelType#GuildAnnouncement}
 	 *
-	 * See https://support.discord.com/hc/en-us/articles/360032008192
+	 * See https://support.discord.com/hc/articles/360032008192
 	 */
 	GuildNews = 5,
 	/**
@@ -456,7 +456,7 @@ export interface APIMessage {
 	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**.
 	 * You also need to specify the intent bit value (`1 << 15`) if you are connecting to the gateway
 	 *
-	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
+	 * See https://support-dev.discord.com/hc/articles/4404772028055
 	 */
 	content: string;
 	/**
@@ -513,7 +513,7 @@ export interface APIMessage {
 	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**.
 	 * You also need to specify the intent bit value (`1 << 15`) if you are connecting to the gateway
 	 *
-	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
+	 * See https://support-dev.discord.com/hc/articles/4404772028055
 	 */
 	attachments: APIAttachment[];
 	/**
@@ -526,7 +526,7 @@ export interface APIMessage {
 	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**.
 	 * You also need to specify the intent bit value (`1 << 15`) if you are connecting to the gateway
 	 *
-	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
+	 * See https://support-dev.discord.com/hc/articles/4404772028055
 	 */
 	embeds: APIEmbed[];
 	/**
@@ -616,7 +616,7 @@ export interface APIMessage {
 	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**.
 	 * You also need to specify the intent bit value (`1 << 15`) if you are connecting to the gateway
 	 *
-	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
+	 * See https://support-dev.discord.com/hc/articles/4404772028055
 	 */
 	components?: APIActionRowComponent<APIMessageActionRowComponent>[];
 	/**

--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -348,7 +348,7 @@ export enum ChannelType {
 	/**
 	 * An organizational category that contains up to 50 channels
 	 *
-	 * See https://support.discord.com/hc/articles/115001580171-Channel-Categories-101
+	 * See https://support.discord.com/hc/articles/115001580171
 	 */
 	GuildCategory,
 	/**
@@ -378,7 +378,7 @@ export enum ChannelType {
 	/**
 	 * The channel in a Student Hub containing the listed servers
 	 *
-	 * See https://support.discord.com/hc/articles/4406046651927-Discord-Student-Hubs-FAQ
+	 * See https://support.discord.com/hc/articles/4406046651927
 	 */
 	GuildDirectory,
 	/**

--- a/deno/payloads/v10/guild.ts
+++ b/deno/payloads/v10/guild.ts
@@ -419,7 +419,7 @@ export enum GuildFeature {
 	/**
 	 * Guild is a Student Hub
 	 *
-	 * See https://support.discord.com/hc/articles/4406046651927-Discord-Student-Hubs-FAQ
+	 * See https://support.discord.com/hc/articles/4406046651927
 	 *
 	 * @unstable This feature is currently not documented by Discord, but has known value
 	 */
@@ -435,7 +435,7 @@ export enum GuildFeature {
 	/**
 	 * Guild is in a Student Hub
 	 *
-	 * See https://support.discord.com/hc/articles/4406046651927-Discord-Student-Hubs-FAQ
+	 * See https://support.discord.com/hc/articles/4406046651927
 	 *
 	 * @unstable This feature is currently not documented by Discord, but has known value
 	 */
@@ -602,7 +602,7 @@ export interface APIGuildMember {
 	/**
 	 * When the user started boosting the guild
 	 *
-	 * See https://support.discord.com/hc/articles/360028038352-Server-Boosting-
+	 * See https://support.discord.com/hc/articles/360028038352
 	 */
 	premium_since?: string | null;
 	/**

--- a/deno/payloads/v10/guild.ts
+++ b/deno/payloads/v10/guild.ts
@@ -419,7 +419,7 @@ export enum GuildFeature {
 	/**
 	 * Guild is a Student Hub
 	 *
-	 * See https://support.discord.com/hc/en-us/articles/4406046651927-Discord-Student-Hubs-FAQ
+	 * See https://support.discord.com/hc/articles/4406046651927-Discord-Student-Hubs-FAQ
 	 *
 	 * @unstable This feature is currently not documented by Discord, but has known value
 	 */
@@ -435,7 +435,7 @@ export enum GuildFeature {
 	/**
 	 * Guild is in a Student Hub
 	 *
-	 * See https://support.discord.com/hc/en-us/articles/4406046651927-Discord-Student-Hubs-FAQ
+	 * See https://support.discord.com/hc/articles/4406046651927-Discord-Student-Hubs-FAQ
 	 *
 	 * @unstable This feature is currently not documented by Discord, but has known value
 	 */
@@ -602,7 +602,7 @@ export interface APIGuildMember {
 	/**
 	 * When the user started boosting the guild
 	 *
-	 * See https://support.discord.com/hc/en-us/articles/360028038352-Server-Boosting-
+	 * See https://support.discord.com/hc/articles/360028038352-Server-Boosting-
 	 */
 	premium_since?: string | null;
 	/**

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -348,13 +348,13 @@ export enum ChannelType {
 	/**
 	 * An organizational category that contains up to 50 channels
 	 *
-	 * See https://support.discord.com/hc/en-us/articles/115001580171-Channel-Categories-101
+	 * See https://support.discord.com/hc/articles/115001580171-Channel-Categories-101
 	 */
 	GuildCategory,
 	/**
 	 * A channel that users can follow and crosspost into their own guild
 	 *
-	 * See https://support.discord.com/hc/en-us/articles/360032008192
+	 * See https://support.discord.com/hc/articles/360032008192
 	 */
 	GuildAnnouncement,
 	/**
@@ -372,13 +372,13 @@ export enum ChannelType {
 	/**
 	 * A voice channel for hosting events with an audience
 	 *
-	 * See https://support.discord.com/hc/en-us/articles/1500005513722
+	 * See https://support.discord.com/hc/articles/1500005513722
 	 */
 	GuildStageVoice,
 	/**
 	 * The channel in a Student Hub containing the listed servers
 	 *
-	 * See https://support.discord.com/hc/en-us/articles/4406046651927-Discord-Student-Hubs-FAQ
+	 * See https://support.discord.com/hc/articles/4406046651927-Discord-Student-Hubs-FAQ
 	 */
 	GuildDirectory,
 	/**
@@ -392,7 +392,7 @@ export enum ChannelType {
 	 *
 	 * @deprecated This is the old name for {@apilink ChannelType#GuildAnnouncement}
 	 *
-	 * See https://support.discord.com/hc/en-us/articles/360032008192
+	 * See https://support.discord.com/hc/articles/360032008192
 	 */
 	GuildNews = 5,
 	/**
@@ -454,7 +454,7 @@ export interface APIMessage {
 	 *
 	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**
 	 *
-	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
+	 * See https://support-dev.discord.com/hc/articles/4404772028055
 	 */
 	content: string;
 	/**
@@ -510,7 +510,7 @@ export interface APIMessage {
 	 *
 	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**
 	 *
-	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
+	 * See https://support-dev.discord.com/hc/articles/4404772028055
 	 */
 	attachments: APIAttachment[];
 	/**
@@ -522,7 +522,7 @@ export interface APIMessage {
 	 *
 	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**
 	 *
-	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
+	 * See https://support-dev.discord.com/hc/articles/4404772028055
 	 */
 	embeds: APIEmbed[];
 	/**
@@ -611,7 +611,7 @@ export interface APIMessage {
 	 *
 	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**
 	 *
-	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
+	 * See https://support-dev.discord.com/hc/articles/4404772028055
 	 */
 	components?: APIActionRowComponent<APIMessageActionRowComponent>[];
 	/**

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -348,7 +348,7 @@ export enum ChannelType {
 	/**
 	 * An organizational category that contains up to 50 channels
 	 *
-	 * See https://support.discord.com/hc/articles/115001580171-Channel-Categories-101
+	 * See https://support.discord.com/hc/articles/115001580171
 	 */
 	GuildCategory,
 	/**
@@ -378,7 +378,7 @@ export enum ChannelType {
 	/**
 	 * The channel in a Student Hub containing the listed servers
 	 *
-	 * See https://support.discord.com/hc/articles/4406046651927-Discord-Student-Hubs-FAQ
+	 * See https://support.discord.com/hc/articles/4406046651927
 	 */
 	GuildDirectory,
 	/**

--- a/deno/payloads/v9/guild.ts
+++ b/deno/payloads/v9/guild.ts
@@ -419,7 +419,7 @@ export enum GuildFeature {
 	/**
 	 * Guild is a Student Hub
 	 *
-	 * See https://support.discord.com/hc/articles/4406046651927-Discord-Student-Hubs-FAQ
+	 * See https://support.discord.com/hc/articles/4406046651927
 	 *
 	 * @unstable This feature is currently not documented by Discord, but has known value
 	 */
@@ -435,7 +435,7 @@ export enum GuildFeature {
 	/**
 	 * Guild is in a Student Hub
 	 *
-	 * See https://support.discord.com/hc/articles/4406046651927-Discord-Student-Hubs-FAQ
+	 * See https://support.discord.com/hc/articles/4406046651927
 	 *
 	 * @unstable This feature is currently not documented by Discord, but has known value
 	 */
@@ -602,7 +602,7 @@ export interface APIGuildMember {
 	/**
 	 * When the user started boosting the guild
 	 *
-	 * See https://support.discord.com/hc/articles/360028038352-Server-Boosting-
+	 * See https://support.discord.com/hc/articles/360028038352
 	 */
 	premium_since?: string | null;
 	/**

--- a/deno/payloads/v9/guild.ts
+++ b/deno/payloads/v9/guild.ts
@@ -419,7 +419,7 @@ export enum GuildFeature {
 	/**
 	 * Guild is a Student Hub
 	 *
-	 * See https://support.discord.com/hc/en-us/articles/4406046651927-Discord-Student-Hubs-FAQ
+	 * See https://support.discord.com/hc/articles/4406046651927-Discord-Student-Hubs-FAQ
 	 *
 	 * @unstable This feature is currently not documented by Discord, but has known value
 	 */
@@ -435,7 +435,7 @@ export enum GuildFeature {
 	/**
 	 * Guild is in a Student Hub
 	 *
-	 * See https://support.discord.com/hc/en-us/articles/4406046651927-Discord-Student-Hubs-FAQ
+	 * See https://support.discord.com/hc/articles/4406046651927-Discord-Student-Hubs-FAQ
 	 *
 	 * @unstable This feature is currently not documented by Discord, but has known value
 	 */
@@ -602,7 +602,7 @@ export interface APIGuildMember {
 	/**
 	 * When the user started boosting the guild
 	 *
-	 * See https://support.discord.com/hc/en-us/articles/360028038352-Server-Boosting-
+	 * See https://support.discord.com/hc/articles/360028038352-Server-Boosting-
 	 */
 	premium_since?: string | null;
 	/**

--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -348,13 +348,13 @@ export enum ChannelType {
 	/**
 	 * An organizational category that contains up to 50 channels
 	 *
-	 * See https://support.discord.com/hc/en-us/articles/115001580171-Channel-Categories-101
+	 * See https://support.discord.com/hc/articles/115001580171-Channel-Categories-101
 	 */
 	GuildCategory,
 	/**
 	 * A channel that users can follow and crosspost into their own guild
 	 *
-	 * See https://support.discord.com/hc/en-us/articles/360032008192
+	 * See https://support.discord.com/hc/articles/360032008192
 	 */
 	GuildAnnouncement,
 	/**
@@ -372,13 +372,13 @@ export enum ChannelType {
 	/**
 	 * A voice channel for hosting events with an audience
 	 *
-	 * See https://support.discord.com/hc/en-us/articles/1500005513722
+	 * See https://support.discord.com/hc/articles/1500005513722
 	 */
 	GuildStageVoice,
 	/**
 	 * The channel in a Student Hub containing the listed servers
 	 *
-	 * See https://support.discord.com/hc/en-us/articles/4406046651927-Discord-Student-Hubs-FAQ
+	 * See https://support.discord.com/hc/articles/4406046651927-Discord-Student-Hubs-FAQ
 	 */
 	GuildDirectory,
 	/**
@@ -393,7 +393,7 @@ export enum ChannelType {
 	 *
 	 * @deprecated This is the old name for {@apilink ChannelType#GuildAnnouncement}
 	 *
-	 * See https://support.discord.com/hc/en-us/articles/360032008192
+	 * See https://support.discord.com/hc/articles/360032008192
 	 */
 	GuildNews = 5,
 	/**
@@ -456,7 +456,7 @@ export interface APIMessage {
 	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**.
 	 * You also need to specify the intent bit value (`1 << 15`) if you are connecting to the gateway
 	 *
-	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
+	 * See https://support-dev.discord.com/hc/articles/4404772028055
 	 */
 	content: string;
 	/**
@@ -513,7 +513,7 @@ export interface APIMessage {
 	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**.
 	 * You also need to specify the intent bit value (`1 << 15`) if you are connecting to the gateway
 	 *
-	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
+	 * See https://support-dev.discord.com/hc/articles/4404772028055
 	 */
 	attachments: APIAttachment[];
 	/**
@@ -526,7 +526,7 @@ export interface APIMessage {
 	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**.
 	 * You also need to specify the intent bit value (`1 << 15`) if you are connecting to the gateway
 	 *
-	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
+	 * See https://support-dev.discord.com/hc/articles/4404772028055
 	 */
 	embeds: APIEmbed[];
 	/**
@@ -616,7 +616,7 @@ export interface APIMessage {
 	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**.
 	 * You also need to specify the intent bit value (`1 << 15`) if you are connecting to the gateway
 	 *
-	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
+	 * See https://support-dev.discord.com/hc/articles/4404772028055
 	 */
 	components?: APIActionRowComponent<APIMessageActionRowComponent>[];
 	/**

--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -348,7 +348,7 @@ export enum ChannelType {
 	/**
 	 * An organizational category that contains up to 50 channels
 	 *
-	 * See https://support.discord.com/hc/articles/115001580171-Channel-Categories-101
+	 * See https://support.discord.com/hc/articles/115001580171
 	 */
 	GuildCategory,
 	/**
@@ -378,7 +378,7 @@ export enum ChannelType {
 	/**
 	 * The channel in a Student Hub containing the listed servers
 	 *
-	 * See https://support.discord.com/hc/articles/4406046651927-Discord-Student-Hubs-FAQ
+	 * See https://support.discord.com/hc/articles/4406046651927
 	 */
 	GuildDirectory,
 	/**

--- a/payloads/v10/guild.ts
+++ b/payloads/v10/guild.ts
@@ -419,7 +419,7 @@ export enum GuildFeature {
 	/**
 	 * Guild is a Student Hub
 	 *
-	 * See https://support.discord.com/hc/articles/4406046651927-Discord-Student-Hubs-FAQ
+	 * See https://support.discord.com/hc/articles/4406046651927
 	 *
 	 * @unstable This feature is currently not documented by Discord, but has known value
 	 */
@@ -435,7 +435,7 @@ export enum GuildFeature {
 	/**
 	 * Guild is in a Student Hub
 	 *
-	 * See https://support.discord.com/hc/articles/4406046651927-Discord-Student-Hubs-FAQ
+	 * See https://support.discord.com/hc/articles/4406046651927
 	 *
 	 * @unstable This feature is currently not documented by Discord, but has known value
 	 */
@@ -602,7 +602,7 @@ export interface APIGuildMember {
 	/**
 	 * When the user started boosting the guild
 	 *
-	 * See https://support.discord.com/hc/articles/360028038352-Server-Boosting-
+	 * See https://support.discord.com/hc/articles/360028038352
 	 */
 	premium_since?: string | null;
 	/**

--- a/payloads/v10/guild.ts
+++ b/payloads/v10/guild.ts
@@ -419,7 +419,7 @@ export enum GuildFeature {
 	/**
 	 * Guild is a Student Hub
 	 *
-	 * See https://support.discord.com/hc/en-us/articles/4406046651927-Discord-Student-Hubs-FAQ
+	 * See https://support.discord.com/hc/articles/4406046651927-Discord-Student-Hubs-FAQ
 	 *
 	 * @unstable This feature is currently not documented by Discord, but has known value
 	 */
@@ -435,7 +435,7 @@ export enum GuildFeature {
 	/**
 	 * Guild is in a Student Hub
 	 *
-	 * See https://support.discord.com/hc/en-us/articles/4406046651927-Discord-Student-Hubs-FAQ
+	 * See https://support.discord.com/hc/articles/4406046651927-Discord-Student-Hubs-FAQ
 	 *
 	 * @unstable This feature is currently not documented by Discord, but has known value
 	 */
@@ -602,7 +602,7 @@ export interface APIGuildMember {
 	/**
 	 * When the user started boosting the guild
 	 *
-	 * See https://support.discord.com/hc/en-us/articles/360028038352-Server-Boosting-
+	 * See https://support.discord.com/hc/articles/360028038352-Server-Boosting-
 	 */
 	premium_since?: string | null;
 	/**

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -348,13 +348,13 @@ export enum ChannelType {
 	/**
 	 * An organizational category that contains up to 50 channels
 	 *
-	 * See https://support.discord.com/hc/en-us/articles/115001580171-Channel-Categories-101
+	 * See https://support.discord.com/hc/articles/115001580171-Channel-Categories-101
 	 */
 	GuildCategory,
 	/**
 	 * A channel that users can follow and crosspost into their own guild
 	 *
-	 * See https://support.discord.com/hc/en-us/articles/360032008192
+	 * See https://support.discord.com/hc/articles/360032008192
 	 */
 	GuildAnnouncement,
 	/**
@@ -372,13 +372,13 @@ export enum ChannelType {
 	/**
 	 * A voice channel for hosting events with an audience
 	 *
-	 * See https://support.discord.com/hc/en-us/articles/1500005513722
+	 * See https://support.discord.com/hc/articles/1500005513722
 	 */
 	GuildStageVoice,
 	/**
 	 * The channel in a Student Hub containing the listed servers
 	 *
-	 * See https://support.discord.com/hc/en-us/articles/4406046651927-Discord-Student-Hubs-FAQ
+	 * See https://support.discord.com/hc/articles/4406046651927-Discord-Student-Hubs-FAQ
 	 */
 	GuildDirectory,
 	/**
@@ -392,7 +392,7 @@ export enum ChannelType {
 	 *
 	 * @deprecated This is the old name for {@apilink ChannelType#GuildAnnouncement}
 	 *
-	 * See https://support.discord.com/hc/en-us/articles/360032008192
+	 * See https://support.discord.com/hc/articles/360032008192
 	 */
 	GuildNews = 5,
 	/**
@@ -454,7 +454,7 @@ export interface APIMessage {
 	 *
 	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**
 	 *
-	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
+	 * See https://support-dev.discord.com/hc/articles/4404772028055
 	 */
 	content: string;
 	/**
@@ -510,7 +510,7 @@ export interface APIMessage {
 	 *
 	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**
 	 *
-	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
+	 * See https://support-dev.discord.com/hc/articles/4404772028055
 	 */
 	attachments: APIAttachment[];
 	/**
@@ -522,7 +522,7 @@ export interface APIMessage {
 	 *
 	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**
 	 *
-	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
+	 * See https://support-dev.discord.com/hc/articles/4404772028055
 	 */
 	embeds: APIEmbed[];
 	/**
@@ -611,7 +611,7 @@ export interface APIMessage {
 	 *
 	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot > Privileged Gateway Intents**
 	 *
-	 * See https://support-dev.discord.com/hc/en-us/articles/4404772028055
+	 * See https://support-dev.discord.com/hc/articles/4404772028055
 	 */
 	components?: APIActionRowComponent<APIMessageActionRowComponent>[];
 	/**

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -348,7 +348,7 @@ export enum ChannelType {
 	/**
 	 * An organizational category that contains up to 50 channels
 	 *
-	 * See https://support.discord.com/hc/articles/115001580171-Channel-Categories-101
+	 * See https://support.discord.com/hc/articles/115001580171
 	 */
 	GuildCategory,
 	/**
@@ -378,7 +378,7 @@ export enum ChannelType {
 	/**
 	 * The channel in a Student Hub containing the listed servers
 	 *
-	 * See https://support.discord.com/hc/articles/4406046651927-Discord-Student-Hubs-FAQ
+	 * See https://support.discord.com/hc/articles/4406046651927
 	 */
 	GuildDirectory,
 	/**

--- a/payloads/v9/guild.ts
+++ b/payloads/v9/guild.ts
@@ -419,7 +419,7 @@ export enum GuildFeature {
 	/**
 	 * Guild is a Student Hub
 	 *
-	 * See https://support.discord.com/hc/articles/4406046651927-Discord-Student-Hubs-FAQ
+	 * See https://support.discord.com/hc/articles/4406046651927
 	 *
 	 * @unstable This feature is currently not documented by Discord, but has known value
 	 */
@@ -435,7 +435,7 @@ export enum GuildFeature {
 	/**
 	 * Guild is in a Student Hub
 	 *
-	 * See https://support.discord.com/hc/articles/4406046651927-Discord-Student-Hubs-FAQ
+	 * See https://support.discord.com/hc/articles/4406046651927
 	 *
 	 * @unstable This feature is currently not documented by Discord, but has known value
 	 */
@@ -602,7 +602,7 @@ export interface APIGuildMember {
 	/**
 	 * When the user started boosting the guild
 	 *
-	 * See https://support.discord.com/hc/articles/360028038352-Server-Boosting-
+	 * See https://support.discord.com/hc/articles/360028038352
 	 */
 	premium_since?: string | null;
 	/**

--- a/payloads/v9/guild.ts
+++ b/payloads/v9/guild.ts
@@ -419,7 +419,7 @@ export enum GuildFeature {
 	/**
 	 * Guild is a Student Hub
 	 *
-	 * See https://support.discord.com/hc/en-us/articles/4406046651927-Discord-Student-Hubs-FAQ
+	 * See https://support.discord.com/hc/articles/4406046651927-Discord-Student-Hubs-FAQ
 	 *
 	 * @unstable This feature is currently not documented by Discord, but has known value
 	 */
@@ -435,7 +435,7 @@ export enum GuildFeature {
 	/**
 	 * Guild is in a Student Hub
 	 *
-	 * See https://support.discord.com/hc/en-us/articles/4406046651927-Discord-Student-Hubs-FAQ
+	 * See https://support.discord.com/hc/articles/4406046651927-Discord-Student-Hubs-FAQ
 	 *
 	 * @unstable This feature is currently not documented by Discord, but has known value
 	 */
@@ -602,7 +602,7 @@ export interface APIGuildMember {
 	/**
 	 * When the user started boosting the guild
 	 *
-	 * See https://support.discord.com/hc/en-us/articles/360028038352-Server-Boosting-
+	 * See https://support.discord.com/hc/articles/360028038352-Server-Boosting-
 	 */
 	premium_since?: string | null;
 	/**


### PR DESCRIPTION
This PR removes locales in links to help center articles (see [this comment](https://github.com/discordjs/discord-api-types/pull/653#discussion_r1031000020)) to prevent overriding a user's current locale. It additionally removes the title portion of urls (if present), leaving the ID.