### PR TITLE
fix: add missing `RESTGetAPIWebhookWithTokenQuery`

### DIFF
--- a/deno/rest/v10/webhook.ts
+++ b/deno/rest/v10/webhook.ts
@@ -238,6 +238,13 @@ export type RESTPostAPIWebhookWithTokenGitHubWaitResult = APIMessage;
 export type RESTGetAPIWebhookWithTokenMessageResult = APIMessage;
 
 /**
+ * https://discord.com/developers/docs/resources/webhook#get-webhook-message-query-string-params
+ */
+export interface RESTGetAPIWebhookWithTokenQuery {
+	thread_id?: string;
+}
+
+/**
  * https://discord.com/developers/docs/resources/webhook#edit-webhook-message
  */
 export type RESTPatchAPIWebhookWithTokenMessageJSONBody = AddUndefinedToPossiblyUndefinedPropertiesOfInterface<

--- a/deno/rest/v9/webhook.ts
+++ b/deno/rest/v9/webhook.ts
@@ -238,6 +238,13 @@ export type RESTPostAPIWebhookWithTokenGitHubWaitResult = APIMessage;
 export type RESTGetAPIWebhookWithTokenMessageResult = APIMessage;
 
 /**
+ * https://discord.com/developers/docs/resources/webhook#get-webhook-message-query-string-params
+ */
+export interface RESTGetAPIWebhookWithTokenQuery {
+	thread_id?: string;
+}
+
+/**
  * https://discord.com/developers/docs/resources/webhook#edit-webhook-message
  */
 export type RESTPatchAPIWebhookWithTokenMessageJSONBody = AddUndefinedToPossiblyUndefinedPropertiesOfInterface<

--- a/rest/v10/webhook.ts
+++ b/rest/v10/webhook.ts
@@ -238,6 +238,13 @@ export type RESTPostAPIWebhookWithTokenGitHubWaitResult = APIMessage;
 export type RESTGetAPIWebhookWithTokenMessageResult = APIMessage;
 
 /**
+ * https://discord.com/developers/docs/resources/webhook#get-webhook-message-query-string-params
+ */
+export interface RESTGetAPIWebhookWithTokenQuery {
+	thread_id?: string;
+}
+
+/**
  * https://discord.com/developers/docs/resources/webhook#edit-webhook-message
  */
 export type RESTPatchAPIWebhookWithTokenMessageJSONBody = AddUndefinedToPossiblyUndefinedPropertiesOfInterface<

--- a/rest/v9/webhook.ts
+++ b/rest/v9/webhook.ts
@@ -238,6 +238,13 @@ export type RESTPostAPIWebhookWithTokenGitHubWaitResult = APIMessage;
 export type RESTGetAPIWebhookWithTokenMessageResult = APIMessage;
 
 /**
+ * https://discord.com/developers/docs/resources/webhook#get-webhook-message-query-string-params
+ */
+export interface RESTGetAPIWebhookWithTokenQuery {
+	thread_id?: string;
+}
+
+/**
  * https://discord.com/developers/docs/resources/webhook#edit-webhook-message
  */
 export type RESTPatchAPIWebhookWithTokenMessageJSONBody = AddUndefinedToPossiblyUndefinedPropertiesOfInterface<


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Adds missing query param interface for fetching webhook messages.
