### PR TITLE
fix(GatewayGuildMembersChunkDispatchData): Omit `guild_id` for presences

### DIFF
--- a/deno/gateway/v10.ts
+++ b/deno/gateway/v10.ts
@@ -976,6 +976,11 @@ export type GatewayGuildMembersChunkDispatch = DataPayload<
 >;
 
 /**
+ * https://discord.com/developers/docs/topics/gateway-events#update-presence
+ */
+export type GatewayGuildMembersChunkPresence = Omit<RawGatewayPresenceUpdate, 'guild_id'>;
+
+/**
  * https://discord.com/developers/docs/topics/gateway-events#guild-members-chunk
  */
 export interface GatewayGuildMembersChunkDispatchData {
@@ -1006,7 +1011,7 @@ export interface GatewayGuildMembersChunkDispatchData {
 	 *
 	 * See https://discord.com/developers/docs/topics/gateway-events#update-presence
 	 */
-	presences?: RawGatewayPresenceUpdate[];
+	presences?: GatewayGuildMembersChunkPresence[];
 	/**
 	 * The nonce used in the Guild Members Request
 	 *

--- a/deno/gateway/v9.ts
+++ b/deno/gateway/v9.ts
@@ -975,6 +975,11 @@ export type GatewayGuildMembersChunkDispatch = DataPayload<
 >;
 
 /**
+ * https://discord.com/developers/docs/topics/gateway-events#update-presence
+ */
+export type GatewayGuildMembersChunkPresence = Omit<RawGatewayPresenceUpdate, 'guild_id'>;
+
+/**
  * https://discord.com/developers/docs/topics/gateway-events#guild-members-chunk
  */
 export interface GatewayGuildMembersChunkDispatchData {
@@ -1005,7 +1010,7 @@ export interface GatewayGuildMembersChunkDispatchData {
 	 *
 	 * See https://discord.com/developers/docs/topics/gateway-events#update-presence
 	 */
-	presences?: RawGatewayPresenceUpdate[];
+	presences?: GatewayGuildMembersChunkPresence[];
 	/**
 	 * The nonce used in the Guild Members Request
 	 *

--- a/gateway/v10.ts
+++ b/gateway/v10.ts
@@ -976,6 +976,11 @@ export type GatewayGuildMembersChunkDispatch = DataPayload<
 >;
 
 /**
+ * https://discord.com/developers/docs/topics/gateway-events#update-presence
+ */
+export type GatewayGuildMembersChunkPresence = Omit<RawGatewayPresenceUpdate, 'guild_id'>;
+
+/**
  * https://discord.com/developers/docs/topics/gateway-events#guild-members-chunk
  */
 export interface GatewayGuildMembersChunkDispatchData {
@@ -1006,7 +1011,7 @@ export interface GatewayGuildMembersChunkDispatchData {
 	 *
 	 * See https://discord.com/developers/docs/topics/gateway-events#update-presence
 	 */
-	presences?: RawGatewayPresenceUpdate[];
+	presences?: GatewayGuildMembersChunkPresence[];
 	/**
 	 * The nonce used in the Guild Members Request
 	 *

--- a/gateway/v9.ts
+++ b/gateway/v9.ts
@@ -975,6 +975,11 @@ export type GatewayGuildMembersChunkDispatch = DataPayload<
 >;
 
 /**
+ * https://discord.com/developers/docs/topics/gateway-events#update-presence
+ */
+export type GatewayGuildMembersChunkPresence = Omit<RawGatewayPresenceUpdate, 'guild_id'>;
+
+/**
  * https://discord.com/developers/docs/topics/gateway-events#guild-members-chunk
  */
 export interface GatewayGuildMembersChunkDispatchData {
@@ -1005,7 +1010,7 @@ export interface GatewayGuildMembersChunkDispatchData {
 	 *
 	 * See https://discord.com/developers/docs/topics/gateway-events#update-presence
 	 */
-	presences?: RawGatewayPresenceUpdate[];
+	presences?: GatewayGuildMembersChunkPresence[];
 	/**
 	 * The nonce used in the Guild Members Request
 	 *


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
When requesting guild members over the gateway (v9 & v10) and receiving guild member chunks, the presence data does not include the guild id.