### PR TITLE
refactor(MessageType): remove `@unstable` stage message types

### DIFF
--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -697,25 +697,10 @@ export enum MessageType {
 	AutoModerationAction,
 	RoleSubscriptionPurchase,
 	InteractionPremiumUpsell,
-	/**
-	 * @unstable
-	 */
 	StageStart,
-	/**
-	 * @unstable
-	 */
 	StageEnd,
-	/**
-	 * @unstable
-	 */
 	StageSpeaker,
-	/**
-	 * @unstable
-	 */
 	StageRaiseHand,
-	/**
-	 * @unstable
-	 */
 	StageTopic,
 	GuildApplicationPremiumSubscription,
 }

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -683,25 +683,10 @@ export enum MessageType {
 	AutoModerationAction,
 	RoleSubscriptionPurchase,
 	InteractionPremiumUpsell,
-	/**
-	 * @unstable
-	 */
 	StageStart,
-	/**
-	 * @unstable
-	 */
 	StageEnd,
-	/**
-	 * @unstable
-	 */
 	StageSpeaker,
-	/**
-	 * @unstable
-	 */
 	StageRaiseHand,
-	/**
-	 * @unstable
-	 */
 	StageTopic,
 	GuildApplicationPremiumSubscription,
 }

--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -697,25 +697,10 @@ export enum MessageType {
 	AutoModerationAction,
 	RoleSubscriptionPurchase,
 	InteractionPremiumUpsell,
-	/**
-	 * @unstable
-	 */
 	StageStart,
-	/**
-	 * @unstable
-	 */
 	StageEnd,
-	/**
-	 * @unstable
-	 */
 	StageSpeaker,
-	/**
-	 * @unstable
-	 */
 	StageRaiseHand,
-	/**
-	 * @unstable
-	 */
 	StageTopic,
 	GuildApplicationPremiumSubscription,
 }

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -683,25 +683,10 @@ export enum MessageType {
 	AutoModerationAction,
 	RoleSubscriptionPurchase,
 	InteractionPremiumUpsell,
-	/**
-	 * @unstable
-	 */
 	StageStart,
-	/**
-	 * @unstable
-	 */
 	StageEnd,
-	/**
-	 * @unstable
-	 */
 	StageSpeaker,
-	/**
-	 * @unstable
-	 */
 	StageRaiseHand,
-	/**
-	 * @unstable
-	 */
 	StageTopic,
 	GuildApplicationPremiumSubscription,
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Removes the `@unstable` tag from these stage-related message types.

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**

- https://github.com/discord/discord-api-docs/pull/5927