### PR TITLE
chore(PermissionFlagsBits): mark `UseExternalSounds` as stable

### DIFF
--- a/deno/payloads/common.ts
+++ b/deno/payloads/common.ts
@@ -255,7 +255,9 @@ export const PermissionFlagsBits = {
 	 */
 	UseSoundboard: 1n << 42n,
 	/**
-	 * @unstable This permission flag is currently not documented by Discord but has a known value which we will try to keep up to date.
+	 * Allows the usage of custom soundboard sounds from other servers
+	 *
+	 * Applies to channel types: Voice
 	 */
 	UseExternalSounds: 1n << 45n,
 	/**

--- a/payloads/common.ts
+++ b/payloads/common.ts
@@ -255,7 +255,9 @@ export const PermissionFlagsBits = {
 	 */
 	UseSoundboard: 1n << 42n,
 	/**
-	 * @unstable This permission flag is currently not documented by Discord but has a known value which we will try to keep up to date.
+	 * Allows the usage of custom soundboard sounds from other servers
+	 *
+	 * Applies to channel types: Voice
 	 */
 	UseExternalSounds: 1n << 45n,
 	/**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
- discord/discord-api-docs#6039