### PR TITLE
fix: standard stickers are now free

### DIFF
--- a/deno/payloads/v10/sticker.ts
+++ b/deno/payloads/v10/sticker.ts
@@ -70,7 +70,7 @@ export interface APISticker {
  */
 export enum StickerType {
 	/**
-	 * An official sticker in a pack, part of Nitro or in a removed purchasable pack
+	 * An official sticker in a pack
 	 */
 	Standard = 1,
 	/**

--- a/deno/payloads/v9/sticker.ts
+++ b/deno/payloads/v9/sticker.ts
@@ -70,7 +70,7 @@ export interface APISticker {
  */
 export enum StickerType {
 	/**
-	 * An official sticker in a pack, part of Nitro or in a removed purchasable pack
+	 * An official sticker in a pack
 	 */
 	Standard = 1,
 	/**

--- a/deno/rest/v10/mod.ts
+++ b/deno/rest/v10/mod.ts
@@ -830,6 +830,16 @@ export const Routes = {
 	 * Route for:
 	 * - GET `/sticker-packs`
 	 */
+	stickerPacks() {
+		return '/sticker-packs' as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/sticker-packs`
+	 *
+	 * @deprecated Use {@link Routes.stickerPacks} instead.
+	 */
 	nitroStickerPacks() {
 		return '/sticker-packs' as const;
 	},

--- a/deno/rest/v10/sticker.ts
+++ b/deno/rest/v10/sticker.ts
@@ -6,11 +6,18 @@ import type { APISticker, APIStickerPack } from '../../payloads/v10/mod.ts';
 export type RESTGetAPIStickerResult = APISticker;
 
 /**
- * https://discord.com/developers/docs/resources/sticker#list-nitro-sticker-packs
+ * https://discord.com/developers/docs/resources/sticker#list-sticker-packs
  */
-export interface RESTGetNitroStickerPacksResult {
+export interface RESTGetStickerPacksResult {
 	sticker_packs: APIStickerPack[];
 }
+
+/**
+ * https://discord.com/developers/docs/resources/sticker#list-sticker-packs
+ *
+ * @deprecated Use `RESTGetStickerPacksResult` instead
+ */
+export type RESTGetNitroStickerPacksResult = RESTGetStickerPacksResult;
 
 /**
  * https://discord.com/developers/docs/resources/sticker#list-guild-stickers

--- a/deno/rest/v9/mod.ts
+++ b/deno/rest/v9/mod.ts
@@ -839,6 +839,16 @@ export const Routes = {
 	 * Route for:
 	 * - GET `/sticker-packs`
 	 */
+	stickerPacks() {
+		return '/sticker-packs' as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/sticker-packs`
+	 *
+	 * @deprecated Use {@link Routes.stickerPacks} instead.
+	 */
 	nitroStickerPacks() {
 		return '/sticker-packs' as const;
 	},

--- a/deno/rest/v9/sticker.ts
+++ b/deno/rest/v9/sticker.ts
@@ -6,11 +6,18 @@ import type { APISticker, APIStickerPack } from '../../payloads/v9/mod.ts';
 export type RESTGetAPIStickerResult = APISticker;
 
 /**
- * https://discord.com/developers/docs/resources/sticker#list-nitro-sticker-packs
+ * https://discord.com/developers/docs/resources/sticker#list-sticker-packs
  */
-export interface RESTGetNitroStickerPacksResult {
+export interface RESTGetStickerPacksResult {
 	sticker_packs: APIStickerPack[];
 }
+
+/**
+ * https://discord.com/developers/docs/resources/sticker#list-sticker-packs
+ *
+ * @deprecated Use `RESTGetStickerPacksResult` instead
+ */
+export type RESTGetNitroStickerPacksResult = RESTGetStickerPacksResult;
 
 /**
  * https://discord.com/developers/docs/resources/sticker#list-guild-stickers

--- a/payloads/v10/sticker.ts
+++ b/payloads/v10/sticker.ts
@@ -70,7 +70,7 @@ export interface APISticker {
  */
 export enum StickerType {
 	/**
-	 * An official sticker in a pack, part of Nitro or in a removed purchasable pack
+	 * An official sticker in a pack
 	 */
 	Standard = 1,
 	/**

--- a/payloads/v9/sticker.ts
+++ b/payloads/v9/sticker.ts
@@ -70,7 +70,7 @@ export interface APISticker {
  */
 export enum StickerType {
 	/**
-	 * An official sticker in a pack, part of Nitro or in a removed purchasable pack
+	 * An official sticker in a pack
 	 */
 	Standard = 1,
 	/**

--- a/rest/v10/index.ts
+++ b/rest/v10/index.ts
@@ -830,6 +830,16 @@ export const Routes = {
 	 * Route for:
 	 * - GET `/sticker-packs`
 	 */
+	stickerPacks() {
+		return '/sticker-packs' as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/sticker-packs`
+	 *
+	 * @deprecated Use {@link Routes.stickerPacks} instead.
+	 */
 	nitroStickerPacks() {
 		return '/sticker-packs' as const;
 	},

--- a/rest/v10/sticker.ts
+++ b/rest/v10/sticker.ts
@@ -6,11 +6,18 @@ import type { APISticker, APIStickerPack } from '../../payloads/v10/index';
 export type RESTGetAPIStickerResult = APISticker;
 
 /**
- * https://discord.com/developers/docs/resources/sticker#list-nitro-sticker-packs
+ * https://discord.com/developers/docs/resources/sticker#list-sticker-packs
  */
-export interface RESTGetNitroStickerPacksResult {
+export interface RESTGetStickerPacksResult {
 	sticker_packs: APIStickerPack[];
 }
+
+/**
+ * https://discord.com/developers/docs/resources/sticker#list-sticker-packs
+ *
+ * @deprecated Use `RESTGetStickerPacksResult` instead
+ */
+export type RESTGetNitroStickerPacksResult = RESTGetStickerPacksResult;
 
 /**
  * https://discord.com/developers/docs/resources/sticker#list-guild-stickers

--- a/rest/v9/index.ts
+++ b/rest/v9/index.ts
@@ -839,6 +839,16 @@ export const Routes = {
 	 * Route for:
 	 * - GET `/sticker-packs`
 	 */
+	stickerPacks() {
+		return '/sticker-packs' as const;
+	},
+
+	/**
+	 * Route for:
+	 * - GET `/sticker-packs`
+	 *
+	 * @deprecated Use {@link Routes.stickerPacks} instead.
+	 */
 	nitroStickerPacks() {
 		return '/sticker-packs' as const;
 	},

--- a/rest/v9/sticker.ts
+++ b/rest/v9/sticker.ts
@@ -6,11 +6,18 @@ import type { APISticker, APIStickerPack } from '../../payloads/v9/index';
 export type RESTGetAPIStickerResult = APISticker;
 
 /**
- * https://discord.com/developers/docs/resources/sticker#list-nitro-sticker-packs
+ * https://discord.com/developers/docs/resources/sticker#list-sticker-packs
  */
-export interface RESTGetNitroStickerPacksResult {
+export interface RESTGetStickerPacksResult {
 	sticker_packs: APIStickerPack[];
 }
+
+/**
+ * https://discord.com/developers/docs/resources/sticker#list-sticker-packs
+ *
+ * @deprecated Use `RESTGetStickerPacksResult` instead
+ */
+export type RESTGetNitroStickerPacksResult = RESTGetStickerPacksResult;
 
 /**
  * https://discord.com/developers/docs/resources/sticker#list-guild-stickers


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
- https://github.com/discord/discord-api-docs/pull/6265