### PR TITLE
Fix: move `types` condition to the front

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,89 +5,89 @@
 	"homepage": "https://discord-api-types.dev",
 	"exports": {
 		"./globals": {
+			"types": "./globals.d.ts",
 			"require": "./globals.js",
-			"import": "./globals.mjs",
-			"types": "./globals.d.ts"
+			"import": "./globals.mjs"
 		},
 		"./v6": {
+			"types": "./v6.d.ts",
 			"require": "./v6.js",
-			"import": "./v6.mjs",
-			"types": "./v6.d.ts"
+			"import": "./v6.mjs"
 		},
 		"./v8": {
+			"types": "./v8.d.ts",
 			"require": "./v8.js",
-			"import": "./v8.mjs",
-			"types": "./v8.d.ts"
+			"import": "./v8.mjs"
 		},
 		"./v9": {
+			"types": "./v9.d.ts",
 			"require": "./v9.js",
-			"import": "./v9.mjs",
-			"types": "./v9.d.ts"
+			"import": "./v9.mjs"
 		},
 		"./v10": {
+			"types": "./v10.d.ts",
 			"require": "./v10.js",
-			"import": "./v10.mjs",
-			"types": "./v10.d.ts"
+			"import": "./v10.mjs"
 		},
 		"./gateway": {
+			"types": "./gateway/index.d.ts",
 			"require": "./gateway/index.js",
-			"import": "./gateway/index.mjs",
-			"types": "./gateway/index.d.ts"
+			"import": "./gateway/index.mjs"
 		},
 		"./gateway/v*": {
+			"types": "./gateway/v*.d.ts",
 			"require": "./gateway/v*.js",
-			"import": "./gateway/v*.mjs",
-			"types": "./gateway/v*.d.ts"
+			"import": "./gateway/v*.mjs"
 		},
 		"./payloads": {
+			"types": "./payloads/index.d.ts",
 			"require": "./payloads/index.js",
-			"import": "./payloads/index.mjs",
-			"types": "./payloads/index.d.ts"
+			"import": "./payloads/index.mjs"
 		},
 		"./payloads/v*": {
+			"types": "./payloads/v*/index.d.ts",
 			"require": "./payloads/v*/index.js",
-			"import": "./payloads/v*/index.mjs",
-			"types": "./payloads/v*/index.d.ts"
+			"import": "./payloads/v*/index.mjs"
 		},
 		"./rest": {
+			"types": "./rest/index.d.ts",
 			"require": "./rest/index.js",
-			"import": "./rest/index.mjs",
-			"types": "./rest/index.d.ts"
+			"import": "./rest/index.mjs"
 		},
 		"./rest/v*": {
+			"types": "./rest/v*/index.d.ts",
 			"require": "./rest/v*/index.js",
-			"import": "./rest/v*/index.mjs",
-			"types": "./rest/v*/index.d.ts"
+			"import": "./rest/v*/index.mjs"
 		},
 		"./rpc": {
+			"types": "./rpc/index.d.ts",
 			"require": "./rpc/index.js",
-			"import": "./rpc/index.mjs",
-			"types": "./rpc/index.d.ts"
+			"import": "./rpc/index.mjs"
 		},
 		"./rpc/v*": {
+			"types": "./rpc/v*.d.ts",
 			"require": "./rpc/v*.js",
-			"import": "./rpc/v*.mjs",
-			"types": "./rpc/v*.d.ts"
+			"import": "./rpc/v*.mjs"
 		},
 		"./voice": {
+			"types": "./voice/index.d.ts",
 			"require": "./voice/index.js",
-			"import": "./voice/index.mjs",
-			"types": "./voice/index.d.ts"
+			"import": "./voice/index.mjs"
 		},
 		"./voice/v*": {
+			"types": "./voice/v*.d.ts",
 			"require": "./voice/v*.js",
-			"import": "./voice/v*.mjs",
-			"types": "./voice/v*.d.ts"
+			"import": "./voice/v*.mjs"
 		},
 		"./utils": {
+			"types": "./utils/index.d.ts",
 			"require": "./utils/index.js",
-			"import": "./utils/index.mjs",
-			"types": "./utils/index.d.ts"
+			"import": "./utils/index.mjs"
 		},
 		"./utils/v*": {
+			"types": "./utils/v*.d.ts",
 			"require": "./utils/v*.js",
-			"import": "./utils/v*.mjs",
-			"types": "./utils/v*.d.ts"
+			"import": "./utils/v*.mjs"
 		}
 	},
 	"scripts": {


### PR DESCRIPTION
I moved `types` condition to the front. `package.json#exports` are **order-sensitive** - they are always matched from the top to the bottom. When a match is found then it should be used and no further matching should occur. 

Right now, the current setup works in TypeScript but it's considered a bug and it should not be relied upon, see the thread and the comment [here](https://github.com/microsoft/TypeScript/issues/50762#issuecomment-1528318260). For that reason, I would like to fix all popular packages that misconfigured their `exports` this way so the bug can be fixed in TypeScript.

⚠️ this PR focuses solely on fixing "🐛 Used fallback condition" problem but the "🎭 Masquerading as CJS" remains here. You can check the reported errors [here](https://arethetypeswrong.github.io/?p=discord-api-types%400.37.40)