### PR TITLE
docs: update description for StickerType.Guild

### DIFF
--- a/deno/payloads/v10/sticker.ts
+++ b/deno/payloads/v10/sticker.ts
@@ -73,7 +73,7 @@ export enum StickerType {
 	 */
 	Standard = 1,
 	/**
-	 * A sticker uploaded to a Boosted guild for the guild's members
+	 * A sticker uploaded to a guild
 	 */
 	Guild,
 }

--- a/deno/payloads/v10/sticker.ts
+++ b/deno/payloads/v10/sticker.ts
@@ -73,7 +73,7 @@ export enum StickerType {
 	 */
 	Standard = 1,
 	/**
-	 * A sticker uploaded to a guild
+	 * A sticker uploaded to a guild for the guild's members
 	 */
 	Guild,
 }

--- a/deno/payloads/v9/sticker.ts
+++ b/deno/payloads/v9/sticker.ts
@@ -73,7 +73,7 @@ export enum StickerType {
 	 */
 	Standard = 1,
 	/**
-	 * A sticker uploaded to a Boosted guild for the guild's members
+	 * A sticker uploaded to a guild
 	 */
 	Guild,
 }

--- a/deno/payloads/v9/sticker.ts
+++ b/deno/payloads/v9/sticker.ts
@@ -73,7 +73,7 @@ export enum StickerType {
 	 */
 	Standard = 1,
 	/**
-	 * A sticker uploaded to a guild
+	 * A sticker uploaded to a guild for the guild's members
 	 */
 	Guild,
 }

--- a/payloads/v10/sticker.ts
+++ b/payloads/v10/sticker.ts
@@ -73,7 +73,7 @@ export enum StickerType {
 	 */
 	Standard = 1,
 	/**
-	 * A sticker uploaded to a Boosted guild for the guild's members
+	 * A sticker uploaded to a guild
 	 */
 	Guild,
 }

--- a/payloads/v10/sticker.ts
+++ b/payloads/v10/sticker.ts
@@ -73,7 +73,7 @@ export enum StickerType {
 	 */
 	Standard = 1,
 	/**
-	 * A sticker uploaded to a guild
+	 * A sticker uploaded to a guild for the guild's members
 	 */
 	Guild,
 }

--- a/payloads/v9/sticker.ts
+++ b/payloads/v9/sticker.ts
@@ -73,7 +73,7 @@ export enum StickerType {
 	 */
 	Standard = 1,
 	/**
-	 * A sticker uploaded to a Boosted guild for the guild's members
+	 * A sticker uploaded to a guild
 	 */
 	Guild,
 }

--- a/payloads/v9/sticker.ts
+++ b/payloads/v9/sticker.ts
@@ -73,7 +73,7 @@ export enum StickerType {
 	 */
 	Standard = 1,
 	/**
-	 * A sticker uploaded to a guild
+	 * A sticker uploaded to a guild for the guild's members
 	 */
 	Guild,
 }


### PR DESCRIPTION
This PR changes the description of the `Guild` `StickerType` to reflect the change that all guilds now have access to uploading stickers, not just boosted servers.

[See related documentation PR](https://github.com/discord/discord-api-docs/pull/5048)