### PR TITLE
fix: allow sending empty choices with autocomplete: true

### DIFF
--- a/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/base.ts
+++ b/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/base.ts
@@ -22,7 +22,7 @@ export type APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper<
 > =
 	| (Base & {
 			autocomplete: true;
-			choices?: never[];
+			choices?: [];
 	  })
 	| (Base & {
 			autocomplete?: false;

--- a/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/base.ts
+++ b/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/base.ts
@@ -22,6 +22,7 @@ export type APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper<
 > =
 	| (Base & {
 			autocomplete: true;
+			choices?: never[];
 	  })
 	| (Base & {
 			autocomplete?: false;

--- a/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/base.ts
+++ b/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/base.ts
@@ -22,7 +22,7 @@ export type APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper<
 > =
 	| (Base & {
 			autocomplete: true;
-			choices?: never[];
+			choices?: [];
 	  })
 	| (Base & {
 			autocomplete?: false;

--- a/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/base.ts
+++ b/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/base.ts
@@ -22,6 +22,7 @@ export type APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper<
 > =
 	| (Base & {
 			autocomplete: true;
+			choices?: never[];
 	  })
 	| (Base & {
 			autocomplete?: false;

--- a/payloads/v10/_interactions/_applicationCommands/_chatInput/base.ts
+++ b/payloads/v10/_interactions/_applicationCommands/_chatInput/base.ts
@@ -22,7 +22,7 @@ export type APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper<
 > =
 	| (Base & {
 			autocomplete: true;
-			choices?: never[];
+			choices?: [];
 	  })
 	| (Base & {
 			autocomplete?: false;

--- a/payloads/v10/_interactions/_applicationCommands/_chatInput/base.ts
+++ b/payloads/v10/_interactions/_applicationCommands/_chatInput/base.ts
@@ -22,6 +22,7 @@ export type APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper<
 > =
 	| (Base & {
 			autocomplete: true;
+			choices?: never[];
 	  })
 	| (Base & {
 			autocomplete?: false;

--- a/payloads/v9/_interactions/_applicationCommands/_chatInput/base.ts
+++ b/payloads/v9/_interactions/_applicationCommands/_chatInput/base.ts
@@ -22,7 +22,7 @@ export type APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper<
 > =
 	| (Base & {
 			autocomplete: true;
-			choices?: never[];
+			choices?: [];
 	  })
 	| (Base & {
 			autocomplete?: false;

--- a/payloads/v9/_interactions/_applicationCommands/_chatInput/base.ts
+++ b/payloads/v9/_interactions/_applicationCommands/_chatInput/base.ts
@@ -22,6 +22,7 @@ export type APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper<
 > =
 	| (Base & {
 			autocomplete: true;
+			choices?: never[];
 	  })
 	| (Base & {
 			autocomplete?: false;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
https://github.com/discordjs/discord.js/blob/6229597db2be67be9e3aa0bf05574d826315eb36/packages/builders/__tests__/interactions/SlashCommands/Options.test.ts#L103-L106

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
