### PR TITLE
fix(RESTPostAPIChannelMessagesThreadsJSONBody): mark `auto_archive_duration` as optional

### DIFF
--- a/deno/rest/v10/channel.ts
+++ b/deno/rest/v10/channel.ts
@@ -608,7 +608,7 @@ export interface RESTPostAPIChannelMessagesThreadsJSONBody {
 	 *
 	 * The 3 day and 7 day archive durations require the server to be boosted. The [guild features](https://discord.com/developers/docs/resources/guild#guild-object-guild-features) will indicate if a server is able to use those settings.
 	 */
-	auto_archive_duration: ThreadAutoArchiveDuration;
+	auto_archive_duration?: ThreadAutoArchiveDuration | undefined;
 	/**
 	 * Amount of seconds a user has to wait before sending another message (0-21600)
 	 */

--- a/deno/rest/v9/channel.ts
+++ b/deno/rest/v9/channel.ts
@@ -622,7 +622,7 @@ export interface RESTPostAPIChannelMessagesThreadsJSONBody {
 	 *
 	 * The 3 day and 7 day archive durations require the server to be boosted. The [guild features](https://discord.com/developers/docs/resources/guild#guild-object-guild-features) will indicate if a server is able to use those settings.
 	 */
-	auto_archive_duration: ThreadAutoArchiveDuration;
+	auto_archive_duration?: ThreadAutoArchiveDuration | undefined;
 	/**
 	 * Amount of seconds a user has to wait before sending another message (0-21600)
 	 */

--- a/rest/v10/channel.ts
+++ b/rest/v10/channel.ts
@@ -608,7 +608,7 @@ export interface RESTPostAPIChannelMessagesThreadsJSONBody {
 	 *
 	 * The 3 day and 7 day archive durations require the server to be boosted. The [guild features](https://discord.com/developers/docs/resources/guild#guild-object-guild-features) will indicate if a server is able to use those settings.
 	 */
-	auto_archive_duration: ThreadAutoArchiveDuration;
+	auto_archive_duration?: ThreadAutoArchiveDuration | undefined;
 	/**
 	 * Amount of seconds a user has to wait before sending another message (0-21600)
 	 */

--- a/rest/v9/channel.ts
+++ b/rest/v9/channel.ts
@@ -622,7 +622,7 @@ export interface RESTPostAPIChannelMessagesThreadsJSONBody {
 	 *
 	 * The 3 day and 7 day archive durations require the server to be boosted. The [guild features](https://discord.com/developers/docs/resources/guild#guild-object-guild-features) will indicate if a server is able to use those settings.
 	 */
-	auto_archive_duration: ThreadAutoArchiveDuration;
+	auto_archive_duration?: ThreadAutoArchiveDuration | undefined;
 	/**
 	 * Amount of seconds a user has to wait before sending another message (0-21600)
 	 */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

`RESTPostAPIChannelMessagesThreadsJSONBody` marks `auto_archive_duration` as required, however, the [documentation](https://discord.com/developers/docs/resources/channel#start-thread-from-message) indicates it's optional.

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**

https://discord.com/developers/docs/resources/channel#start-thread-from-message
