### PR TITLE
feat: add `NoContent` generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,6 @@ The exports of each API version is split into three main parts:
 
   - If a type ends with `Result`, then it represents the expected result by calling its accompanying route.
 
-    - Types that are exported as `never` usually mean the result will be a `204 No Content`, so you can safely ignore it. This does **not** account for errors.
-
 - Anything else that is miscellaneous will be exported based on what it represents (for example the `REST` route object).
 
 - There may be types exported that are identical for all versions. These will be exported as is and can be found in the `globals` file. They will still be prefixed accordingly as described above.

--- a/deno/README.md
+++ b/deno/README.md
@@ -91,8 +91,6 @@ The exports of each API version is split into three main parts:
 
   - If a type ends with `Result`, then it represents the expected result by calling its accompanying route.
 
-    - Types that are exported as `never` usually mean the result will be a `204 No Content`, so you can safely ignore it. This does **not** account for errors.
-
 - Anything else that is miscellaneous will be exported based on what it represents (for example the `REST` route object).
 
 - There may be types exported that are identical for all versions. These will be exported as is and can be found in the `globals` file. They will still be prefixed accordingly as described above.

--- a/deno/rest/v10/autoModeration.ts
+++ b/deno/rest/v10/autoModeration.ts
@@ -80,4 +80,4 @@ export type RESTPatchAPIAutoModerationRuleResult = APIAutoModerationRule;
 /**
  * https://discord.com/developers/docs/resources/auto-moderation#delete-auto-moderation-rule
  */
-export type RESTDeleteAPIAutoModerationRuleResult = never;
+export type RESTDeleteAPIAutoModerationRuleResult<NoContent extends unknown = never> = NoContent;

--- a/deno/rest/v10/channel.ts
+++ b/deno/rest/v10/channel.ts
@@ -316,17 +316,17 @@ export type RESTPostAPIChannelMessageCrosspostResult = APIMessage;
 /**
  * https://discord.com/developers/docs/resources/channel#create-reaction
  */
-export type RESTPutAPIChannelMessageReactionResult = never;
+export type RESTPutAPIChannelMessageReactionResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#delete-own-reaction
  */
-export type RESTDeleteAPIChannelMessageOwnReaction = never;
+export type RESTDeleteAPIChannelMessageOwnReaction<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#delete-user-reaction
  */
-export type RESTDeleteAPIChannelMessageUserReactionResult = never;
+export type RESTDeleteAPIChannelMessageUserReactionResult<NoContent extends unknown = never> = NoContent;
 
 /*
  * https://discord.com/developers/docs/resources/channel#get-reactions
@@ -352,12 +352,12 @@ export type RESTGetAPIChannelMessageReactionUsersResult = APIUser[];
 /**
  * https://discord.com/developers/docs/resources/channel#delete-all-reactions
  */
-export type RESTDeleteAPIChannelAllMessageReactionsResult = never;
+export type RESTDeleteAPIChannelAllMessageReactionsResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#delete-all-reactions-for-emoji
  */
-export type RESTDeleteAPIChannelMessageReactionResult = never;
+export type RESTDeleteAPIChannelMessageReactionResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#edit-message
@@ -424,7 +424,7 @@ export type RESTPatchAPIChannelMessageResult = APIMessage;
 /**
  * https://discord.com/developers/docs/resources/channel#delete-message
  */
-export type RESTDeleteAPIChannelMessageResult = never;
+export type RESTDeleteAPIChannelMessageResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#bulk-delete-messages
@@ -439,7 +439,7 @@ export interface RESTPostAPIChannelMessagesBulkDeleteJSONBody {
 /**
  * https://discord.com/developers/docs/resources/channel#bulk-delete-messages
  */
-export type RESTPostAPIChannelMessagesBulkDeleteResult = never;
+export type RESTPostAPIChannelMessagesBulkDeleteResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#edit-channel-permissions
@@ -470,7 +470,7 @@ export interface RESTPutAPIChannelPermissionJSONBody {
 /**
  * https://discord.com/developers/docs/resources/channel#edit-channel-permissions
  */
-export type RESTPutAPIChannelPermissionResult = never;
+export type RESTPutAPIChannelPermissionResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#get-channel-invites
@@ -534,7 +534,7 @@ export type RESTPostAPIChannelInviteResult = APIExtendedInvite;
 /**
  * https://discord.com/developers/docs/resources/channel#delete-channel-permission
  */
-export type RESTDeleteAPIChannelPermissionResult = never;
+export type RESTDeleteAPIChannelPermissionResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#follow-news-channel
@@ -554,7 +554,7 @@ export type RESTPostAPIChannelFollowersResult = APIFollowedChannel;
 /**
  * https://discord.com/developers/docs/resources/channel#trigger-typing-indicator
  */
-export type RESTPostAPIChannelTypingResult = never;
+export type RESTPostAPIChannelTypingResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#get-pinned-messages
@@ -564,12 +564,12 @@ export type RESTGetAPIChannelPinsResult = APIMessage[];
 /**
  * https://discord.com/developers/docs/resources/channel#pin-message
  */
-export type RESTPutAPIChannelPinResult = never;
+export type RESTPutAPIChannelPinResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#unpin-message
  */
-export type RESTDeleteAPIChannelPinResult = never;
+export type RESTDeleteAPIChannelPinResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#group-dm-add-recipient
@@ -671,12 +671,12 @@ export type RESTPostAPIChannelThreadsResult = APIChannel;
 /**
  * https://discord.com/developers/docs/resources/channel#join-thread
  */
-export type RESTPutAPIChannelThreadMembersResult = never;
+export type RESTPutAPIChannelThreadMembersResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#leave-thread
  */
-export type RESTDeleteAPIChannelThreadMembersResult = never;
+export type RESTDeleteAPIChannelThreadMembersResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#get-thread-member

--- a/deno/rest/v10/emoji.ts
+++ b/deno/rest/v10/emoji.ts
@@ -58,4 +58,4 @@ export type RESTPatchAPIGuildEmojiResult = APIEmoji;
 /**
  * https://discord.com/developers/docs/resources/emoji#delete-guild-emoji
  */
-export type RESTDeleteAPIGuildEmojiResult = never;
+export type RESTDeleteAPIGuildEmojiResult<NoContent extends unknown = never> = NoContent;

--- a/deno/rest/v10/guild.ts
+++ b/deno/rest/v10/guild.ts
@@ -320,7 +320,7 @@ export type RESTPatchAPIGuildResult = APIGuild;
 /**
  * https://discord.com/developers/docs/resources/guild#delete-guild
  */
-export type RESTDeleteAPIGuildResult = never;
+export type RESTDeleteAPIGuildResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#get-guild-channels
@@ -362,7 +362,7 @@ export type RESTPatchAPIGuildChannelPositionsJSONBody = {
 /**
  * https://discord.com/developers/docs/resources/guild#modify-guild-channel-positions
  */
-export type RESTPatchAPIGuildChannelPositionsResult = never;
+export type RESTPatchAPIGuildChannelPositionsResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#list-active-guild-threads
@@ -449,7 +449,7 @@ export interface RESTPutAPIGuildMemberJSONBody {
 	deaf?: boolean | undefined;
 }
 
-export type RESTPutAPIGuildMemberResult = APIGuildMember | never;
+export type RESTPutAPIGuildMemberResult<NoContent extends unknown = never> = APIGuildMember | NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#modify-guild-member
@@ -533,17 +533,17 @@ export type RESTPatchAPICurrentGuildMemberNicknameResult =
 /**
  * https://discord.com/developers/docs/resources/guild#add-guild-member-role
  */
-export type RESTPutAPIGuildMemberRoleResult = never;
+export type RESTPutAPIGuildMemberRoleResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#remove-guild-member-role
  */
-export type RESTDeleteAPIGuildMemberRoleResult = never;
+export type RESTDeleteAPIGuildMemberRoleResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#remove-guild-member
  */
-export type RESTDeleteAPIGuildMemberResult = never;
+export type RESTDeleteAPIGuildMemberResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#get-guild-bans
@@ -594,12 +594,12 @@ export interface RESTPutAPIGuildBanJSONBody {
 /**
  * https://discord.com/developers/docs/resources/guild#create-guild-ban
  */
-export type RESTPutAPIGuildBanResult = never;
+export type RESTPutAPIGuildBanResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#remove-guild-ban
  */
-export type RESTDeleteAPIGuildBanResult = never;
+export type RESTDeleteAPIGuildBanResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#get-guild-roles
@@ -716,7 +716,7 @@ export type RESTPatchAPIGuildRoleResult = APIRole;
 /**
  * https://discord.com/developers/docs/resources/guild#delete-guild-role
  */
-export type RESTDeleteAPIGuildRoleResult = never;
+export type RESTDeleteAPIGuildRoleResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#get-guild-prune-count
@@ -793,7 +793,7 @@ export type RESTGetAPIGuildIntegrationsResult = APIGuildIntegration[];
 /**
  * https://discord.com/developers/docs/resources/guild#delete-guild-integration
  */
-export type RESTDeleteAPIGuildIntegrationResult = never;
+export type RESTDeleteAPIGuildIntegrationResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#get-guild-widget-settings
@@ -881,7 +881,7 @@ export interface RESTPatchAPIGuildVoiceStateCurrentMemberJSONBody {
 /**
  * https://discord.com/developers/docs/resources/guild#modify-current-user-voice-state
  */
-export type RESTPatchAPIGuildVoiceStateCurrentMemberResult = never;
+export type RESTPatchAPIGuildVoiceStateCurrentMemberResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#modify-user-voice-state
@@ -900,7 +900,7 @@ export interface RESTPatchAPIGuildVoiceStateUserJSONBody {
 /**
  * https://discord.com/developers/docs/resources/guild#modify-user-voice-state
  */
-export type RESTPatchAPIGuildVoiceStateUserResult = never;
+export type RESTPatchAPIGuildVoiceStateUserResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#get-guild-welcome-screen

--- a/deno/rest/v10/guildScheduledEvent.ts
+++ b/deno/rest/v10/guildScheduledEvent.ts
@@ -112,7 +112,7 @@ export type RESTPatchAPIGuildScheduledEventResult = APIGuildScheduledEvent;
 /**
  * https://discord.com/developers/docs/resources/guild-scheduled-event#delete-guild-scheduled-event
  */
-export type RESTDeleteAPIGuildScheduledEventResult = never;
+export type RESTDeleteAPIGuildScheduledEventResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild-scheduled-event#get-guild-scheduled-event-users

--- a/deno/rest/v10/stageInstance.ts
+++ b/deno/rest/v10/stageInstance.ts
@@ -57,4 +57,4 @@ export type RESTPatchAPIStageInstanceResult = APIStageInstance;
 /**
  * https://discord.com/developers/docs/resources/stage-instance#delete-stage-instance
  */
-export type RESTDeleteAPIStageInstanceResult = never;
+export type RESTDeleteAPIStageInstanceResult<NoContent extends unknown = never> = NoContent;

--- a/deno/rest/v10/sticker.ts
+++ b/deno/rest/v10/sticker.ts
@@ -77,4 +77,4 @@ export type RESTPatchAPIGuildStickerResult = APISticker;
 /**
  * https://discord.com/developers/docs/resources/sticker#delete-guild-sticker
  */
-export type RESTDeleteAPIGuildStickerResult = never;
+export type RESTDeleteAPIGuildStickerResult<NoContent extends unknown = never> = NoContent;

--- a/deno/rest/v10/user.ts
+++ b/deno/rest/v10/user.ts
@@ -87,7 +87,7 @@ export type RESTGetAPICurrentUserGuildsResult = RESTAPIPartialCurrentUserGuild[]
 /**
  * https://discord.com/developers/docs/resources/user#leave-guild
  */
-export type RESTDeleteAPICurrentUserGuildResult = never;
+export type RESTDeleteAPICurrentUserGuildResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/user#create-dm

--- a/deno/rest/v10/webhook.ts
+++ b/deno/rest/v10/webhook.ts
@@ -89,12 +89,12 @@ export type RESTPatchAPIWebhookWithTokenResult = RESTGetAPIWebhookWithTokenResul
 /**
  * https://discord.com/developers/docs/resources/webhook#delete-webhook
  */
-export type RESTDeleteAPIWebhookResult = never;
+export type RESTDeleteAPIWebhookResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/webhook#delete-webhook-with-token
  */
-export type RESTDeleteAPIWebhookWithTokenResult = never;
+export type RESTDeleteAPIWebhookWithTokenResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/webhook#execute-webhook
@@ -186,7 +186,7 @@ export interface RESTPostAPIWebhookWithTokenQuery {
 /**
  * https://discord.com/developers/docs/resources/webhook#execute-webhook
  */
-export type RESTPostAPIWebhookWithTokenResult = never;
+export type RESTPostAPIWebhookWithTokenResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * Received when a call to https://discord.com/developers/docs/resources/webhook#execute-webhook receives
@@ -204,7 +204,7 @@ export type RESTPostAPIWebhookWithTokenSlackQuery = RESTPostAPIWebhookWithTokenQ
 /**
  * https://discord.com/developers/docs/resources/webhook#execute-slackcompatible-webhook
  */
-export type RESTPostAPIWebhookWithTokenSlackResult = never;
+export type RESTPostAPIWebhookWithTokenSlackResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * Received when a call to https://discord.com/developers/docs/resources/webhook#execute-webhook receives
@@ -222,7 +222,7 @@ export type RESTPostAPIWebhookWithTokenGitHubQuery = RESTPostAPIWebhookWithToken
 /**
  * https://discord.com/developers/docs/resources/webhook#execute-githubcompatible-webhook
  */
-export type RESTPostAPIWebhookWithTokenGitHubResult = never;
+export type RESTPostAPIWebhookWithTokenGitHubResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * Received when a call to https://discord.com/developers/docs/resources/webhook#execute-webhook receives
@@ -280,4 +280,4 @@ export type RESTPatchAPIWebhookWithTokenMessageResult = APIMessage;
 /**
  * https://discord.com/developers/docs/resources/webhook#delete-webhook-message
  */
-export type RESTDeleteAPIWebhookWithTokenMessageResult = never;
+export type RESTDeleteAPIWebhookWithTokenMessageResult<NoContent extends unknown = never> = NoContent;

--- a/deno/rest/v6/channel.ts
+++ b/deno/rest/v6/channel.ts
@@ -173,7 +173,7 @@ export type RESTPatchAPIChannelMessageResult = APIMessage;
 /**
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTDeleteAPIChannelMessageResult = never;
+export type RESTDeleteAPIChannelMessageResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#get-reactions
@@ -194,17 +194,17 @@ export type RESTGetAPIChannelMessageReactionsResult = APIUser[];
 /**
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTPutAPIChannelMessageReactionResult = never;
+export type RESTPutAPIChannelMessageReactionResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTDeleteAPIChannelMessageReactionResult = never;
+export type RESTDeleteAPIChannelMessageReactionResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTDeleteAPIChannelAllMessageReactionsResult = never;
+export type RESTDeleteAPIChannelAllMessageReactionsResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#bulk-delete-messages
@@ -218,7 +218,7 @@ export interface RESTPostAPIChannelMessagesBulkDeleteJSONBody {
 /**
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTPostAPIChannelMessagesBulkDeleteResult = never;
+export type RESTPostAPIChannelMessagesBulkDeleteResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#edit-channel-permissions
@@ -234,12 +234,12 @@ export interface RESTPutAPIChannelPermissionsJSONBody {
 /**
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTPutAPIChannelPermissionsResult = never;
+export type RESTPutAPIChannelPermissionsResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTDeleteAPIChannelPermissionsResult = never;
+export type RESTDeleteAPIChannelPermissionsResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#get-channel-invites
@@ -265,7 +265,7 @@ export interface RESTPostAPIChannelInviteJSONBody {
  *
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTPostAPIChannelTypingResult = never;
+export type RESTPostAPIChannelTypingResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#get-pinned-messages
@@ -279,12 +279,12 @@ export type RESTGetAPIChannelPinsResult = APIMessage[];
  *
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTPutAPIChannelPinResult = never;
+export type RESTPutAPIChannelPinResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTDeleteAPIChannelPinResult = never;
+export type RESTDeleteAPIChannelPinResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#group-dm-add-recipient

--- a/deno/rest/v6/emoji.ts
+++ b/deno/rest/v6/emoji.ts
@@ -53,4 +53,4 @@ export type RESTPatchAPIGuildEmojiResult = APIEmoji;
  *
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTDeleteAPIGuildEmojiResult = never;
+export type RESTDeleteAPIGuildEmojiResult<NoContent extends unknown = never> = NoContent;

--- a/deno/rest/v6/guild.ts
+++ b/deno/rest/v6/guild.ts
@@ -125,7 +125,7 @@ export type RESTPatchAPIGuildResult = APIGuild;
  *
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTDeleteAPIGuildResult = never;
+export type RESTDeleteAPIGuildResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#get-guild-channels
@@ -167,7 +167,7 @@ export type RESTPatchAPIGuildChannelPositionsJSONBody = {
 /**
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTPatchAPIGuildChannelPositionsResult = never;
+export type RESTPatchAPIGuildChannelPositionsResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#get-guild-member
@@ -238,7 +238,7 @@ export interface RESTPatchAPIGuildMemberJSONBody {
 /**
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTPatchAPIGuildMemberResult = never;
+export type RESTPatchAPIGuildMemberResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#modify-current-user-nick
@@ -259,21 +259,21 @@ export type RESTPatchAPICurrentGuildMemberNicknameResult = Required<RESTPatchAPI
  *
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTPutAPIGuildMemberRoleResult = never;
+export type RESTPutAPIGuildMemberRoleResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#remove-guild-member-role
  *
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTDeleteAPIGuildMemberRoleResult = never;
+export type RESTDeleteAPIGuildMemberRoleResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#remove-guild-member
  *
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTDeleteAPIGuildMemberResult = never;
+export type RESTDeleteAPIGuildMemberResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#get-guild-bans
@@ -302,14 +302,14 @@ export interface RESTPutAPIGuildBanJSONBody {
 /**
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTPutAPIGuildBanResult = never;
+export type RESTPutAPIGuildBanResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#remove-guild-ban
  *
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTDeleteAPIGuildBanResult = never;
+export type RESTDeleteAPIGuildBanResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#get-guild-roles
@@ -374,7 +374,7 @@ export type RESTPatchAPIGuildRoleResult = APIRole;
  *
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTDeleteAPIGuildRoleResult = never;
+export type RESTDeleteAPIGuildRoleResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#get-guild-prune-count
@@ -458,7 +458,7 @@ export interface RESTPostAPIGuildIntegrationJSONBody {
 /**
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTPostAPIGuildIntegrationResult = never;
+export type RESTPostAPIGuildIntegrationResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#modify-guild-integration
@@ -474,21 +474,21 @@ export interface RESTPatchAPIGuildIntegrationJSONBody {
 /**
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTPatchAPIGuildIntegrationResult = never;
+export type RESTPatchAPIGuildIntegrationResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#delete-guild-integration
  *
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTDeleteAPIGuildIntegrationResult = never;
+export type RESTDeleteAPIGuildIntegrationResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#sync-guild-integration
  *
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTPostAPIGuildIntegrationSyncResult = never;
+export type RESTPostAPIGuildIntegrationSyncResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * @deprecated Renamed to RESTGetAPIGuildWidgetSettingsResult

--- a/deno/rest/v6/user.ts
+++ b/deno/rest/v6/user.ts
@@ -66,7 +66,7 @@ export type RESTGetAPICurrentUserGuildsResult = RESTAPIPartialCurrentUserGuild[]
  *
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTDeleteAPICurrentUserGuildResult = never;
+export type RESTDeleteAPICurrentUserGuildResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/user#create-dm

--- a/deno/rest/v6/webhook.ts
+++ b/deno/rest/v6/webhook.ts
@@ -77,12 +77,12 @@ export type RESTPatchAPIWebhookWithTokenResult = Omit<APIWebhook, 'user'>;
  *
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTDeleteAPIWebhookResult = never;
+export type RESTDeleteAPIWebhookResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTDeleteAPIWebhookWithTokenResult = never;
+export type RESTDeleteAPIWebhookWithTokenResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/webhook#execute-webhook
@@ -133,7 +133,7 @@ export interface RESTPostAPIWebhookWithTokenQuery {
 /**
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTPostAPIWebhookWithTokenResult = never;
+export type RESTPostAPIWebhookWithTokenResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * Received when a call to POST `/webhooks/{webhook.id}/{webhook.token}` receives

--- a/deno/rest/v8/channel.ts
+++ b/deno/rest/v8/channel.ts
@@ -285,21 +285,21 @@ export type RESTPostAPIChannelMessageCrosspostResult = APIMessage;
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTPutAPIChannelMessageReactionResult = never;
+export type RESTPutAPIChannelMessageReactionResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#delete-own-reaction
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTDeleteAPIChannelMessageOwnReaction = never;
+export type RESTDeleteAPIChannelMessageOwnReaction<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#delete-user-reaction
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTDeleteAPIChannelMessageUserReactionResult = never;
+export type RESTDeleteAPIChannelMessageUserReactionResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#get-reactions
@@ -331,14 +331,14 @@ export type RESTGetAPIChannelMessageReactionUsersResult = APIUser[];
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTDeleteAPIChannelAllMessageReactionsResult = never;
+export type RESTDeleteAPIChannelAllMessageReactionsResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#delete-all-reactions-for-emoji
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTDeleteAPIChannelMessageReactionResult = never;
+export type RESTDeleteAPIChannelMessageReactionResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#edit-message
@@ -421,7 +421,7 @@ export type RESTPatchAPIChannelMessageResult = APIMessage;
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTDeleteAPIChannelMessageResult = never;
+export type RESTDeleteAPIChannelMessageResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#bulk-delete-messages
@@ -440,7 +440,7 @@ export interface RESTPostAPIChannelMessagesBulkDeleteJSONBody {
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTPostAPIChannelMessagesBulkDeleteResult = never;
+export type RESTPostAPIChannelMessagesBulkDeleteResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#edit-channel-permissions
@@ -475,7 +475,7 @@ export interface RESTPutAPIChannelPermissionJSONBody {
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTPutAPIChannelPermissionResult = never;
+export type RESTPutAPIChannelPermissionResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#get-channel-invites
@@ -547,7 +547,7 @@ export type RESTPostAPIChannelInviteResult = APIExtendedInvite;
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTDeleteAPIChannelPermissionResult = never;
+export type RESTDeleteAPIChannelPermissionResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#follow-news-channel
@@ -573,7 +573,7 @@ export type RESTPostAPIChannelFollowersResult = APIFollowedChannel;
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTPostAPIChannelTypingResult = never;
+export type RESTPostAPIChannelTypingResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#get-pinned-messages
@@ -587,14 +587,14 @@ export type RESTGetAPIChannelPinsResult = APIMessage[];
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTPutAPIChannelPinResult = never;
+export type RESTPutAPIChannelPinResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#delete-pinned-channel-message
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTDeleteAPIChannelPinResult = never;
+export type RESTDeleteAPIChannelPinResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#group-dm-add-recipient

--- a/deno/rest/v8/emoji.ts
+++ b/deno/rest/v8/emoji.ts
@@ -72,4 +72,4 @@ export type RESTPatchAPIGuildEmojiResult = APIEmoji;
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTDeleteAPIGuildEmojiResult = never;
+export type RESTDeleteAPIGuildEmojiResult<NoContent extends unknown = never> = NoContent;

--- a/deno/rest/v8/guild.ts
+++ b/deno/rest/v8/guild.ts
@@ -304,7 +304,7 @@ export type RESTPatchAPIGuildResult = APIGuild;
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTDeleteAPIGuildResult = never;
+export type RESTDeleteAPIGuildResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#get-guild-channels
@@ -356,7 +356,7 @@ export type RESTPatchAPIGuildChannelPositionsJSONBody = {
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTPatchAPIGuildChannelPositionsResult = never;
+export type RESTPatchAPIGuildChannelPositionsResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#get-guild-member
@@ -454,7 +454,7 @@ export interface RESTPutAPIGuildMemberJSONBody {
 /**
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTPutAPIGuildMemberResult = APIGuildMember | never;
+export type RESTPutAPIGuildMemberResult<NoContent extends unknown = never> = APIGuildMember | NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#modify-guild-member
@@ -548,21 +548,21 @@ export type RESTPatchAPICurrentGuildMemberNicknameResult =
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTPutAPIGuildMemberRoleResult = never;
+export type RESTPutAPIGuildMemberRoleResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#remove-guild-member-role
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTDeleteAPIGuildMemberRoleResult = never;
+export type RESTDeleteAPIGuildMemberRoleResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#remove-guild-member
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTDeleteAPIGuildMemberResult = never;
+export type RESTDeleteAPIGuildMemberResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#get-guild-bans
@@ -601,14 +601,14 @@ export interface RESTPutAPIGuildBanJSONBody {
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTPutAPIGuildBanResult = never;
+export type RESTPutAPIGuildBanResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#remove-guild-ban
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTDeleteAPIGuildBanResult = never;
+export type RESTDeleteAPIGuildBanResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#get-guild-roles
@@ -741,7 +741,7 @@ export type RESTPatchAPIGuildRoleResult = APIRole;
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTDeleteAPIGuildRoleResult = never;
+export type RESTDeleteAPIGuildRoleResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#get-guild-prune-count
@@ -834,7 +834,7 @@ export type RESTGetAPIGuildIntegrationsResult = APIGuildIntegration[];
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTDeleteAPIGuildIntegrationResult = never;
+export type RESTDeleteAPIGuildIntegrationResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#get-guild-widget-settings

--- a/deno/rest/v8/guildScheduledEvent.ts
+++ b/deno/rest/v8/guildScheduledEvent.ts
@@ -122,7 +122,7 @@ export type RESTPatchAPIGuildScheduledEventResult = APIGuildScheduledEvent;
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTDeleteAPIGuildScheduledEventResult = never;
+export type RESTDeleteAPIGuildScheduledEventResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild-scheduled-event#get-guild-scheduled-event-users

--- a/deno/rest/v8/stageInstance.ts
+++ b/deno/rest/v8/stageInstance.ts
@@ -65,4 +65,4 @@ export type RESTPatchAPIStageInstanceResult = APIStageInstance;
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTDeleteAPIStageInstanceResult = never;
+export type RESTDeleteAPIStageInstanceResult<NoContent extends unknown = never> = NoContent;

--- a/deno/rest/v8/sticker.ts
+++ b/deno/rest/v8/sticker.ts
@@ -75,4 +75,4 @@ export type RESTPatchAPIGuildStickerResult = APISticker;
 /**
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTDeleteAPIGuildStickerResult = never;
+export type RESTDeleteAPIGuildStickerResult<NoContent extends unknown = never> = NoContent;

--- a/deno/rest/v8/user.ts
+++ b/deno/rest/v8/user.ts
@@ -91,7 +91,7 @@ export type RESTGetAPICurrentUserGuildsResult = RESTAPIPartialCurrentUserGuild[]
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTDeleteAPICurrentUserGuildResult = never;
+export type RESTDeleteAPICurrentUserGuildResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/user#create-dm

--- a/deno/rest/v8/webhook.ts
+++ b/deno/rest/v8/webhook.ts
@@ -112,14 +112,14 @@ export type RESTPatchAPIWebhookWithTokenResult = RESTGetAPIWebhookWithTokenResul
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTDeleteAPIWebhookResult = never;
+export type RESTDeleteAPIWebhookResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/webhook#delete-webhook-with-token
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTDeleteAPIWebhookWithTokenResult = never;
+export type RESTDeleteAPIWebhookWithTokenResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/webhook#execute-webhook
@@ -211,7 +211,7 @@ export interface RESTPostAPIWebhookWithTokenQuery {
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTPostAPIWebhookWithTokenResult = never;
+export type RESTPostAPIWebhookWithTokenResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * Received when a call to https://discord.com/developers/docs/resources/webhook#execute-webhook receives
@@ -235,7 +235,7 @@ export type RESTPostAPIWebhookWithTokenSlackQuery = RESTPostAPIWebhookWithTokenQ
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTPostAPIWebhookWithTokenSlackResult = never;
+export type RESTPostAPIWebhookWithTokenSlackResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * Received when a call to https://discord.com/developers/docs/resources/webhook#execute-webhook receives
@@ -259,7 +259,7 @@ export type RESTPostAPIWebhookWithTokenGitHubQuery = RESTPostAPIWebhookWithToken
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTPostAPIWebhookWithTokenGitHubResult = never;
+export type RESTPostAPIWebhookWithTokenGitHubResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * Received when a call to https://discord.com/developers/docs/resources/webhook#execute-webhook receives
@@ -322,4 +322,4 @@ export type RESTPatchAPIWebhookWithTokenMessageResult = APIMessage;
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTDeleteAPIWebhookWithTokenMessageResult = never;
+export type RESTDeleteAPIWebhookWithTokenMessageResult<NoContent extends unknown = never> = NoContent;

--- a/deno/rest/v9/autoModeration.ts
+++ b/deno/rest/v9/autoModeration.ts
@@ -80,4 +80,4 @@ export type RESTPatchAPIAutoModerationRuleResult = APIAutoModerationRule;
 /**
  * https://discord.com/developers/docs/resources/auto-moderation#delete-auto-moderation-rule
  */
-export type RESTDeleteAPIAutoModerationRuleResult = never;
+export type RESTDeleteAPIAutoModerationRuleResult<NoContent extends unknown = never> = NoContent;

--- a/deno/rest/v9/channel.ts
+++ b/deno/rest/v9/channel.ts
@@ -324,17 +324,17 @@ export type RESTPostAPIChannelMessageCrosspostResult = APIMessage;
 /**
  * https://discord.com/developers/docs/resources/channel#create-reaction
  */
-export type RESTPutAPIChannelMessageReactionResult = never;
+export type RESTPutAPIChannelMessageReactionResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#delete-own-reaction
  */
-export type RESTDeleteAPIChannelMessageOwnReaction = never;
+export type RESTDeleteAPIChannelMessageOwnReaction<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#delete-user-reaction
  */
-export type RESTDeleteAPIChannelMessageUserReactionResult = never;
+export type RESTDeleteAPIChannelMessageUserReactionResult<NoContent extends unknown = never> = NoContent;
 
 /*
  * https://discord.com/developers/docs/resources/channel#get-reactions
@@ -360,12 +360,12 @@ export type RESTGetAPIChannelMessageReactionUsersResult = APIUser[];
 /**
  * https://discord.com/developers/docs/resources/channel#delete-all-reactions
  */
-export type RESTDeleteAPIChannelAllMessageReactionsResult = never;
+export type RESTDeleteAPIChannelAllMessageReactionsResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#delete-all-reactions-for-emoji
  */
-export type RESTDeleteAPIChannelMessageReactionResult = never;
+export type RESTDeleteAPIChannelMessageReactionResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#edit-message
@@ -440,7 +440,7 @@ export type RESTPatchAPIChannelMessageResult = APIMessage;
 /**
  * https://discord.com/developers/docs/resources/channel#delete-message
  */
-export type RESTDeleteAPIChannelMessageResult = never;
+export type RESTDeleteAPIChannelMessageResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#bulk-delete-messages
@@ -455,7 +455,7 @@ export interface RESTPostAPIChannelMessagesBulkDeleteJSONBody {
 /**
  * https://discord.com/developers/docs/resources/channel#bulk-delete-messages
  */
-export type RESTPostAPIChannelMessagesBulkDeleteResult = never;
+export type RESTPostAPIChannelMessagesBulkDeleteResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#edit-channel-permissions
@@ -486,7 +486,7 @@ export interface RESTPutAPIChannelPermissionJSONBody {
 /**
  * https://discord.com/developers/docs/resources/channel#edit-channel-permissions
  */
-export type RESTPutAPIChannelPermissionResult = never;
+export type RESTPutAPIChannelPermissionResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#get-channel-invites
@@ -550,7 +550,7 @@ export type RESTPostAPIChannelInviteResult = APIExtendedInvite;
 /**
  * https://discord.com/developers/docs/resources/channel#delete-channel-permission
  */
-export type RESTDeleteAPIChannelPermissionResult = never;
+export type RESTDeleteAPIChannelPermissionResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#follow-news-channel
@@ -570,7 +570,7 @@ export type RESTPostAPIChannelFollowersResult = APIFollowedChannel;
 /**
  * https://discord.com/developers/docs/resources/channel#trigger-typing-indicator
  */
-export type RESTPostAPIChannelTypingResult = never;
+export type RESTPostAPIChannelTypingResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#get-pinned-messages
@@ -580,12 +580,12 @@ export type RESTGetAPIChannelPinsResult = APIMessage[];
 /**
  * https://discord.com/developers/docs/resources/channel#pin-message
  */
-export type RESTPutAPIChannelPinResult = never;
+export type RESTPutAPIChannelPinResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#unpin-message
  */
-export type RESTDeleteAPIChannelPinResult = never;
+export type RESTDeleteAPIChannelPinResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#group-dm-add-recipient
@@ -687,12 +687,12 @@ export type RESTPostAPIChannelThreadsResult = APIChannel;
 /**
  * https://discord.com/developers/docs/resources/channel#join-thread
  */
-export type RESTPutAPIChannelThreadMembersResult = never;
+export type RESTPutAPIChannelThreadMembersResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#leave-thread
  */
-export type RESTDeleteAPIChannelThreadMembersResult = never;
+export type RESTDeleteAPIChannelThreadMembersResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#get-thread-member

--- a/deno/rest/v9/emoji.ts
+++ b/deno/rest/v9/emoji.ts
@@ -58,4 +58,4 @@ export type RESTPatchAPIGuildEmojiResult = APIEmoji;
 /**
  * https://discord.com/developers/docs/resources/emoji#delete-guild-emoji
  */
-export type RESTDeleteAPIGuildEmojiResult = never;
+export type RESTDeleteAPIGuildEmojiResult<NoContent extends unknown = never> = NoContent;

--- a/deno/rest/v9/guild.ts
+++ b/deno/rest/v9/guild.ts
@@ -320,7 +320,7 @@ export type RESTPatchAPIGuildResult = APIGuild;
 /**
  * https://discord.com/developers/docs/resources/guild#delete-guild
  */
-export type RESTDeleteAPIGuildResult = never;
+export type RESTDeleteAPIGuildResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#get-guild-channels
@@ -362,7 +362,7 @@ export type RESTPatchAPIGuildChannelPositionsJSONBody = {
 /**
  * https://discord.com/developers/docs/resources/guild#modify-guild-channel-positions
  */
-export type RESTPatchAPIGuildChannelPositionsResult = never;
+export type RESTPatchAPIGuildChannelPositionsResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#list-active-guild-threads
@@ -449,7 +449,7 @@ export interface RESTPutAPIGuildMemberJSONBody {
 	deaf?: boolean | undefined;
 }
 
-export type RESTPutAPIGuildMemberResult = APIGuildMember | never;
+export type RESTPutAPIGuildMemberResult<NoContent extends unknown = never> = APIGuildMember | NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#modify-guild-member
@@ -533,17 +533,17 @@ export type RESTPatchAPICurrentGuildMemberNicknameResult =
 /**
  * https://discord.com/developers/docs/resources/guild#add-guild-member-role
  */
-export type RESTPutAPIGuildMemberRoleResult = never;
+export type RESTPutAPIGuildMemberRoleResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#remove-guild-member-role
  */
-export type RESTDeleteAPIGuildMemberRoleResult = never;
+export type RESTDeleteAPIGuildMemberRoleResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#remove-guild-member
  */
-export type RESTDeleteAPIGuildMemberResult = never;
+export type RESTDeleteAPIGuildMemberResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#get-guild-bans
@@ -600,12 +600,12 @@ export interface RESTPutAPIGuildBanJSONBody {
 /**
  * https://discord.com/developers/docs/resources/guild#create-guild-ban
  */
-export type RESTPutAPIGuildBanResult = never;
+export type RESTPutAPIGuildBanResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#remove-guild-ban
  */
-export type RESTDeleteAPIGuildBanResult = never;
+export type RESTDeleteAPIGuildBanResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#get-guild-roles
@@ -722,7 +722,7 @@ export type RESTPatchAPIGuildRoleResult = APIRole;
 /**
  * https://discord.com/developers/docs/resources/guild#delete-guild-role
  */
-export type RESTDeleteAPIGuildRoleResult = never;
+export type RESTDeleteAPIGuildRoleResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#get-guild-prune-count
@@ -799,7 +799,7 @@ export type RESTGetAPIGuildIntegrationsResult = APIGuildIntegration[];
 /**
  * https://discord.com/developers/docs/resources/guild#delete-guild-integration
  */
-export type RESTDeleteAPIGuildIntegrationResult = never;
+export type RESTDeleteAPIGuildIntegrationResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#get-guild-widget-settings
@@ -887,7 +887,7 @@ export interface RESTPatchAPIGuildVoiceStateCurrentMemberJSONBody {
 /**
  * https://discord.com/developers/docs/resources/guild#modify-current-user-voice-state
  */
-export type RESTPatchAPIGuildVoiceStateCurrentMemberResult = never;
+export type RESTPatchAPIGuildVoiceStateCurrentMemberResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#modify-user-voice-state
@@ -906,7 +906,7 @@ export interface RESTPatchAPIGuildVoiceStateUserJSONBody {
 /**
  * https://discord.com/developers/docs/resources/guild#modify-user-voice-state
  */
-export type RESTPatchAPIGuildVoiceStateUserResult = never;
+export type RESTPatchAPIGuildVoiceStateUserResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#get-guild-welcome-screen

--- a/deno/rest/v9/guildScheduledEvent.ts
+++ b/deno/rest/v9/guildScheduledEvent.ts
@@ -112,7 +112,7 @@ export type RESTPatchAPIGuildScheduledEventResult = APIGuildScheduledEvent;
 /**
  * https://discord.com/developers/docs/resources/guild-scheduled-event#delete-guild-scheduled-event
  */
-export type RESTDeleteAPIGuildScheduledEventResult = never;
+export type RESTDeleteAPIGuildScheduledEventResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild-scheduled-event#get-guild-scheduled-event-users

--- a/deno/rest/v9/stageInstance.ts
+++ b/deno/rest/v9/stageInstance.ts
@@ -57,4 +57,4 @@ export type RESTPatchAPIStageInstanceResult = APIStageInstance;
 /**
  * https://discord.com/developers/docs/resources/stage-instance#delete-stage-instance
  */
-export type RESTDeleteAPIStageInstanceResult = never;
+export type RESTDeleteAPIStageInstanceResult<NoContent extends unknown = never> = NoContent;

--- a/deno/rest/v9/sticker.ts
+++ b/deno/rest/v9/sticker.ts
@@ -77,4 +77,4 @@ export type RESTPatchAPIGuildStickerResult = APISticker;
 /**
  * https://discord.com/developers/docs/resources/sticker#delete-guild-sticker
  */
-export type RESTDeleteAPIGuildStickerResult = never;
+export type RESTDeleteAPIGuildStickerResult<NoContent extends unknown = never> = NoContent;

--- a/deno/rest/v9/user.ts
+++ b/deno/rest/v9/user.ts
@@ -87,7 +87,7 @@ export type RESTGetAPICurrentUserGuildsResult = RESTAPIPartialCurrentUserGuild[]
 /**
  * https://discord.com/developers/docs/resources/user#leave-guild
  */
-export type RESTDeleteAPICurrentUserGuildResult = never;
+export type RESTDeleteAPICurrentUserGuildResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/user#create-dm

--- a/deno/rest/v9/webhook.ts
+++ b/deno/rest/v9/webhook.ts
@@ -89,12 +89,12 @@ export type RESTPatchAPIWebhookWithTokenResult = RESTGetAPIWebhookWithTokenResul
 /**
  * https://discord.com/developers/docs/resources/webhook#delete-webhook
  */
-export type RESTDeleteAPIWebhookResult = never;
+export type RESTDeleteAPIWebhookResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/webhook#delete-webhook-with-token
  */
-export type RESTDeleteAPIWebhookWithTokenResult = never;
+export type RESTDeleteAPIWebhookWithTokenResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/webhook#execute-webhook
@@ -186,7 +186,7 @@ export interface RESTPostAPIWebhookWithTokenQuery {
 /**
  * https://discord.com/developers/docs/resources/webhook#execute-webhook
  */
-export type RESTPostAPIWebhookWithTokenResult = never;
+export type RESTPostAPIWebhookWithTokenResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * Received when a call to https://discord.com/developers/docs/resources/webhook#execute-webhook receives
@@ -204,7 +204,7 @@ export type RESTPostAPIWebhookWithTokenSlackQuery = RESTPostAPIWebhookWithTokenQ
 /**
  * https://discord.com/developers/docs/resources/webhook#execute-slackcompatible-webhook
  */
-export type RESTPostAPIWebhookWithTokenSlackResult = never;
+export type RESTPostAPIWebhookWithTokenSlackResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * Received when a call to https://discord.com/developers/docs/resources/webhook#execute-webhook receives
@@ -222,7 +222,7 @@ export type RESTPostAPIWebhookWithTokenGitHubQuery = RESTPostAPIWebhookWithToken
 /**
  * https://discord.com/developers/docs/resources/webhook#execute-githubcompatible-webhook
  */
-export type RESTPostAPIWebhookWithTokenGitHubResult = never;
+export type RESTPostAPIWebhookWithTokenGitHubResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * Received when a call to https://discord.com/developers/docs/resources/webhook#execute-webhook receives
@@ -280,4 +280,4 @@ export type RESTPatchAPIWebhookWithTokenMessageResult = APIMessage;
 /**
  * https://discord.com/developers/docs/resources/webhook#delete-webhook-message
  */
-export type RESTDeleteAPIWebhookWithTokenMessageResult = never;
+export type RESTDeleteAPIWebhookWithTokenMessageResult<NoContent extends unknown = never> = NoContent;

--- a/rest/v10/autoModeration.ts
+++ b/rest/v10/autoModeration.ts
@@ -80,4 +80,4 @@ export type RESTPatchAPIAutoModerationRuleResult = APIAutoModerationRule;
 /**
  * https://discord.com/developers/docs/resources/auto-moderation#delete-auto-moderation-rule
  */
-export type RESTDeleteAPIAutoModerationRuleResult = never;
+export type RESTDeleteAPIAutoModerationRuleResult<NoContent extends unknown = never> = NoContent;

--- a/rest/v10/channel.ts
+++ b/rest/v10/channel.ts
@@ -316,17 +316,17 @@ export type RESTPostAPIChannelMessageCrosspostResult = APIMessage;
 /**
  * https://discord.com/developers/docs/resources/channel#create-reaction
  */
-export type RESTPutAPIChannelMessageReactionResult = never;
+export type RESTPutAPIChannelMessageReactionResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#delete-own-reaction
  */
-export type RESTDeleteAPIChannelMessageOwnReaction = never;
+export type RESTDeleteAPIChannelMessageOwnReaction<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#delete-user-reaction
  */
-export type RESTDeleteAPIChannelMessageUserReactionResult = never;
+export type RESTDeleteAPIChannelMessageUserReactionResult<NoContent extends unknown = never> = NoContent;
 
 /*
  * https://discord.com/developers/docs/resources/channel#get-reactions
@@ -352,12 +352,12 @@ export type RESTGetAPIChannelMessageReactionUsersResult = APIUser[];
 /**
  * https://discord.com/developers/docs/resources/channel#delete-all-reactions
  */
-export type RESTDeleteAPIChannelAllMessageReactionsResult = never;
+export type RESTDeleteAPIChannelAllMessageReactionsResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#delete-all-reactions-for-emoji
  */
-export type RESTDeleteAPIChannelMessageReactionResult = never;
+export type RESTDeleteAPIChannelMessageReactionResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#edit-message
@@ -424,7 +424,7 @@ export type RESTPatchAPIChannelMessageResult = APIMessage;
 /**
  * https://discord.com/developers/docs/resources/channel#delete-message
  */
-export type RESTDeleteAPIChannelMessageResult = never;
+export type RESTDeleteAPIChannelMessageResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#bulk-delete-messages
@@ -439,7 +439,7 @@ export interface RESTPostAPIChannelMessagesBulkDeleteJSONBody {
 /**
  * https://discord.com/developers/docs/resources/channel#bulk-delete-messages
  */
-export type RESTPostAPIChannelMessagesBulkDeleteResult = never;
+export type RESTPostAPIChannelMessagesBulkDeleteResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#edit-channel-permissions
@@ -470,7 +470,7 @@ export interface RESTPutAPIChannelPermissionJSONBody {
 /**
  * https://discord.com/developers/docs/resources/channel#edit-channel-permissions
  */
-export type RESTPutAPIChannelPermissionResult = never;
+export type RESTPutAPIChannelPermissionResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#get-channel-invites
@@ -534,7 +534,7 @@ export type RESTPostAPIChannelInviteResult = APIExtendedInvite;
 /**
  * https://discord.com/developers/docs/resources/channel#delete-channel-permission
  */
-export type RESTDeleteAPIChannelPermissionResult = never;
+export type RESTDeleteAPIChannelPermissionResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#follow-news-channel
@@ -554,7 +554,7 @@ export type RESTPostAPIChannelFollowersResult = APIFollowedChannel;
 /**
  * https://discord.com/developers/docs/resources/channel#trigger-typing-indicator
  */
-export type RESTPostAPIChannelTypingResult = never;
+export type RESTPostAPIChannelTypingResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#get-pinned-messages
@@ -564,12 +564,12 @@ export type RESTGetAPIChannelPinsResult = APIMessage[];
 /**
  * https://discord.com/developers/docs/resources/channel#pin-message
  */
-export type RESTPutAPIChannelPinResult = never;
+export type RESTPutAPIChannelPinResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#unpin-message
  */
-export type RESTDeleteAPIChannelPinResult = never;
+export type RESTDeleteAPIChannelPinResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#group-dm-add-recipient
@@ -671,12 +671,12 @@ export type RESTPostAPIChannelThreadsResult = APIChannel;
 /**
  * https://discord.com/developers/docs/resources/channel#join-thread
  */
-export type RESTPutAPIChannelThreadMembersResult = never;
+export type RESTPutAPIChannelThreadMembersResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#leave-thread
  */
-export type RESTDeleteAPIChannelThreadMembersResult = never;
+export type RESTDeleteAPIChannelThreadMembersResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#get-thread-member

--- a/rest/v10/emoji.ts
+++ b/rest/v10/emoji.ts
@@ -58,4 +58,4 @@ export type RESTPatchAPIGuildEmojiResult = APIEmoji;
 /**
  * https://discord.com/developers/docs/resources/emoji#delete-guild-emoji
  */
-export type RESTDeleteAPIGuildEmojiResult = never;
+export type RESTDeleteAPIGuildEmojiResult<NoContent extends unknown = never> = NoContent;

--- a/rest/v10/guild.ts
+++ b/rest/v10/guild.ts
@@ -320,7 +320,7 @@ export type RESTPatchAPIGuildResult = APIGuild;
 /**
  * https://discord.com/developers/docs/resources/guild#delete-guild
  */
-export type RESTDeleteAPIGuildResult = never;
+export type RESTDeleteAPIGuildResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#get-guild-channels
@@ -362,7 +362,7 @@ export type RESTPatchAPIGuildChannelPositionsJSONBody = {
 /**
  * https://discord.com/developers/docs/resources/guild#modify-guild-channel-positions
  */
-export type RESTPatchAPIGuildChannelPositionsResult = never;
+export type RESTPatchAPIGuildChannelPositionsResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#list-active-guild-threads
@@ -449,7 +449,7 @@ export interface RESTPutAPIGuildMemberJSONBody {
 	deaf?: boolean | undefined;
 }
 
-export type RESTPutAPIGuildMemberResult = APIGuildMember | never;
+export type RESTPutAPIGuildMemberResult<NoContent extends unknown = never> = APIGuildMember | NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#modify-guild-member
@@ -533,17 +533,17 @@ export type RESTPatchAPICurrentGuildMemberNicknameResult =
 /**
  * https://discord.com/developers/docs/resources/guild#add-guild-member-role
  */
-export type RESTPutAPIGuildMemberRoleResult = never;
+export type RESTPutAPIGuildMemberRoleResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#remove-guild-member-role
  */
-export type RESTDeleteAPIGuildMemberRoleResult = never;
+export type RESTDeleteAPIGuildMemberRoleResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#remove-guild-member
  */
-export type RESTDeleteAPIGuildMemberResult = never;
+export type RESTDeleteAPIGuildMemberResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#get-guild-bans
@@ -594,12 +594,12 @@ export interface RESTPutAPIGuildBanJSONBody {
 /**
  * https://discord.com/developers/docs/resources/guild#create-guild-ban
  */
-export type RESTPutAPIGuildBanResult = never;
+export type RESTPutAPIGuildBanResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#remove-guild-ban
  */
-export type RESTDeleteAPIGuildBanResult = never;
+export type RESTDeleteAPIGuildBanResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#get-guild-roles
@@ -716,7 +716,7 @@ export type RESTPatchAPIGuildRoleResult = APIRole;
 /**
  * https://discord.com/developers/docs/resources/guild#delete-guild-role
  */
-export type RESTDeleteAPIGuildRoleResult = never;
+export type RESTDeleteAPIGuildRoleResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#get-guild-prune-count
@@ -793,7 +793,7 @@ export type RESTGetAPIGuildIntegrationsResult = APIGuildIntegration[];
 /**
  * https://discord.com/developers/docs/resources/guild#delete-guild-integration
  */
-export type RESTDeleteAPIGuildIntegrationResult = never;
+export type RESTDeleteAPIGuildIntegrationResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#get-guild-widget-settings
@@ -881,7 +881,7 @@ export interface RESTPatchAPIGuildVoiceStateCurrentMemberJSONBody {
 /**
  * https://discord.com/developers/docs/resources/guild#modify-current-user-voice-state
  */
-export type RESTPatchAPIGuildVoiceStateCurrentMemberResult = never;
+export type RESTPatchAPIGuildVoiceStateCurrentMemberResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#modify-user-voice-state
@@ -900,7 +900,7 @@ export interface RESTPatchAPIGuildVoiceStateUserJSONBody {
 /**
  * https://discord.com/developers/docs/resources/guild#modify-user-voice-state
  */
-export type RESTPatchAPIGuildVoiceStateUserResult = never;
+export type RESTPatchAPIGuildVoiceStateUserResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#get-guild-welcome-screen

--- a/rest/v10/guildScheduledEvent.ts
+++ b/rest/v10/guildScheduledEvent.ts
@@ -112,7 +112,7 @@ export type RESTPatchAPIGuildScheduledEventResult = APIGuildScheduledEvent;
 /**
  * https://discord.com/developers/docs/resources/guild-scheduled-event#delete-guild-scheduled-event
  */
-export type RESTDeleteAPIGuildScheduledEventResult = never;
+export type RESTDeleteAPIGuildScheduledEventResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild-scheduled-event#get-guild-scheduled-event-users

--- a/rest/v10/stageInstance.ts
+++ b/rest/v10/stageInstance.ts
@@ -57,4 +57,4 @@ export type RESTPatchAPIStageInstanceResult = APIStageInstance;
 /**
  * https://discord.com/developers/docs/resources/stage-instance#delete-stage-instance
  */
-export type RESTDeleteAPIStageInstanceResult = never;
+export type RESTDeleteAPIStageInstanceResult<NoContent extends unknown = never> = NoContent;

--- a/rest/v10/sticker.ts
+++ b/rest/v10/sticker.ts
@@ -77,4 +77,4 @@ export type RESTPatchAPIGuildStickerResult = APISticker;
 /**
  * https://discord.com/developers/docs/resources/sticker#delete-guild-sticker
  */
-export type RESTDeleteAPIGuildStickerResult = never;
+export type RESTDeleteAPIGuildStickerResult<NoContent extends unknown = never> = NoContent;

--- a/rest/v10/user.ts
+++ b/rest/v10/user.ts
@@ -87,7 +87,7 @@ export type RESTGetAPICurrentUserGuildsResult = RESTAPIPartialCurrentUserGuild[]
 /**
  * https://discord.com/developers/docs/resources/user#leave-guild
  */
-export type RESTDeleteAPICurrentUserGuildResult = never;
+export type RESTDeleteAPICurrentUserGuildResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/user#create-dm

--- a/rest/v10/webhook.ts
+++ b/rest/v10/webhook.ts
@@ -89,12 +89,12 @@ export type RESTPatchAPIWebhookWithTokenResult = RESTGetAPIWebhookWithTokenResul
 /**
  * https://discord.com/developers/docs/resources/webhook#delete-webhook
  */
-export type RESTDeleteAPIWebhookResult = never;
+export type RESTDeleteAPIWebhookResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/webhook#delete-webhook-with-token
  */
-export type RESTDeleteAPIWebhookWithTokenResult = never;
+export type RESTDeleteAPIWebhookWithTokenResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/webhook#execute-webhook
@@ -186,7 +186,7 @@ export interface RESTPostAPIWebhookWithTokenQuery {
 /**
  * https://discord.com/developers/docs/resources/webhook#execute-webhook
  */
-export type RESTPostAPIWebhookWithTokenResult = never;
+export type RESTPostAPIWebhookWithTokenResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * Received when a call to https://discord.com/developers/docs/resources/webhook#execute-webhook receives
@@ -204,7 +204,7 @@ export type RESTPostAPIWebhookWithTokenSlackQuery = RESTPostAPIWebhookWithTokenQ
 /**
  * https://discord.com/developers/docs/resources/webhook#execute-slackcompatible-webhook
  */
-export type RESTPostAPIWebhookWithTokenSlackResult = never;
+export type RESTPostAPIWebhookWithTokenSlackResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * Received when a call to https://discord.com/developers/docs/resources/webhook#execute-webhook receives
@@ -222,7 +222,7 @@ export type RESTPostAPIWebhookWithTokenGitHubQuery = RESTPostAPIWebhookWithToken
 /**
  * https://discord.com/developers/docs/resources/webhook#execute-githubcompatible-webhook
  */
-export type RESTPostAPIWebhookWithTokenGitHubResult = never;
+export type RESTPostAPIWebhookWithTokenGitHubResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * Received when a call to https://discord.com/developers/docs/resources/webhook#execute-webhook receives
@@ -280,4 +280,4 @@ export type RESTPatchAPIWebhookWithTokenMessageResult = APIMessage;
 /**
  * https://discord.com/developers/docs/resources/webhook#delete-webhook-message
  */
-export type RESTDeleteAPIWebhookWithTokenMessageResult = never;
+export type RESTDeleteAPIWebhookWithTokenMessageResult<NoContent extends unknown = never> = NoContent;

--- a/rest/v6/channel.ts
+++ b/rest/v6/channel.ts
@@ -173,7 +173,7 @@ export type RESTPatchAPIChannelMessageResult = APIMessage;
 /**
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTDeleteAPIChannelMessageResult = never;
+export type RESTDeleteAPIChannelMessageResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#get-reactions
@@ -194,17 +194,17 @@ export type RESTGetAPIChannelMessageReactionsResult = APIUser[];
 /**
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTPutAPIChannelMessageReactionResult = never;
+export type RESTPutAPIChannelMessageReactionResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTDeleteAPIChannelMessageReactionResult = never;
+export type RESTDeleteAPIChannelMessageReactionResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTDeleteAPIChannelAllMessageReactionsResult = never;
+export type RESTDeleteAPIChannelAllMessageReactionsResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#bulk-delete-messages
@@ -218,7 +218,7 @@ export interface RESTPostAPIChannelMessagesBulkDeleteJSONBody {
 /**
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTPostAPIChannelMessagesBulkDeleteResult = never;
+export type RESTPostAPIChannelMessagesBulkDeleteResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#edit-channel-permissions
@@ -234,12 +234,12 @@ export interface RESTPutAPIChannelPermissionsJSONBody {
 /**
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTPutAPIChannelPermissionsResult = never;
+export type RESTPutAPIChannelPermissionsResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTDeleteAPIChannelPermissionsResult = never;
+export type RESTDeleteAPIChannelPermissionsResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#get-channel-invites
@@ -265,7 +265,7 @@ export interface RESTPostAPIChannelInviteJSONBody {
  *
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTPostAPIChannelTypingResult = never;
+export type RESTPostAPIChannelTypingResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#get-pinned-messages
@@ -279,12 +279,12 @@ export type RESTGetAPIChannelPinsResult = APIMessage[];
  *
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTPutAPIChannelPinResult = never;
+export type RESTPutAPIChannelPinResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTDeleteAPIChannelPinResult = never;
+export type RESTDeleteAPIChannelPinResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#group-dm-add-recipient

--- a/rest/v6/emoji.ts
+++ b/rest/v6/emoji.ts
@@ -53,4 +53,4 @@ export type RESTPatchAPIGuildEmojiResult = APIEmoji;
  *
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTDeleteAPIGuildEmojiResult = never;
+export type RESTDeleteAPIGuildEmojiResult<NoContent extends unknown = never> = NoContent;

--- a/rest/v6/guild.ts
+++ b/rest/v6/guild.ts
@@ -125,7 +125,7 @@ export type RESTPatchAPIGuildResult = APIGuild;
  *
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTDeleteAPIGuildResult = never;
+export type RESTDeleteAPIGuildResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#get-guild-channels
@@ -167,7 +167,7 @@ export type RESTPatchAPIGuildChannelPositionsJSONBody = {
 /**
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTPatchAPIGuildChannelPositionsResult = never;
+export type RESTPatchAPIGuildChannelPositionsResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#get-guild-member
@@ -238,7 +238,7 @@ export interface RESTPatchAPIGuildMemberJSONBody {
 /**
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTPatchAPIGuildMemberResult = never;
+export type RESTPatchAPIGuildMemberResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#modify-current-user-nick
@@ -259,21 +259,21 @@ export type RESTPatchAPICurrentGuildMemberNicknameResult = Required<RESTPatchAPI
  *
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTPutAPIGuildMemberRoleResult = never;
+export type RESTPutAPIGuildMemberRoleResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#remove-guild-member-role
  *
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTDeleteAPIGuildMemberRoleResult = never;
+export type RESTDeleteAPIGuildMemberRoleResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#remove-guild-member
  *
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTDeleteAPIGuildMemberResult = never;
+export type RESTDeleteAPIGuildMemberResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#get-guild-bans
@@ -302,14 +302,14 @@ export interface RESTPutAPIGuildBanJSONBody {
 /**
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTPutAPIGuildBanResult = never;
+export type RESTPutAPIGuildBanResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#remove-guild-ban
  *
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTDeleteAPIGuildBanResult = never;
+export type RESTDeleteAPIGuildBanResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#get-guild-roles
@@ -374,7 +374,7 @@ export type RESTPatchAPIGuildRoleResult = APIRole;
  *
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTDeleteAPIGuildRoleResult = never;
+export type RESTDeleteAPIGuildRoleResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#get-guild-prune-count
@@ -458,7 +458,7 @@ export interface RESTPostAPIGuildIntegrationJSONBody {
 /**
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTPostAPIGuildIntegrationResult = never;
+export type RESTPostAPIGuildIntegrationResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#modify-guild-integration
@@ -474,21 +474,21 @@ export interface RESTPatchAPIGuildIntegrationJSONBody {
 /**
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTPatchAPIGuildIntegrationResult = never;
+export type RESTPatchAPIGuildIntegrationResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#delete-guild-integration
  *
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTDeleteAPIGuildIntegrationResult = never;
+export type RESTDeleteAPIGuildIntegrationResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#sync-guild-integration
  *
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTPostAPIGuildIntegrationSyncResult = never;
+export type RESTPostAPIGuildIntegrationSyncResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * @deprecated Renamed to RESTGetAPIGuildWidgetSettingsResult

--- a/rest/v6/user.ts
+++ b/rest/v6/user.ts
@@ -66,7 +66,7 @@ export type RESTGetAPICurrentUserGuildsResult = RESTAPIPartialCurrentUserGuild[]
  *
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTDeleteAPICurrentUserGuildResult = never;
+export type RESTDeleteAPICurrentUserGuildResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/user#create-dm

--- a/rest/v6/webhook.ts
+++ b/rest/v6/webhook.ts
@@ -77,12 +77,12 @@ export type RESTPatchAPIWebhookWithTokenResult = Omit<APIWebhook, 'user'>;
  *
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTDeleteAPIWebhookResult = never;
+export type RESTDeleteAPIWebhookResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTDeleteAPIWebhookWithTokenResult = never;
+export type RESTDeleteAPIWebhookWithTokenResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/webhook#execute-webhook
@@ -133,7 +133,7 @@ export interface RESTPostAPIWebhookWithTokenQuery {
 /**
  * @deprecated API v6 is deprecated and the types will not receive further updates, please update to v8.
  */
-export type RESTPostAPIWebhookWithTokenResult = never;
+export type RESTPostAPIWebhookWithTokenResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * Received when a call to POST `/webhooks/{webhook.id}/{webhook.token}` receives

--- a/rest/v8/channel.ts
+++ b/rest/v8/channel.ts
@@ -285,21 +285,21 @@ export type RESTPostAPIChannelMessageCrosspostResult = APIMessage;
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTPutAPIChannelMessageReactionResult = never;
+export type RESTPutAPIChannelMessageReactionResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#delete-own-reaction
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTDeleteAPIChannelMessageOwnReaction = never;
+export type RESTDeleteAPIChannelMessageOwnReaction<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#delete-user-reaction
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTDeleteAPIChannelMessageUserReactionResult = never;
+export type RESTDeleteAPIChannelMessageUserReactionResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#get-reactions
@@ -331,14 +331,14 @@ export type RESTGetAPIChannelMessageReactionUsersResult = APIUser[];
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTDeleteAPIChannelAllMessageReactionsResult = never;
+export type RESTDeleteAPIChannelAllMessageReactionsResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#delete-all-reactions-for-emoji
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTDeleteAPIChannelMessageReactionResult = never;
+export type RESTDeleteAPIChannelMessageReactionResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#edit-message
@@ -421,7 +421,7 @@ export type RESTPatchAPIChannelMessageResult = APIMessage;
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTDeleteAPIChannelMessageResult = never;
+export type RESTDeleteAPIChannelMessageResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#bulk-delete-messages
@@ -440,7 +440,7 @@ export interface RESTPostAPIChannelMessagesBulkDeleteJSONBody {
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTPostAPIChannelMessagesBulkDeleteResult = never;
+export type RESTPostAPIChannelMessagesBulkDeleteResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#edit-channel-permissions
@@ -475,7 +475,7 @@ export interface RESTPutAPIChannelPermissionJSONBody {
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTPutAPIChannelPermissionResult = never;
+export type RESTPutAPIChannelPermissionResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#get-channel-invites
@@ -547,7 +547,7 @@ export type RESTPostAPIChannelInviteResult = APIExtendedInvite;
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTDeleteAPIChannelPermissionResult = never;
+export type RESTDeleteAPIChannelPermissionResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#follow-news-channel
@@ -573,7 +573,7 @@ export type RESTPostAPIChannelFollowersResult = APIFollowedChannel;
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTPostAPIChannelTypingResult = never;
+export type RESTPostAPIChannelTypingResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#get-pinned-messages
@@ -587,14 +587,14 @@ export type RESTGetAPIChannelPinsResult = APIMessage[];
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTPutAPIChannelPinResult = never;
+export type RESTPutAPIChannelPinResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#delete-pinned-channel-message
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTDeleteAPIChannelPinResult = never;
+export type RESTDeleteAPIChannelPinResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#group-dm-add-recipient

--- a/rest/v8/emoji.ts
+++ b/rest/v8/emoji.ts
@@ -72,4 +72,4 @@ export type RESTPatchAPIGuildEmojiResult = APIEmoji;
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTDeleteAPIGuildEmojiResult = never;
+export type RESTDeleteAPIGuildEmojiResult<NoContent extends unknown = never> = NoContent;

--- a/rest/v8/guild.ts
+++ b/rest/v8/guild.ts
@@ -304,7 +304,7 @@ export type RESTPatchAPIGuildResult = APIGuild;
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTDeleteAPIGuildResult = never;
+export type RESTDeleteAPIGuildResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#get-guild-channels
@@ -356,7 +356,7 @@ export type RESTPatchAPIGuildChannelPositionsJSONBody = {
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTPatchAPIGuildChannelPositionsResult = never;
+export type RESTPatchAPIGuildChannelPositionsResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#get-guild-member
@@ -454,7 +454,7 @@ export interface RESTPutAPIGuildMemberJSONBody {
 /**
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTPutAPIGuildMemberResult = APIGuildMember | never;
+export type RESTPutAPIGuildMemberResult<NoContent extends unknown = never> = APIGuildMember | NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#modify-guild-member
@@ -548,21 +548,21 @@ export type RESTPatchAPICurrentGuildMemberNicknameResult =
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTPutAPIGuildMemberRoleResult = never;
+export type RESTPutAPIGuildMemberRoleResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#remove-guild-member-role
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTDeleteAPIGuildMemberRoleResult = never;
+export type RESTDeleteAPIGuildMemberRoleResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#remove-guild-member
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTDeleteAPIGuildMemberResult = never;
+export type RESTDeleteAPIGuildMemberResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#get-guild-bans
@@ -601,14 +601,14 @@ export interface RESTPutAPIGuildBanJSONBody {
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTPutAPIGuildBanResult = never;
+export type RESTPutAPIGuildBanResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#remove-guild-ban
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTDeleteAPIGuildBanResult = never;
+export type RESTDeleteAPIGuildBanResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#get-guild-roles
@@ -741,7 +741,7 @@ export type RESTPatchAPIGuildRoleResult = APIRole;
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTDeleteAPIGuildRoleResult = never;
+export type RESTDeleteAPIGuildRoleResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#get-guild-prune-count
@@ -834,7 +834,7 @@ export type RESTGetAPIGuildIntegrationsResult = APIGuildIntegration[];
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTDeleteAPIGuildIntegrationResult = never;
+export type RESTDeleteAPIGuildIntegrationResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#get-guild-widget-settings

--- a/rest/v8/guildScheduledEvent.ts
+++ b/rest/v8/guildScheduledEvent.ts
@@ -122,7 +122,7 @@ export type RESTPatchAPIGuildScheduledEventResult = APIGuildScheduledEvent;
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTDeleteAPIGuildScheduledEventResult = never;
+export type RESTDeleteAPIGuildScheduledEventResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild-scheduled-event#get-guild-scheduled-event-users

--- a/rest/v8/stageInstance.ts
+++ b/rest/v8/stageInstance.ts
@@ -65,4 +65,4 @@ export type RESTPatchAPIStageInstanceResult = APIStageInstance;
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTDeleteAPIStageInstanceResult = never;
+export type RESTDeleteAPIStageInstanceResult<NoContent extends unknown = never> = NoContent;

--- a/rest/v8/sticker.ts
+++ b/rest/v8/sticker.ts
@@ -75,4 +75,4 @@ export type RESTPatchAPIGuildStickerResult = APISticker;
 /**
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTDeleteAPIGuildStickerResult = never;
+export type RESTDeleteAPIGuildStickerResult<NoContent extends unknown = never> = NoContent;

--- a/rest/v8/user.ts
+++ b/rest/v8/user.ts
@@ -91,7 +91,7 @@ export type RESTGetAPICurrentUserGuildsResult = RESTAPIPartialCurrentUserGuild[]
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTDeleteAPICurrentUserGuildResult = never;
+export type RESTDeleteAPICurrentUserGuildResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/user#create-dm

--- a/rest/v8/webhook.ts
+++ b/rest/v8/webhook.ts
@@ -112,14 +112,14 @@ export type RESTPatchAPIWebhookWithTokenResult = RESTGetAPIWebhookWithTokenResul
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTDeleteAPIWebhookResult = never;
+export type RESTDeleteAPIWebhookResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/webhook#delete-webhook-with-token
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTDeleteAPIWebhookWithTokenResult = never;
+export type RESTDeleteAPIWebhookWithTokenResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/webhook#execute-webhook
@@ -211,7 +211,7 @@ export interface RESTPostAPIWebhookWithTokenQuery {
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTPostAPIWebhookWithTokenResult = never;
+export type RESTPostAPIWebhookWithTokenResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * Received when a call to https://discord.com/developers/docs/resources/webhook#execute-webhook receives
@@ -235,7 +235,7 @@ export type RESTPostAPIWebhookWithTokenSlackQuery = RESTPostAPIWebhookWithTokenQ
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTPostAPIWebhookWithTokenSlackResult = never;
+export type RESTPostAPIWebhookWithTokenSlackResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * Received when a call to https://discord.com/developers/docs/resources/webhook#execute-webhook receives
@@ -259,7 +259,7 @@ export type RESTPostAPIWebhookWithTokenGitHubQuery = RESTPostAPIWebhookWithToken
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTPostAPIWebhookWithTokenGitHubResult = never;
+export type RESTPostAPIWebhookWithTokenGitHubResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * Received when a call to https://discord.com/developers/docs/resources/webhook#execute-webhook receives
@@ -322,4 +322,4 @@ export type RESTPatchAPIWebhookWithTokenMessageResult = APIMessage;
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
-export type RESTDeleteAPIWebhookWithTokenMessageResult = never;
+export type RESTDeleteAPIWebhookWithTokenMessageResult<NoContent extends unknown = never> = NoContent;

--- a/rest/v9/autoModeration.ts
+++ b/rest/v9/autoModeration.ts
@@ -80,4 +80,4 @@ export type RESTPatchAPIAutoModerationRuleResult = APIAutoModerationRule;
 /**
  * https://discord.com/developers/docs/resources/auto-moderation#delete-auto-moderation-rule
  */
-export type RESTDeleteAPIAutoModerationRuleResult = never;
+export type RESTDeleteAPIAutoModerationRuleResult<NoContent extends unknown = never> = NoContent;

--- a/rest/v9/channel.ts
+++ b/rest/v9/channel.ts
@@ -324,17 +324,17 @@ export type RESTPostAPIChannelMessageCrosspostResult = APIMessage;
 /**
  * https://discord.com/developers/docs/resources/channel#create-reaction
  */
-export type RESTPutAPIChannelMessageReactionResult = never;
+export type RESTPutAPIChannelMessageReactionResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#delete-own-reaction
  */
-export type RESTDeleteAPIChannelMessageOwnReaction = never;
+export type RESTDeleteAPIChannelMessageOwnReaction<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#delete-user-reaction
  */
-export type RESTDeleteAPIChannelMessageUserReactionResult = never;
+export type RESTDeleteAPIChannelMessageUserReactionResult<NoContent extends unknown = never> = NoContent;
 
 /*
  * https://discord.com/developers/docs/resources/channel#get-reactions
@@ -360,12 +360,12 @@ export type RESTGetAPIChannelMessageReactionUsersResult = APIUser[];
 /**
  * https://discord.com/developers/docs/resources/channel#delete-all-reactions
  */
-export type RESTDeleteAPIChannelAllMessageReactionsResult = never;
+export type RESTDeleteAPIChannelAllMessageReactionsResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#delete-all-reactions-for-emoji
  */
-export type RESTDeleteAPIChannelMessageReactionResult = never;
+export type RESTDeleteAPIChannelMessageReactionResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#edit-message
@@ -440,7 +440,7 @@ export type RESTPatchAPIChannelMessageResult = APIMessage;
 /**
  * https://discord.com/developers/docs/resources/channel#delete-message
  */
-export type RESTDeleteAPIChannelMessageResult = never;
+export type RESTDeleteAPIChannelMessageResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#bulk-delete-messages
@@ -455,7 +455,7 @@ export interface RESTPostAPIChannelMessagesBulkDeleteJSONBody {
 /**
  * https://discord.com/developers/docs/resources/channel#bulk-delete-messages
  */
-export type RESTPostAPIChannelMessagesBulkDeleteResult = never;
+export type RESTPostAPIChannelMessagesBulkDeleteResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#edit-channel-permissions
@@ -486,7 +486,7 @@ export interface RESTPutAPIChannelPermissionJSONBody {
 /**
  * https://discord.com/developers/docs/resources/channel#edit-channel-permissions
  */
-export type RESTPutAPIChannelPermissionResult = never;
+export type RESTPutAPIChannelPermissionResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#get-channel-invites
@@ -550,7 +550,7 @@ export type RESTPostAPIChannelInviteResult = APIExtendedInvite;
 /**
  * https://discord.com/developers/docs/resources/channel#delete-channel-permission
  */
-export type RESTDeleteAPIChannelPermissionResult = never;
+export type RESTDeleteAPIChannelPermissionResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#follow-news-channel
@@ -570,7 +570,7 @@ export type RESTPostAPIChannelFollowersResult = APIFollowedChannel;
 /**
  * https://discord.com/developers/docs/resources/channel#trigger-typing-indicator
  */
-export type RESTPostAPIChannelTypingResult = never;
+export type RESTPostAPIChannelTypingResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#get-pinned-messages
@@ -580,12 +580,12 @@ export type RESTGetAPIChannelPinsResult = APIMessage[];
 /**
  * https://discord.com/developers/docs/resources/channel#pin-message
  */
-export type RESTPutAPIChannelPinResult = never;
+export type RESTPutAPIChannelPinResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#unpin-message
  */
-export type RESTDeleteAPIChannelPinResult = never;
+export type RESTDeleteAPIChannelPinResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#group-dm-add-recipient
@@ -687,12 +687,12 @@ export type RESTPostAPIChannelThreadsResult = APIChannel;
 /**
  * https://discord.com/developers/docs/resources/channel#join-thread
  */
-export type RESTPutAPIChannelThreadMembersResult = never;
+export type RESTPutAPIChannelThreadMembersResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#leave-thread
  */
-export type RESTDeleteAPIChannelThreadMembersResult = never;
+export type RESTDeleteAPIChannelThreadMembersResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/channel#get-thread-member

--- a/rest/v9/emoji.ts
+++ b/rest/v9/emoji.ts
@@ -58,4 +58,4 @@ export type RESTPatchAPIGuildEmojiResult = APIEmoji;
 /**
  * https://discord.com/developers/docs/resources/emoji#delete-guild-emoji
  */
-export type RESTDeleteAPIGuildEmojiResult = never;
+export type RESTDeleteAPIGuildEmojiResult<NoContent extends unknown = never> = NoContent;

--- a/rest/v9/guild.ts
+++ b/rest/v9/guild.ts
@@ -320,7 +320,7 @@ export type RESTPatchAPIGuildResult = APIGuild;
 /**
  * https://discord.com/developers/docs/resources/guild#delete-guild
  */
-export type RESTDeleteAPIGuildResult = never;
+export type RESTDeleteAPIGuildResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#get-guild-channels
@@ -362,7 +362,7 @@ export type RESTPatchAPIGuildChannelPositionsJSONBody = {
 /**
  * https://discord.com/developers/docs/resources/guild#modify-guild-channel-positions
  */
-export type RESTPatchAPIGuildChannelPositionsResult = never;
+export type RESTPatchAPIGuildChannelPositionsResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#list-active-guild-threads
@@ -449,7 +449,7 @@ export interface RESTPutAPIGuildMemberJSONBody {
 	deaf?: boolean | undefined;
 }
 
-export type RESTPutAPIGuildMemberResult = APIGuildMember | never;
+export type RESTPutAPIGuildMemberResult<NoContent extends unknown = never> = APIGuildMember | NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#modify-guild-member
@@ -533,17 +533,17 @@ export type RESTPatchAPICurrentGuildMemberNicknameResult =
 /**
  * https://discord.com/developers/docs/resources/guild#add-guild-member-role
  */
-export type RESTPutAPIGuildMemberRoleResult = never;
+export type RESTPutAPIGuildMemberRoleResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#remove-guild-member-role
  */
-export type RESTDeleteAPIGuildMemberRoleResult = never;
+export type RESTDeleteAPIGuildMemberRoleResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#remove-guild-member
  */
-export type RESTDeleteAPIGuildMemberResult = never;
+export type RESTDeleteAPIGuildMemberResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#get-guild-bans
@@ -600,12 +600,12 @@ export interface RESTPutAPIGuildBanJSONBody {
 /**
  * https://discord.com/developers/docs/resources/guild#create-guild-ban
  */
-export type RESTPutAPIGuildBanResult = never;
+export type RESTPutAPIGuildBanResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#remove-guild-ban
  */
-export type RESTDeleteAPIGuildBanResult = never;
+export type RESTDeleteAPIGuildBanResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#get-guild-roles
@@ -722,7 +722,7 @@ export type RESTPatchAPIGuildRoleResult = APIRole;
 /**
  * https://discord.com/developers/docs/resources/guild#delete-guild-role
  */
-export type RESTDeleteAPIGuildRoleResult = never;
+export type RESTDeleteAPIGuildRoleResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#get-guild-prune-count
@@ -799,7 +799,7 @@ export type RESTGetAPIGuildIntegrationsResult = APIGuildIntegration[];
 /**
  * https://discord.com/developers/docs/resources/guild#delete-guild-integration
  */
-export type RESTDeleteAPIGuildIntegrationResult = never;
+export type RESTDeleteAPIGuildIntegrationResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#get-guild-widget-settings
@@ -887,7 +887,7 @@ export interface RESTPatchAPIGuildVoiceStateCurrentMemberJSONBody {
 /**
  * https://discord.com/developers/docs/resources/guild#modify-current-user-voice-state
  */
-export type RESTPatchAPIGuildVoiceStateCurrentMemberResult = never;
+export type RESTPatchAPIGuildVoiceStateCurrentMemberResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#modify-user-voice-state
@@ -906,7 +906,7 @@ export interface RESTPatchAPIGuildVoiceStateUserJSONBody {
 /**
  * https://discord.com/developers/docs/resources/guild#modify-user-voice-state
  */
-export type RESTPatchAPIGuildVoiceStateUserResult = never;
+export type RESTPatchAPIGuildVoiceStateUserResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild#get-guild-welcome-screen

--- a/rest/v9/guildScheduledEvent.ts
+++ b/rest/v9/guildScheduledEvent.ts
@@ -112,7 +112,7 @@ export type RESTPatchAPIGuildScheduledEventResult = APIGuildScheduledEvent;
 /**
  * https://discord.com/developers/docs/resources/guild-scheduled-event#delete-guild-scheduled-event
  */
-export type RESTDeleteAPIGuildScheduledEventResult = never;
+export type RESTDeleteAPIGuildScheduledEventResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/guild-scheduled-event#get-guild-scheduled-event-users

--- a/rest/v9/stageInstance.ts
+++ b/rest/v9/stageInstance.ts
@@ -57,4 +57,4 @@ export type RESTPatchAPIStageInstanceResult = APIStageInstance;
 /**
  * https://discord.com/developers/docs/resources/stage-instance#delete-stage-instance
  */
-export type RESTDeleteAPIStageInstanceResult = never;
+export type RESTDeleteAPIStageInstanceResult<NoContent extends unknown = never> = NoContent;

--- a/rest/v9/sticker.ts
+++ b/rest/v9/sticker.ts
@@ -77,4 +77,4 @@ export type RESTPatchAPIGuildStickerResult = APISticker;
 /**
  * https://discord.com/developers/docs/resources/sticker#delete-guild-sticker
  */
-export type RESTDeleteAPIGuildStickerResult = never;
+export type RESTDeleteAPIGuildStickerResult<NoContent extends unknown = never> = NoContent;

--- a/rest/v9/user.ts
+++ b/rest/v9/user.ts
@@ -87,7 +87,7 @@ export type RESTGetAPICurrentUserGuildsResult = RESTAPIPartialCurrentUserGuild[]
 /**
  * https://discord.com/developers/docs/resources/user#leave-guild
  */
-export type RESTDeleteAPICurrentUserGuildResult = never;
+export type RESTDeleteAPICurrentUserGuildResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/user#create-dm

--- a/rest/v9/webhook.ts
+++ b/rest/v9/webhook.ts
@@ -89,12 +89,12 @@ export type RESTPatchAPIWebhookWithTokenResult = RESTGetAPIWebhookWithTokenResul
 /**
  * https://discord.com/developers/docs/resources/webhook#delete-webhook
  */
-export type RESTDeleteAPIWebhookResult = never;
+export type RESTDeleteAPIWebhookResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/webhook#delete-webhook-with-token
  */
-export type RESTDeleteAPIWebhookWithTokenResult = never;
+export type RESTDeleteAPIWebhookWithTokenResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * https://discord.com/developers/docs/resources/webhook#execute-webhook
@@ -186,7 +186,7 @@ export interface RESTPostAPIWebhookWithTokenQuery {
 /**
  * https://discord.com/developers/docs/resources/webhook#execute-webhook
  */
-export type RESTPostAPIWebhookWithTokenResult = never;
+export type RESTPostAPIWebhookWithTokenResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * Received when a call to https://discord.com/developers/docs/resources/webhook#execute-webhook receives
@@ -204,7 +204,7 @@ export type RESTPostAPIWebhookWithTokenSlackQuery = RESTPostAPIWebhookWithTokenQ
 /**
  * https://discord.com/developers/docs/resources/webhook#execute-slackcompatible-webhook
  */
-export type RESTPostAPIWebhookWithTokenSlackResult = never;
+export type RESTPostAPIWebhookWithTokenSlackResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * Received when a call to https://discord.com/developers/docs/resources/webhook#execute-webhook receives
@@ -222,7 +222,7 @@ export type RESTPostAPIWebhookWithTokenGitHubQuery = RESTPostAPIWebhookWithToken
 /**
  * https://discord.com/developers/docs/resources/webhook#execute-githubcompatible-webhook
  */
-export type RESTPostAPIWebhookWithTokenGitHubResult = never;
+export type RESTPostAPIWebhookWithTokenGitHubResult<NoContent extends unknown = never> = NoContent;
 
 /**
  * Received when a call to https://discord.com/developers/docs/resources/webhook#execute-webhook receives
@@ -280,4 +280,4 @@ export type RESTPatchAPIWebhookWithTokenMessageResult = APIMessage;
 /**
  * https://discord.com/developers/docs/resources/webhook#delete-webhook-message
  */
-export type RESTDeleteAPIWebhookWithTokenMessageResult = never;
+export type RESTDeleteAPIWebhookWithTokenMessageResult<NoContent extends unknown = never> = NoContent;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR adds `NoContent` generic so that users can choose the type for their 204 NoContent responses. 