### PR TITLE
fix(APIChannel): correctly type present properties based on channel type

### DIFF
--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -58,6 +58,11 @@ export interface APITextBasedChannel<T extends ChannelType> extends APIChannelBa
 	 */
 	last_message_id?: Snowflake | null;
 	/**
+	 * When the last pinned message was pinned.
+	 * This may be `null` in events such as `GUILD_CREATE` when a message is not pinned
+	 */
+	last_pin_timestamp?: string | null;
+	/**
 	 * Amount of seconds a user has to wait before sending another message (0-21600);
 	 * bots, as well as users with the permission `MANAGE_MESSAGES` or `MANAGE_CHANNELS`, are unaffected
 	 *
@@ -112,14 +117,14 @@ export interface APIGuildTextChannel<T extends GuildTextChannelType>
 	 */
 	default_auto_archive_duration?: ThreadAutoArchiveDuration;
 	/**
+	 * The initial `rate_limit_per_user` to set on newly created threads.
+	 * This field is copied to the thread at creation time and does not live update
+	 */
+	default_thread_rate_limit_per_user?: number;
+	/**
 	 * The channel topic (0-4096 characters for forum channels, 0-1024 characters for all others)
 	 */
 	topic?: string | null;
-	/**
-	 * When the last pinned message was pinned.
-	 * This may be `null` in events such as `GUILD_CREATE` when a message is not pinned
-	 */
-	last_pin_timestamp?: string | null;
 }
 
 export type APITextChannel = APIGuildTextChannel<ChannelType.GuildText>;
@@ -145,7 +150,7 @@ export interface APIVoiceChannelBase<T extends ChannelType> extends APIGuildChan
 
 export interface APIGuildVoiceChannel
 	extends APIVoiceChannelBase<ChannelType.GuildVoice>,
-		Omit<APITextBasedChannel<ChannelType.GuildVoice>, 'name'> {
+		Omit<APITextBasedChannel<ChannelType.GuildVoice>, 'name' | 'last_pin_timestamp'> {
 	/**
 	 * The camera video quality mode of the voice channel, `1` when not present
 	 *
@@ -196,7 +201,7 @@ export interface APIGroupDMChannel extends Omit<APIDMChannelBase<ChannelType.Gro
 }
 
 export interface APIThreadChannel
-	extends APIGuildChannel<ChannelType.PublicThread | ChannelType.PrivateThread | ChannelType.AnnouncementThread> {
+	extends APITextBasedChannel<ChannelType.PublicThread | ChannelType.PrivateThread | ChannelType.AnnouncementThread> {
 	/**
 	 * The client users member for the thread, only included in select endpoints
 	 */
@@ -216,23 +221,9 @@ export interface APIThreadChannel
 	 */
 	member_count?: number;
 	/**
-	 * Amount of seconds a user has to wait before sending another message (0-21600);
-	 * bots, as well as users with the permission `MANAGE_MESSAGES` or `MANAGE_CHANNELS`, are unaffected
-	 *
-	 * `rate_limit_per_user` also applies to thread creation. Users can send one message and create one thread during each `rate_limit_per_user` interval.
-	 *
-	 * For thread channels, `rate_limit_per_user` is only returned if the field is set to a non-zero and non-null value.
-	 * The absence of this field in API calls and Gateway events should indicate that slowmode has been reset to the default value.
-	 */
-	rate_limit_per_user?: number;
-	/**
 	 * ID of the thread creator
 	 */
 	owner_id?: Snowflake;
-	/**
-	 * The id of the last message sent in this thread (may not point to an existing or valid message)
-	 */
-	last_message_id?: Snowflake | null;
 	/**
 	 * Number of messages ever sent in a thread
 	 *
@@ -305,11 +296,6 @@ export interface APIGuildForumChannel extends APIGuildTextChannel<ChannelType.Gu
 	 */
 	available_tags: APIGuildForumTag[];
 	/**
-	 * The initial `rate_limit_per_user` to set on newly created threads in a forum channel.
-	 * This field is copied to the thread at creation time and does not live update
-	 */
-	default_thread_rate_limit_per_user?: number;
-	/**
 	 * The emoji to show in the add reaction button on a thread in a forum channel
 	 */
 	default_reaction_emoji: APIGuildForumDefaultReactionEmoji | null;
@@ -331,7 +317,6 @@ export type APIChannel =
 	| APIGuildStageVoiceChannel
 	| APIGuildCategoryChannel
 	| APIThreadChannel
-	| APINewsChannel
 	| APIGuildForumChannel;
 
 /**

--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -201,7 +201,11 @@ export interface APIGroupDMChannel extends Omit<APIDMChannelBase<ChannelType.Gro
 }
 
 export interface APIThreadChannel
-	extends APITextBasedChannel<ChannelType.PublicThread | ChannelType.PrivateThread | ChannelType.AnnouncementThread> {
+	extends Omit<
+			APITextBasedChannel<ChannelType.PublicThread | ChannelType.PrivateThread | ChannelType.AnnouncementThread>,
+			'name'
+		>,
+		APIGuildChannel<ChannelType.PublicThread | ChannelType.PrivateThread | ChannelType.AnnouncementThread> {
 	/**
 	 * The client users member for the thread, only included in select endpoints
 	 */

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -58,6 +58,11 @@ export interface APITextBasedChannel<T extends ChannelType> extends APIChannelBa
 	 */
 	last_message_id?: Snowflake | null;
 	/**
+	 * When the last pinned message was pinned.
+	 * This may be `null` in events such as `GUILD_CREATE` when a message is not pinned
+	 */
+	last_pin_timestamp?: string | null;
+	/**
 	 * Amount of seconds a user has to wait before sending another message (0-21600);
 	 * bots, as well as users with the permission `MANAGE_MESSAGES` or `MANAGE_CHANNELS`, are unaffected
 	 *
@@ -112,14 +117,14 @@ export interface APIGuildTextChannel<T extends GuildTextChannelType>
 	 */
 	default_auto_archive_duration?: ThreadAutoArchiveDuration;
 	/**
+	 * The initial `rate_limit_per_user` to set on newly created threads.
+	 * This field is copied to the thread at creation time and does not live update
+	 */
+	default_thread_rate_limit_per_user?: number;
+	/**
 	 * The channel topic (0-1024 characters)
 	 */
 	topic?: string | null;
-	/**
-	 * When the last pinned message was pinned.
-	 * This may be `null` in events such as `GUILD_CREATE` when a message is not pinned
-	 */
-	last_pin_timestamp?: string | null;
 }
 
 export type APITextChannel = APIGuildTextChannel<ChannelType.GuildText>;
@@ -145,7 +150,7 @@ export interface APIVoiceChannelBase<T extends ChannelType> extends APIGuildChan
 
 export interface APIGuildVoiceChannel
 	extends APIVoiceChannelBase<ChannelType.GuildVoice>,
-		Omit<APITextBasedChannel<ChannelType.GuildVoice>, 'name'> {
+		Omit<APITextBasedChannel<ChannelType.GuildVoice>, 'name' | 'last_pin_timestamp'> {
 	/**
 	 * The camera video quality mode of the voice channel, `1` when not present
 	 *
@@ -189,14 +194,10 @@ export interface APIGroupDMChannel extends Omit<APIDMChannelBase<ChannelType.Gro
 	 * ID of the DM creator
 	 */
 	owner_id?: Snowflake;
-	/**
-	 * The id of the last message sent in this channel (may not point to an existing or valid message)
-	 */
-	last_message_id?: Snowflake | null;
 }
 
 export interface APIThreadChannel
-	extends APIGuildChannel<ChannelType.PublicThread | ChannelType.PrivateThread | ChannelType.AnnouncementThread> {
+	extends APITextBasedChannel<ChannelType.PublicThread | ChannelType.PrivateThread | ChannelType.AnnouncementThread> {
 	/**
 	 * The client users member for the thread, only included in select endpoints
 	 */
@@ -216,23 +217,9 @@ export interface APIThreadChannel
 	 */
 	member_count?: number;
 	/**
-	 * Amount of seconds a user has to wait before sending another message (0-21600);
-	 * bots, as well as users with the permission `MANAGE_MESSAGES` or `MANAGE_CHANNELS`, are unaffected
-	 *
-	 * `rate_limit_per_user` also applies to thread creation. Users can send one message and create one thread during each `rate_limit_per_user` interval.
-	 *
-	 * For thread channels, `rate_limit_per_user` is only returned if the field is set to a non-zero and non-null value.
-	 * The absence of this field in API calls and Gateway events should indicate that slowmode has been reset to the default value.
-	 */
-	rate_limit_per_user?: number;
-	/**
 	 * ID of the thread creator
 	 */
 	owner_id?: Snowflake;
-	/**
-	 * The id of the last message sent in this thread (may not point to an existing or valid message)
-	 */
-	last_message_id?: Snowflake | null;
 	/**
 	 * Number of messages ever sent in a thread
 	 *
@@ -305,11 +292,6 @@ export interface APIGuildForumChannel extends APIGuildTextChannel<ChannelType.Gu
 	 */
 	available_tags: APIGuildForumTag[];
 	/**
-	 * The initial `rate_limit_per_user` to set on newly created threads in a forum channel.
-	 * This field is copied to the thread at creation time and does not live update
-	 */
-	default_thread_rate_limit_per_user?: number;
-	/**
 	 * The emoji to show in the add reaction button on a thread in a forum channel
 	 */
 	default_reaction_emoji: APIGuildForumDefaultReactionEmoji | null;
@@ -331,7 +313,6 @@ export type APIChannel =
 	| APIGuildStageVoiceChannel
 	| APIGuildCategoryChannel
 	| APIThreadChannel
-	| APINewsChannel
 	| APIGuildForumChannel;
 
 /**

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -197,7 +197,11 @@ export interface APIGroupDMChannel extends Omit<APIDMChannelBase<ChannelType.Gro
 }
 
 export interface APIThreadChannel
-	extends APITextBasedChannel<ChannelType.PublicThread | ChannelType.PrivateThread | ChannelType.AnnouncementThread> {
+	extends Omit<
+			APITextBasedChannel<ChannelType.PublicThread | ChannelType.PrivateThread | ChannelType.AnnouncementThread>,
+			'name'
+		>,
+		APIGuildChannel<ChannelType.PublicThread | ChannelType.PrivateThread | ChannelType.AnnouncementThread> {
 	/**
 	 * The client users member for the thread, only included in select endpoints
 	 */

--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -58,6 +58,11 @@ export interface APITextBasedChannel<T extends ChannelType> extends APIChannelBa
 	 */
 	last_message_id?: Snowflake | null;
 	/**
+	 * When the last pinned message was pinned.
+	 * This may be `null` in events such as `GUILD_CREATE` when a message is not pinned
+	 */
+	last_pin_timestamp?: string | null;
+	/**
 	 * Amount of seconds a user has to wait before sending another message (0-21600);
 	 * bots, as well as users with the permission `MANAGE_MESSAGES` or `MANAGE_CHANNELS`, are unaffected
 	 *
@@ -112,14 +117,14 @@ export interface APIGuildTextChannel<T extends GuildTextChannelType>
 	 */
 	default_auto_archive_duration?: ThreadAutoArchiveDuration;
 	/**
+	 * The initial `rate_limit_per_user` to set on newly created threads.
+	 * This field is copied to the thread at creation time and does not live update
+	 */
+	default_thread_rate_limit_per_user?: number;
+	/**
 	 * The channel topic (0-4096 characters for forum channels, 0-1024 characters for all others)
 	 */
 	topic?: string | null;
-	/**
-	 * When the last pinned message was pinned.
-	 * This may be `null` in events such as `GUILD_CREATE` when a message is not pinned
-	 */
-	last_pin_timestamp?: string | null;
 }
 
 export type APITextChannel = APIGuildTextChannel<ChannelType.GuildText>;
@@ -145,7 +150,7 @@ export interface APIVoiceChannelBase<T extends ChannelType> extends APIGuildChan
 
 export interface APIGuildVoiceChannel
 	extends APIVoiceChannelBase<ChannelType.GuildVoice>,
-		Omit<APITextBasedChannel<ChannelType.GuildVoice>, 'name'> {
+		Omit<APITextBasedChannel<ChannelType.GuildVoice>, 'name' | 'last_pin_timestamp'> {
 	/**
 	 * The camera video quality mode of the voice channel, `1` when not present
 	 *
@@ -196,7 +201,7 @@ export interface APIGroupDMChannel extends Omit<APIDMChannelBase<ChannelType.Gro
 }
 
 export interface APIThreadChannel
-	extends APIGuildChannel<ChannelType.PublicThread | ChannelType.PrivateThread | ChannelType.AnnouncementThread> {
+	extends APITextBasedChannel<ChannelType.PublicThread | ChannelType.PrivateThread | ChannelType.AnnouncementThread> {
 	/**
 	 * The client users member for the thread, only included in select endpoints
 	 */
@@ -216,23 +221,9 @@ export interface APIThreadChannel
 	 */
 	member_count?: number;
 	/**
-	 * Amount of seconds a user has to wait before sending another message (0-21600);
-	 * bots, as well as users with the permission `MANAGE_MESSAGES` or `MANAGE_CHANNELS`, are unaffected
-	 *
-	 * `rate_limit_per_user` also applies to thread creation. Users can send one message and create one thread during each `rate_limit_per_user` interval.
-	 *
-	 * For thread channels, `rate_limit_per_user` is only returned if the field is set to a non-zero and non-null value.
-	 * The absence of this field in API calls and Gateway events should indicate that slowmode has been reset to the default value.
-	 */
-	rate_limit_per_user?: number;
-	/**
 	 * ID of the thread creator
 	 */
 	owner_id?: Snowflake;
-	/**
-	 * The id of the last message sent in this thread (may not point to an existing or valid message)
-	 */
-	last_message_id?: Snowflake | null;
 	/**
 	 * Number of messages ever sent in a thread
 	 *
@@ -305,11 +296,6 @@ export interface APIGuildForumChannel extends APIGuildTextChannel<ChannelType.Gu
 	 */
 	available_tags: APIGuildForumTag[];
 	/**
-	 * The initial `rate_limit_per_user` to set on newly created threads in a forum channel.
-	 * This field is copied to the thread at creation time and does not live update
-	 */
-	default_thread_rate_limit_per_user?: number;
-	/**
 	 * The emoji to show in the add reaction button on a thread in a forum channel
 	 */
 	default_reaction_emoji: APIGuildForumDefaultReactionEmoji | null;
@@ -331,7 +317,6 @@ export type APIChannel =
 	| APIGuildStageVoiceChannel
 	| APIGuildCategoryChannel
 	| APIThreadChannel
-	| APINewsChannel
 	| APIGuildForumChannel;
 
 /**

--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -201,7 +201,11 @@ export interface APIGroupDMChannel extends Omit<APIDMChannelBase<ChannelType.Gro
 }
 
 export interface APIThreadChannel
-	extends APITextBasedChannel<ChannelType.PublicThread | ChannelType.PrivateThread | ChannelType.AnnouncementThread> {
+	extends Omit<
+			APITextBasedChannel<ChannelType.PublicThread | ChannelType.PrivateThread | ChannelType.AnnouncementThread>,
+			'name'
+		>,
+		APIGuildChannel<ChannelType.PublicThread | ChannelType.PrivateThread | ChannelType.AnnouncementThread> {
 	/**
 	 * The client users member for the thread, only included in select endpoints
 	 */

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -58,6 +58,11 @@ export interface APITextBasedChannel<T extends ChannelType> extends APIChannelBa
 	 */
 	last_message_id?: Snowflake | null;
 	/**
+	 * When the last pinned message was pinned.
+	 * This may be `null` in events such as `GUILD_CREATE` when a message is not pinned
+	 */
+	last_pin_timestamp?: string | null;
+	/**
 	 * Amount of seconds a user has to wait before sending another message (0-21600);
 	 * bots, as well as users with the permission `MANAGE_MESSAGES` or `MANAGE_CHANNELS`, are unaffected
 	 *
@@ -112,14 +117,14 @@ export interface APIGuildTextChannel<T extends GuildTextChannelType>
 	 */
 	default_auto_archive_duration?: ThreadAutoArchiveDuration;
 	/**
+	 * The initial `rate_limit_per_user` to set on newly created threads.
+	 * This field is copied to the thread at creation time and does not live update
+	 */
+	default_thread_rate_limit_per_user?: number;
+	/**
 	 * The channel topic (0-1024 characters)
 	 */
 	topic?: string | null;
-	/**
-	 * When the last pinned message was pinned.
-	 * This may be `null` in events such as `GUILD_CREATE` when a message is not pinned
-	 */
-	last_pin_timestamp?: string | null;
 }
 
 export type APITextChannel = APIGuildTextChannel<ChannelType.GuildText>;
@@ -145,7 +150,7 @@ export interface APIVoiceChannelBase<T extends ChannelType> extends APIGuildChan
 
 export interface APIGuildVoiceChannel
 	extends APIVoiceChannelBase<ChannelType.GuildVoice>,
-		Omit<APITextBasedChannel<ChannelType.GuildVoice>, 'name'> {
+		Omit<APITextBasedChannel<ChannelType.GuildVoice>, 'name' | 'last_pin_timestamp'> {
 	/**
 	 * The camera video quality mode of the voice channel, `1` when not present
 	 *
@@ -189,14 +194,10 @@ export interface APIGroupDMChannel extends Omit<APIDMChannelBase<ChannelType.Gro
 	 * ID of the DM creator
 	 */
 	owner_id?: Snowflake;
-	/**
-	 * The id of the last message sent in this channel (may not point to an existing or valid message)
-	 */
-	last_message_id?: Snowflake | null;
 }
 
 export interface APIThreadChannel
-	extends APIGuildChannel<ChannelType.PublicThread | ChannelType.PrivateThread | ChannelType.AnnouncementThread> {
+	extends APITextBasedChannel<ChannelType.PublicThread | ChannelType.PrivateThread | ChannelType.AnnouncementThread> {
 	/**
 	 * The client users member for the thread, only included in select endpoints
 	 */
@@ -216,23 +217,9 @@ export interface APIThreadChannel
 	 */
 	member_count?: number;
 	/**
-	 * Amount of seconds a user has to wait before sending another message (0-21600);
-	 * bots, as well as users with the permission `MANAGE_MESSAGES` or `MANAGE_CHANNELS`, are unaffected
-	 *
-	 * `rate_limit_per_user` also applies to thread creation. Users can send one message and create one thread during each `rate_limit_per_user` interval.
-	 *
-	 * For thread channels, `rate_limit_per_user` is only returned if the field is set to a non-zero and non-null value.
-	 * The absence of this field in API calls and Gateway events should indicate that slowmode has been reset to the default value.
-	 */
-	rate_limit_per_user?: number;
-	/**
 	 * ID of the thread creator
 	 */
 	owner_id?: Snowflake;
-	/**
-	 * The id of the last message sent in this thread (may not point to an existing or valid message)
-	 */
-	last_message_id?: Snowflake | null;
 	/**
 	 * Number of messages ever sent in a thread
 	 *
@@ -305,11 +292,6 @@ export interface APIGuildForumChannel extends APIGuildTextChannel<ChannelType.Gu
 	 */
 	available_tags: APIGuildForumTag[];
 	/**
-	 * The initial `rate_limit_per_user` to set on newly created threads in a forum channel.
-	 * This field is copied to the thread at creation time and does not live update
-	 */
-	default_thread_rate_limit_per_user?: number;
-	/**
 	 * The emoji to show in the add reaction button on a thread in a forum channel
 	 */
 	default_reaction_emoji: APIGuildForumDefaultReactionEmoji | null;
@@ -331,7 +313,6 @@ export type APIChannel =
 	| APIGuildStageVoiceChannel
 	| APIGuildCategoryChannel
 	| APIThreadChannel
-	| APINewsChannel
 	| APIGuildForumChannel;
 
 /**

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -197,7 +197,11 @@ export interface APIGroupDMChannel extends Omit<APIDMChannelBase<ChannelType.Gro
 }
 
 export interface APIThreadChannel
-	extends APITextBasedChannel<ChannelType.PublicThread | ChannelType.PrivateThread | ChannelType.AnnouncementThread> {
+	extends Omit<
+			APITextBasedChannel<ChannelType.PublicThread | ChannelType.PrivateThread | ChannelType.AnnouncementThread>,
+			'name'
+		>,
+		APIGuildChannel<ChannelType.PublicThread | ChannelType.PrivateThread | ChannelType.AnnouncementThread> {
 	/**
 	 * The client users member for the thread, only included in select endpoints
 	 */

--- a/tests/v10/channel.test-d.ts
+++ b/tests/v10/channel.test-d.ts
@@ -1,4 +1,4 @@
-import { expectType, expectError } from 'tsd';
+import { expectType, expectAssignable, expectNotAssignable, expectError } from 'tsd';
 import type {
 	ChannelType,
 	APIPartialChannel,
@@ -11,14 +11,24 @@ import type {
 	APIGuildStageVoiceChannel,
 } from '../../v10';
 
+type AnyGuildChannel = APIGuildChannel<ChannelType>;
+
 declare const partialChannel: APIPartialChannel;
-declare const groupDMChannel: APIGroupDMChannel;
 declare const dmChannel: APIDMChannel;
-declare const guildChannel: APIGuildChannel<ChannelType>;
+declare const groupDMChannel: APIGroupDMChannel;
+declare const guildChannel: AnyGuildChannel;
 declare const guildTextChannel: APITextChannel;
 declare const guildThreadChannel: APIThreadChannel;
 declare const guildVoiceChannel: APIGuildVoiceChannel;
 declare const guildVoiceStageChannel: APIGuildStageVoiceChannel;
+
+// Make sure types follow expected hierarchy
+expectNotAssignable<AnyGuildChannel>(dmChannel);
+expectNotAssignable<AnyGuildChannel>(groupDMChannel);
+expectAssignable<AnyGuildChannel>(guildTextChannel);
+expectAssignable<AnyGuildChannel>(guildThreadChannel);
+expectAssignable<AnyGuildChannel>(guildVoiceChannel);
+expectAssignable<AnyGuildChannel>(guildVoiceStageChannel);
 
 // Test channel names are properly typed
 // Always non-null present for non-DM channels, always null for DM channel

--- a/tests/v10/channel.test-d.ts
+++ b/tests/v10/channel.test-d.ts
@@ -1,10 +1,24 @@
-import { expectType } from 'tsd';
-import type { ChannelType, APIPartialChannel, APIGroupDMChannel, APIDMChannel, APIGuildChannel } from '../../v10';
+import { expectType, expectError } from 'tsd';
+import type {
+	ChannelType,
+	APIPartialChannel,
+	APIGroupDMChannel,
+	APIDMChannel,
+	APIGuildChannel,
+	APITextChannel,
+	APIThreadChannel,
+	APIGuildVoiceChannel,
+	APIGuildStageVoiceChannel,
+} from '../../v10';
 
 declare const partialChannel: APIPartialChannel;
 declare const groupDMChannel: APIGroupDMChannel;
 declare const dmChannel: APIDMChannel;
 declare const guildChannel: APIGuildChannel<ChannelType>;
+declare const guildTextChannel: APITextChannel;
+declare const guildThreadChannel: APIThreadChannel;
+declare const guildVoiceChannel: APIGuildVoiceChannel;
+declare const guildVoiceStageChannel: APIGuildStageVoiceChannel;
 
 // Test channel names are properly typed
 // Always non-null present for non-DM channels, always null for DM channel
@@ -12,3 +26,15 @@ expectType<string | null | undefined>(partialChannel.name);
 expectType<string | null>(groupDMChannel.name);
 expectType<null>(dmChannel.name);
 expectType<string>(guildChannel.name);
+
+// Test last pin timestamp
+expectType<string | null | undefined>(dmChannel.last_pin_timestamp);
+expectType<string | null | undefined>(groupDMChannel.last_pin_timestamp);
+expectType<string | null | undefined>(guildTextChannel.last_pin_timestamp);
+expectType<string | null | undefined>(guildThreadChannel.last_pin_timestamp);
+expectError(guildVoiceChannel.last_pin_timestamp);
+expectError(guildVoiceStageChannel.last_pin_timestamp);
+
+// Test rate limit types
+expectType<number | undefined>(guildTextChannel.default_thread_rate_limit_per_user);
+expectError(guildVoiceChannel.default_thread_rate_limit_per_user);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Sort-of follow up of #666 after finding out some additional problems with the typings of the `APIChannel`-related objects

 - `default_thread_rate_limit_per_user` can be set on regular channels, despite the Discord client not showing this possibility, and newly created threads do abide by this configuration.
 - `last_pin_timestamp` was not present on DM channels, despite them having this property.

Tests included

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
N/A
