### PR TITLE
fix(APIChannel): correctly type `name` based on channel type

### DIFF
--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -73,7 +73,7 @@ export interface APIGuildChannel<T extends ChannelType> extends Omit<APIChannelB
 	/**
 	 * The name of the channel (1-100 characters)
 	 */
-	name?: string;
+	name: string;
 	/**
 	 * The id of the guild (may be missing for some channel objects received over gateway guild dispatches)
 	 */
@@ -169,10 +169,14 @@ export interface APIDMChannel extends Omit<APIDMChannelBase<ChannelType.DM>, 'na
 	/**
 	 * The name of the channel (always null for DM channels)
 	 */
-	name?: null;
+	name: null;
 }
 
-export interface APIGroupDMChannel extends APIDMChannelBase<ChannelType.GroupDM> {
+export interface APIGroupDMChannel extends Omit<APIDMChannelBase<ChannelType.GroupDM>, 'name'> {
+	/**
+	 * The name of the channel (1-100 characters)
+	 */
+	name: string | null;
 	/**
 	 * Application id of the group DM creator if it is bot-created
 	 */

--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -25,9 +25,9 @@ export interface APIPartialChannel {
 	 */
 	type: ChannelType;
 	/**
-	 * The name of the channel (2-100 characters)
+	 * The name of the channel (1-100 characters)
 	 */
-	name?: string;
+	name?: string | null;
 }
 
 /**
@@ -69,7 +69,11 @@ export interface APITextBasedChannel<T extends ChannelType> extends APIChannelBa
 	rate_limit_per_user?: number;
 }
 
-export interface APIGuildChannel<T extends ChannelType> extends APIChannelBase<T> {
+export interface APIGuildChannel<T extends ChannelType> extends Omit<APIChannelBase<T>, 'name'> {
+	/**
+	 * The name of the channel (1-100 characters)
+	 */
+	name?: string;
 	/**
 	 * The id of the guild (may be missing for some channel objects received over gateway guild dispatches)
 	 */
@@ -101,7 +105,7 @@ export interface APIGuildChannel<T extends ChannelType> extends APIChannelBase<T
 export type GuildTextChannelType = Exclude<TextChannelType, ChannelType.DM | ChannelType.GroupDM>;
 
 export interface APIGuildTextChannel<T extends GuildTextChannelType>
-	extends APITextBasedChannel<T>,
+	extends Omit<APITextBasedChannel<T>, 'name'>,
 		APIGuildChannel<T> {
 	/**
 	 * Default duration for newly created threads, in minutes, to automatically archive the thread after recent activity
@@ -141,7 +145,7 @@ export interface APIVoiceChannelBase<T extends ChannelType> extends APIGuildChan
 
 export interface APIGuildVoiceChannel
 	extends APIVoiceChannelBase<ChannelType.GuildVoice>,
-		APITextBasedChannel<ChannelType.GuildVoice> {
+		Omit<APITextBasedChannel<ChannelType.GuildVoice>, 'name'> {
 	/**
 	 * The camera video quality mode of the voice channel, `1` when not present
 	 *
@@ -161,9 +165,14 @@ export interface APIDMChannelBase<T extends ChannelType> extends Omit<APITextBas
 	recipients?: APIUser[];
 }
 
-export type APIDMChannel = APIDMChannelBase<ChannelType.DM>;
+export interface APIDMChannel extends Omit<APIDMChannelBase<ChannelType.DM>, 'name'> {
+	/**
+	 * The name of the channel (always null for DM channels)
+	 */
+	name?: null;
+}
 
-export interface APIGroupDMChannel extends Omit<APIDMChannelBase<ChannelType.GroupDM>, 'name'> {
+export interface APIGroupDMChannel extends APIDMChannelBase<ChannelType.GroupDM> {
 	/**
 	 * Application id of the group DM creator if it is bot-created
 	 */
@@ -172,10 +181,6 @@ export interface APIGroupDMChannel extends Omit<APIDMChannelBase<ChannelType.Gro
 	 * Icon hash
 	 */
 	icon?: string | null;
-	/**
-	 * The name of the channel (2-100 characters)
-	 */
-	name?: string | null;
 	/**
 	 * ID of the DM creator
 	 */

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -73,7 +73,7 @@ export interface APIGuildChannel<T extends ChannelType> extends Omit<APIChannelB
 	/**
 	 * The name of the channel (1-100 characters)
 	 */
-	name?: string;
+	name: string;
 	/**
 	 * The id of the guild (may be missing for some channel objects received over gateway guild dispatches)
 	 */
@@ -169,10 +169,14 @@ export interface APIDMChannel extends Omit<APIDMChannelBase<ChannelType.DM>, 'na
 	/**
 	 * The name of the channel (always null for DM channels)
 	 */
-	name?: null;
+	name: null;
 }
 
-export interface APIGroupDMChannel extends APIDMChannelBase<ChannelType.GroupDM> {
+export interface APIGroupDMChannel extends Omit<APIDMChannelBase<ChannelType.GroupDM>, 'name'> {
+	/**
+	 * The name of the channel (1-100 characters)
+	 */
+	name: string | null;
 	/**
 	 * Application id of the group DM creator if it is bot-created
 	 */

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -25,9 +25,9 @@ export interface APIPartialChannel {
 	 */
 	type: ChannelType;
 	/**
-	 * The name of the channel (2-100 characters)
+	 * The name of the channel (1-100 characters)
 	 */
-	name?: string;
+	name?: string | null;
 }
 
 /**
@@ -69,7 +69,11 @@ export interface APITextBasedChannel<T extends ChannelType> extends APIChannelBa
 	rate_limit_per_user?: number;
 }
 
-export interface APIGuildChannel<T extends ChannelType> extends APIChannelBase<T> {
+export interface APIGuildChannel<T extends ChannelType> extends Omit<APIChannelBase<T>, 'name'> {
+	/**
+	 * The name of the channel (1-100 characters)
+	 */
+	name?: string;
 	/**
 	 * The id of the guild (may be missing for some channel objects received over gateway guild dispatches)
 	 */
@@ -101,7 +105,7 @@ export interface APIGuildChannel<T extends ChannelType> extends APIChannelBase<T
 export type GuildTextChannelType = Exclude<TextChannelType, ChannelType.DM | ChannelType.GroupDM>;
 
 export interface APIGuildTextChannel<T extends GuildTextChannelType>
-	extends APITextBasedChannel<T>,
+	extends Omit<APITextBasedChannel<T>, 'name'>,
 		APIGuildChannel<T> {
 	/**
 	 * Default duration for newly created threads, in minutes, to automatically archive the thread after recent activity
@@ -141,7 +145,7 @@ export interface APIVoiceChannelBase<T extends ChannelType> extends APIGuildChan
 
 export interface APIGuildVoiceChannel
 	extends APIVoiceChannelBase<ChannelType.GuildVoice>,
-		APITextBasedChannel<ChannelType.GuildVoice> {
+		Omit<APITextBasedChannel<ChannelType.GuildVoice>, 'name'> {
 	/**
 	 * The camera video quality mode of the voice channel, `1` when not present
 	 *
@@ -161,9 +165,14 @@ export interface APIDMChannelBase<T extends ChannelType> extends Omit<APITextBas
 	recipients?: APIUser[];
 }
 
-export type APIDMChannel = APIDMChannelBase<ChannelType.DM>;
+export interface APIDMChannel extends Omit<APIDMChannelBase<ChannelType.DM>, 'name'> {
+	/**
+	 * The name of the channel (always null for DM channels)
+	 */
+	name?: null;
+}
 
-export interface APIGroupDMChannel extends Omit<APIDMChannelBase<ChannelType.GroupDM>, 'name'> {
+export interface APIGroupDMChannel extends APIDMChannelBase<ChannelType.GroupDM> {
 	/**
 	 * Application id of the group DM creator if it is bot-created
 	 */
@@ -172,10 +181,6 @@ export interface APIGroupDMChannel extends Omit<APIDMChannelBase<ChannelType.Gro
 	 * Icon hash
 	 */
 	icon?: string | null;
-	/**
-	 * The name of the channel (2-100 characters)
-	 */
-	name?: string | null;
 	/**
 	 * ID of the DM creator
 	 */

--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -73,7 +73,7 @@ export interface APIGuildChannel<T extends ChannelType> extends Omit<APIChannelB
 	/**
 	 * The name of the channel (1-100 characters)
 	 */
-	name?: string;
+	name: string;
 	/**
 	 * The id of the guild (may be missing for some channel objects received over gateway guild dispatches)
 	 */
@@ -169,10 +169,14 @@ export interface APIDMChannel extends Omit<APIDMChannelBase<ChannelType.DM>, 'na
 	/**
 	 * The name of the channel (always null for DM channels)
 	 */
-	name?: null;
+	name: null;
 }
 
-export interface APIGroupDMChannel extends APIDMChannelBase<ChannelType.GroupDM> {
+export interface APIGroupDMChannel extends Omit<APIDMChannelBase<ChannelType.GroupDM>, 'name'> {
+	/**
+	 * The name of the channel (1-100 characters)
+	 */
+	name: string | null;
 	/**
 	 * Application id of the group DM creator if it is bot-created
 	 */

--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -25,9 +25,9 @@ export interface APIPartialChannel {
 	 */
 	type: ChannelType;
 	/**
-	 * The name of the channel (2-100 characters)
+	 * The name of the channel (1-100 characters)
 	 */
-	name?: string;
+	name?: string | null;
 }
 
 /**
@@ -69,7 +69,11 @@ export interface APITextBasedChannel<T extends ChannelType> extends APIChannelBa
 	rate_limit_per_user?: number;
 }
 
-export interface APIGuildChannel<T extends ChannelType> extends APIChannelBase<T> {
+export interface APIGuildChannel<T extends ChannelType> extends Omit<APIChannelBase<T>, 'name'> {
+	/**
+	 * The name of the channel (1-100 characters)
+	 */
+	name?: string;
 	/**
 	 * The id of the guild (may be missing for some channel objects received over gateway guild dispatches)
 	 */
@@ -101,7 +105,7 @@ export interface APIGuildChannel<T extends ChannelType> extends APIChannelBase<T
 export type GuildTextChannelType = Exclude<TextChannelType, ChannelType.DM | ChannelType.GroupDM>;
 
 export interface APIGuildTextChannel<T extends GuildTextChannelType>
-	extends APITextBasedChannel<T>,
+	extends Omit<APITextBasedChannel<T>, 'name'>,
 		APIGuildChannel<T> {
 	/**
 	 * Default duration for newly created threads, in minutes, to automatically archive the thread after recent activity
@@ -141,7 +145,7 @@ export interface APIVoiceChannelBase<T extends ChannelType> extends APIGuildChan
 
 export interface APIGuildVoiceChannel
 	extends APIVoiceChannelBase<ChannelType.GuildVoice>,
-		APITextBasedChannel<ChannelType.GuildVoice> {
+		Omit<APITextBasedChannel<ChannelType.GuildVoice>, 'name'> {
 	/**
 	 * The camera video quality mode of the voice channel, `1` when not present
 	 *
@@ -161,9 +165,14 @@ export interface APIDMChannelBase<T extends ChannelType> extends Omit<APITextBas
 	recipients?: APIUser[];
 }
 
-export type APIDMChannel = APIDMChannelBase<ChannelType.DM>;
+export interface APIDMChannel extends Omit<APIDMChannelBase<ChannelType.DM>, 'name'> {
+	/**
+	 * The name of the channel (always null for DM channels)
+	 */
+	name?: null;
+}
 
-export interface APIGroupDMChannel extends Omit<APIDMChannelBase<ChannelType.GroupDM>, 'name'> {
+export interface APIGroupDMChannel extends APIDMChannelBase<ChannelType.GroupDM> {
 	/**
 	 * Application id of the group DM creator if it is bot-created
 	 */
@@ -172,10 +181,6 @@ export interface APIGroupDMChannel extends Omit<APIDMChannelBase<ChannelType.Gro
 	 * Icon hash
 	 */
 	icon?: string | null;
-	/**
-	 * The name of the channel (2-100 characters)
-	 */
-	name?: string | null;
 	/**
 	 * ID of the DM creator
 	 */

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -73,7 +73,7 @@ export interface APIGuildChannel<T extends ChannelType> extends Omit<APIChannelB
 	/**
 	 * The name of the channel (1-100 characters)
 	 */
-	name?: string;
+	name: string;
 	/**
 	 * The id of the guild (may be missing for some channel objects received over gateway guild dispatches)
 	 */
@@ -169,10 +169,14 @@ export interface APIDMChannel extends Omit<APIDMChannelBase<ChannelType.DM>, 'na
 	/**
 	 * The name of the channel (always null for DM channels)
 	 */
-	name?: null;
+	name: null;
 }
 
-export interface APIGroupDMChannel extends APIDMChannelBase<ChannelType.GroupDM> {
+export interface APIGroupDMChannel extends Omit<APIDMChannelBase<ChannelType.GroupDM>, 'name'> {
+	/**
+	 * The name of the channel (1-100 characters)
+	 */
+	name: string | null;
 	/**
 	 * Application id of the group DM creator if it is bot-created
 	 */

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -25,9 +25,9 @@ export interface APIPartialChannel {
 	 */
 	type: ChannelType;
 	/**
-	 * The name of the channel (2-100 characters)
+	 * The name of the channel (1-100 characters)
 	 */
-	name?: string;
+	name?: string | null;
 }
 
 /**
@@ -69,7 +69,11 @@ export interface APITextBasedChannel<T extends ChannelType> extends APIChannelBa
 	rate_limit_per_user?: number;
 }
 
-export interface APIGuildChannel<T extends ChannelType> extends APIChannelBase<T> {
+export interface APIGuildChannel<T extends ChannelType> extends Omit<APIChannelBase<T>, 'name'> {
+	/**
+	 * The name of the channel (1-100 characters)
+	 */
+	name?: string;
 	/**
 	 * The id of the guild (may be missing for some channel objects received over gateway guild dispatches)
 	 */
@@ -101,7 +105,7 @@ export interface APIGuildChannel<T extends ChannelType> extends APIChannelBase<T
 export type GuildTextChannelType = Exclude<TextChannelType, ChannelType.DM | ChannelType.GroupDM>;
 
 export interface APIGuildTextChannel<T extends GuildTextChannelType>
-	extends APITextBasedChannel<T>,
+	extends Omit<APITextBasedChannel<T>, 'name'>,
 		APIGuildChannel<T> {
 	/**
 	 * Default duration for newly created threads, in minutes, to automatically archive the thread after recent activity
@@ -141,7 +145,7 @@ export interface APIVoiceChannelBase<T extends ChannelType> extends APIGuildChan
 
 export interface APIGuildVoiceChannel
 	extends APIVoiceChannelBase<ChannelType.GuildVoice>,
-		APITextBasedChannel<ChannelType.GuildVoice> {
+		Omit<APITextBasedChannel<ChannelType.GuildVoice>, 'name'> {
 	/**
 	 * The camera video quality mode of the voice channel, `1` when not present
 	 *
@@ -161,9 +165,14 @@ export interface APIDMChannelBase<T extends ChannelType> extends Omit<APITextBas
 	recipients?: APIUser[];
 }
 
-export type APIDMChannel = APIDMChannelBase<ChannelType.DM>;
+export interface APIDMChannel extends Omit<APIDMChannelBase<ChannelType.DM>, 'name'> {
+	/**
+	 * The name of the channel (always null for DM channels)
+	 */
+	name?: null;
+}
 
-export interface APIGroupDMChannel extends Omit<APIDMChannelBase<ChannelType.GroupDM>, 'name'> {
+export interface APIGroupDMChannel extends APIDMChannelBase<ChannelType.GroupDM> {
 	/**
 	 * Application id of the group DM creator if it is bot-created
 	 */
@@ -172,10 +181,6 @@ export interface APIGroupDMChannel extends Omit<APIDMChannelBase<ChannelType.Gro
 	 * Icon hash
 	 */
 	icon?: string | null;
-	/**
-	 * The name of the channel (2-100 characters)
-	 */
-	name?: string | null;
 	/**
 	 * ID of the DM creator
 	 */

--- a/tests/v10/channel.test-d.ts
+++ b/tests/v10/channel.test-d.ts
@@ -1,0 +1,11 @@
+import { expectType } from 'tsd';
+import type { ChannelType, APIPartialChannel, APIGroupDMChannel, APIDMChannel, APIGuildChannel } from '../../v10';
+
+const anything: unknown = null;
+
+// Test channel names are properly typed
+// Always non-null present for non-DM channels, always null for DM channel
+expectType<string | null | undefined>((anything as APIPartialChannel).name);
+expectType<string | null | undefined>((anything as APIGroupDMChannel).name);
+expectType<null | undefined>((anything as APIDMChannel).name);
+expectType<string | undefined>((anything as APIGuildChannel<ChannelType>).name);

--- a/tests/v10/channel.test-d.ts
+++ b/tests/v10/channel.test-d.ts
@@ -9,6 +9,6 @@ declare const guildChannel: APIGuildChannel<ChannelType>;
 // Test channel names are properly typed
 // Always non-null present for non-DM channels, always null for DM channel
 expectType<string | null | undefined>(partialChannel.name);
-expectType<string | null | undefined>(groupDMChannel.name);
-expectType<null | undefined>(dmChannel.name);
-expectType<string | undefined>(guildChannel.name);
+expectType<string | null>(groupDMChannel.name);
+expectType<null>(dmChannel.name);
+expectType<string>(guildChannel.name);

--- a/tests/v10/channel.test-d.ts
+++ b/tests/v10/channel.test-d.ts
@@ -1,11 +1,14 @@
 import { expectType } from 'tsd';
 import type { ChannelType, APIPartialChannel, APIGroupDMChannel, APIDMChannel, APIGuildChannel } from '../../v10';
 
-const anything: unknown = null;
+declare const partialChannel: APIPartialChannel;
+declare const groupDMChannel: APIGroupDMChannel;
+declare const dmChannel: APIDMChannel;
+declare const guildChannel: APIGuildChannel<ChannelType>;
 
 // Test channel names are properly typed
 // Always non-null present for non-DM channels, always null for DM channel
-expectType<string | null | undefined>((anything as APIPartialChannel).name);
-expectType<string | null | undefined>((anything as APIGroupDMChannel).name);
-expectType<null | undefined>((anything as APIDMChannel).name);
-expectType<string | undefined>((anything as APIGuildChannel<ChannelType>).name);
+expectType<string | null | undefined>(partialChannel.name);
+expectType<string | null | undefined>(groupDMChannel.name);
+expectType<null | undefined>(dmChannel.name);
+expectType<string | undefined>(guildChannel.name);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Types incorrectly assume PartialChannel objects will always have a name.
In some circumstances, PartialChannels may be DM channels, which do have a null name.

Also fixes the comment about minimum name length.

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
This change aligns with the already documented [Channel data structure](https://discord.com/developers/docs/resources/channel#channel-object-channel-structure)
