### PR TITLE
fix(Guild): union with never type

### DIFF
--- a/deno/rest/v10/guild.ts
+++ b/deno/rest/v10/guild.ts
@@ -449,7 +449,7 @@ export interface RESTPutAPIGuildMemberJSONBody {
 	deaf?: boolean | undefined;
 }
 
-export type RESTPutAPIGuildMemberResult = APIGuildMember | never;
+export type RESTPutAPIGuildMemberResult = APIGuildMember | undefined;
 
 /**
  * https://discord.com/developers/docs/resources/guild#modify-guild-member

--- a/deno/rest/v8/guild.ts
+++ b/deno/rest/v8/guild.ts
@@ -454,7 +454,7 @@ export interface RESTPutAPIGuildMemberJSONBody {
 /**
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTPutAPIGuildMemberResult = APIGuildMember | never;
+export type RESTPutAPIGuildMemberResult = APIGuildMember | undefined;
 
 /**
  * https://discord.com/developers/docs/resources/guild#modify-guild-member

--- a/deno/rest/v9/guild.ts
+++ b/deno/rest/v9/guild.ts
@@ -449,7 +449,7 @@ export interface RESTPutAPIGuildMemberJSONBody {
 	deaf?: boolean | undefined;
 }
 
-export type RESTPutAPIGuildMemberResult = APIGuildMember | never;
+export type RESTPutAPIGuildMemberResult = APIGuildMember | undefined;
 
 /**
  * https://discord.com/developers/docs/resources/guild#modify-guild-member

--- a/rest/v10/guild.ts
+++ b/rest/v10/guild.ts
@@ -449,7 +449,7 @@ export interface RESTPutAPIGuildMemberJSONBody {
 	deaf?: boolean | undefined;
 }
 
-export type RESTPutAPIGuildMemberResult = APIGuildMember | never;
+export type RESTPutAPIGuildMemberResult = APIGuildMember | undefined;
 
 /**
  * https://discord.com/developers/docs/resources/guild#modify-guild-member

--- a/rest/v8/guild.ts
+++ b/rest/v8/guild.ts
@@ -454,7 +454,7 @@ export interface RESTPutAPIGuildMemberJSONBody {
 /**
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTPutAPIGuildMemberResult = APIGuildMember | never;
+export type RESTPutAPIGuildMemberResult = APIGuildMember | undefined;
 
 /**
  * https://discord.com/developers/docs/resources/guild#modify-guild-member

--- a/rest/v9/guild.ts
+++ b/rest/v9/guild.ts
@@ -449,7 +449,7 @@ export interface RESTPutAPIGuildMemberJSONBody {
 	deaf?: boolean | undefined;
 }
 
-export type RESTPutAPIGuildMemberResult = APIGuildMember | never;
+export type RESTPutAPIGuildMemberResult = APIGuildMember | undefined;
 
 /**
  * https://discord.com/developers/docs/resources/guild#modify-guild-member


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The usage of 'never' in discord-api-types for all API responses with a 204 (empty) response leads to potential confusion among developers due to implicit precedence given to the declared type in TypeScript. It is essential to diligently avoid such undesirable situations.

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**