### PR TITLE
feat: fetching a webhook with its token now returns a user

### DIFF
--- a/deno/payloads/v10/webhook.ts
+++ b/deno/payloads/v10/webhook.ts
@@ -28,11 +28,11 @@ export interface APIWebhook {
 	 */
 	channel_id: Snowflake;
 	/**
-	 * The user this webhook was created by (not returned when getting a webhook with its token)
+	 * The user this webhook was created by
 	 *
 	 * See https://discord.com/developers/docs/resources/user#user-object
 	 */
-	user?: APIUser;
+	user: APIUser;
 	/**
 	 * The default name of the webhook
 	 */

--- a/deno/payloads/v9/webhook.ts
+++ b/deno/payloads/v9/webhook.ts
@@ -28,11 +28,11 @@ export interface APIWebhook {
 	 */
 	channel_id: Snowflake;
 	/**
-	 * The user this webhook was created by (not returned when getting a webhook with its token)
+	 * The user this webhook was created by
 	 *
 	 * See https://discord.com/developers/docs/resources/user#user-object
 	 */
-	user?: APIUser;
+	user: APIUser;
 	/**
 	 * The default name of the webhook
 	 */

--- a/deno/rest/v10/webhook.ts
+++ b/deno/rest/v10/webhook.ts
@@ -49,7 +49,7 @@ export type RESTGetAPIWebhookResult = APIWebhook;
 /**
  * https://discord.com/developers/docs/resources/webhook#get-webhook-with-token
  */
-export type RESTGetAPIWebhookWithTokenResult = Omit<APIWebhook, 'user'>;
+export type RESTGetAPIWebhookWithTokenResult = APIWebhook;
 
 /**
  * https://discord.com/developers/docs/resources/webhook#modify-webhook

--- a/deno/rest/v9/webhook.ts
+++ b/deno/rest/v9/webhook.ts
@@ -49,7 +49,7 @@ export type RESTGetAPIWebhookResult = APIWebhook;
 /**
  * https://discord.com/developers/docs/resources/webhook#get-webhook-with-token
  */
-export type RESTGetAPIWebhookWithTokenResult = Omit<APIWebhook, 'user'>;
+export type RESTGetAPIWebhookWithTokenResult = APIWebhook;
 
 /**
  * https://discord.com/developers/docs/resources/webhook#modify-webhook

--- a/payloads/v10/webhook.ts
+++ b/payloads/v10/webhook.ts
@@ -28,11 +28,11 @@ export interface APIWebhook {
 	 */
 	channel_id: Snowflake;
 	/**
-	 * The user this webhook was created by (not returned when getting a webhook with its token)
+	 * The user this webhook was created by
 	 *
 	 * See https://discord.com/developers/docs/resources/user#user-object
 	 */
-	user?: APIUser;
+	user: APIUser;
 	/**
 	 * The default name of the webhook
 	 */

--- a/payloads/v9/webhook.ts
+++ b/payloads/v9/webhook.ts
@@ -28,11 +28,11 @@ export interface APIWebhook {
 	 */
 	channel_id: Snowflake;
 	/**
-	 * The user this webhook was created by (not returned when getting a webhook with its token)
+	 * The user this webhook was created by
 	 *
 	 * See https://discord.com/developers/docs/resources/user#user-object
 	 */
-	user?: APIUser;
+	user: APIUser;
 	/**
 	 * The default name of the webhook
 	 */

--- a/rest/v10/webhook.ts
+++ b/rest/v10/webhook.ts
@@ -49,7 +49,7 @@ export type RESTGetAPIWebhookResult = APIWebhook;
 /**
  * https://discord.com/developers/docs/resources/webhook#get-webhook-with-token
  */
-export type RESTGetAPIWebhookWithTokenResult = Omit<APIWebhook, 'user'>;
+export type RESTGetAPIWebhookWithTokenResult = APIWebhook;
 
 /**
  * https://discord.com/developers/docs/resources/webhook#modify-webhook

--- a/rest/v9/webhook.ts
+++ b/rest/v9/webhook.ts
@@ -49,7 +49,7 @@ export type RESTGetAPIWebhookResult = APIWebhook;
 /**
  * https://discord.com/developers/docs/resources/webhook#get-webhook-with-token
  */
-export type RESTGetAPIWebhookWithTokenResult = Omit<APIWebhook, 'user'>;
+export type RESTGetAPIWebhookWithTokenResult = APIWebhook;
 
 /**
  * https://discord.com/developers/docs/resources/webhook#modify-webhook


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fetching a webhook with its token now returns the user it was created by.

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**

- discord/discord-api-docs#6303
