### PR TITLE
fix(APIApplicationRoleConnection): `metadata` values can be numbers

### DIFF
--- a/deno/payloads/v10/user.ts
+++ b/deno/payloads/v10/user.ts
@@ -271,5 +271,5 @@ export interface APIApplicationRoleConnection {
 	/**
 	 * Object mapping application role connection metadata keys to their `string`-ified value (max 100 characters) for the user on the platform a bot has connected
 	 */
-	metadata: Record<string, string>;
+	metadata: Record<string, string | number>;
 }

--- a/deno/payloads/v9/user.ts
+++ b/deno/payloads/v9/user.ts
@@ -271,5 +271,5 @@ export interface APIApplicationRoleConnection {
 	/**
 	 * Object mapping application role connection metadata keys to their `string`-ified value (max 100 characters) for the user on the platform a bot has connected
 	 */
-	metadata: Record<string, string>;
+	metadata: Record<string, string | number>;
 }

--- a/deno/rest/v10/user.ts
+++ b/deno/rest/v10/user.ts
@@ -122,7 +122,7 @@ export interface RESTPutAPICurrentUserApplicationRoleConnectionJSONBody {
 	/**
 	 * Object mapping application role connection metadata keys to their `string`-ified value (max 100 characters) for the user on the platform a bot has connected
 	 */
-	metadata?: Record<string, string>;
+	metadata?: Record<string, string | number>;
 }
 
 /**

--- a/deno/rest/v9/user.ts
+++ b/deno/rest/v9/user.ts
@@ -122,7 +122,7 @@ export interface RESTPutAPICurrentUserApplicationRoleConnectionJSONBody {
 	/**
 	 * Object mapping application role connection metadata keys to their `string`-ified value (max 100 characters) for the user on the platform a bot has connected
 	 */
-	metadata?: Record<string, string>;
+	metadata?: Record<string, string | number>;
 }
 
 /**

--- a/payloads/v10/user.ts
+++ b/payloads/v10/user.ts
@@ -271,5 +271,5 @@ export interface APIApplicationRoleConnection {
 	/**
 	 * Object mapping application role connection metadata keys to their `string`-ified value (max 100 characters) for the user on the platform a bot has connected
 	 */
-	metadata: Record<string, string>;
+	metadata: Record<string, string | number>;
 }

--- a/payloads/v9/user.ts
+++ b/payloads/v9/user.ts
@@ -271,5 +271,5 @@ export interface APIApplicationRoleConnection {
 	/**
 	 * Object mapping application role connection metadata keys to their `string`-ified value (max 100 characters) for the user on the platform a bot has connected
 	 */
-	metadata: Record<string, string>;
+	metadata: Record<string, string | number>;
 }

--- a/rest/v10/user.ts
+++ b/rest/v10/user.ts
@@ -122,7 +122,7 @@ export interface RESTPutAPICurrentUserApplicationRoleConnectionJSONBody {
 	/**
 	 * Object mapping application role connection metadata keys to their `string`-ified value (max 100 characters) for the user on the platform a bot has connected
 	 */
-	metadata?: Record<string, string>;
+	metadata?: Record<string, string | number>;
 }
 
 /**

--- a/rest/v9/user.ts
+++ b/rest/v9/user.ts
@@ -122,7 +122,7 @@ export interface RESTPutAPICurrentUserApplicationRoleConnectionJSONBody {
 	/**
 	 * Object mapping application role connection metadata keys to their `string`-ified value (max 100 characters) for the user on the platform a bot has connected
 	 */
-	metadata?: Record<string, string>;
+	metadata?: Record<string, string | number>;
 }
 
 /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The metadata keys can be strings or integers, as can be seen in the official example
https://github.com/discord/linked-roles-sample/blob/013fb8f30ecb484324a53093f912a08122a03167/src/server.js#L113-L117

It does not support boolean values as per https://github.com/discord/discord-api-docs/issues/5755#issuecomment-1353749675
**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
