### PR TITLE
docs(APITextInputComponent): correct label max characters

### DIFF
--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -1668,7 +1668,7 @@ export interface APITextInputComponent extends APIBaseComponent<ComponentType.Te
 	 */
 	custom_id: string;
 	/**
-	 * Text that appears on top of the text input field, max 80 characters
+	 * Text that appears on top of the text input field, max 45 characters
 	 */
 	label: string;
 	/**

--- a/deno/payloads/v8/channel.ts
+++ b/deno/payloads/v8/channel.ts
@@ -1297,7 +1297,7 @@ export interface APITextInputComponent extends APIBaseComponent<ComponentType.Te
 	 */
 	custom_id: string;
 	/**
-	 * Text that appears on top of the text input field, max 80 characters
+	 * Text that appears on top of the text input field, max 45 characters
 	 */
 	label: string;
 	/**

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -1636,7 +1636,7 @@ export interface APITextInputComponent extends APIBaseComponent<ComponentType.Te
 	 */
 	custom_id: string;
 	/**
-	 * Text that appears on top of the text input field, max 80 characters
+	 * Text that appears on top of the text input field, max 45 characters
 	 */
 	label: string;
 	/**

--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -1668,7 +1668,7 @@ export interface APITextInputComponent extends APIBaseComponent<ComponentType.Te
 	 */
 	custom_id: string;
 	/**
-	 * Text that appears on top of the text input field, max 80 characters
+	 * Text that appears on top of the text input field, max 45 characters
 	 */
 	label: string;
 	/**

--- a/payloads/v8/channel.ts
+++ b/payloads/v8/channel.ts
@@ -1297,7 +1297,7 @@ export interface APITextInputComponent extends APIBaseComponent<ComponentType.Te
 	 */
 	custom_id: string;
 	/**
-	 * Text that appears on top of the text input field, max 80 characters
+	 * Text that appears on top of the text input field, max 45 characters
 	 */
 	label: string;
 	/**

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -1636,7 +1636,7 @@ export interface APITextInputComponent extends APIBaseComponent<ComponentType.Te
 	 */
 	custom_id: string;
 	/**
-	 * Text that appears on top of the text input field, max 80 characters
+	 * Text that appears on top of the text input field, max 45 characters
 	 */
 	label: string;
 	/**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
[APITextInputComponent](https://discord-api-types.dev/api/discord-api-types-v8/interface/APITextInputComponent#label) shows max 80 characters but it's actually 45 characters according to [Text Input Structure](https://discord.com/developers/docs/interactions/message-components#text-inputs-text-input-structure)

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**