### PR TITLE
fix(RESTPatchAPIChannelJSONBody): `available_tags` requires `name` only

### DIFF
--- a/deno/rest/v10/channel.ts
+++ b/deno/rest/v10/channel.ts
@@ -150,7 +150,7 @@ export interface RESTPatchAPIChannelJSONBody {
 	 *
 	 * Channel types: forum
 	 */
-	available_tags?: APIGuildForumTag[] | undefined;
+	available_tags?: (Partial<APIGuildForumTag> & Pick<APIGuildForumTag, 'name'>)[] | undefined;
 	/**
 	 * The emoji to show in the add reaction button on a thread in a forum channel
 	 *

--- a/deno/rest/v9/channel.ts
+++ b/deno/rest/v9/channel.ts
@@ -150,7 +150,7 @@ export interface RESTPatchAPIChannelJSONBody {
 	 *
 	 * Channel types: forum
 	 */
-	available_tags?: APIGuildForumTag[] | undefined;
+	available_tags?: (Partial<APIGuildForumTag> & Pick<APIGuildForumTag, 'name'>)[] | undefined;
 	/**
 	 * The emoji to show in the add reaction button on a thread in a forum channel
 	 *

--- a/rest/v10/channel.ts
+++ b/rest/v10/channel.ts
@@ -150,7 +150,7 @@ export interface RESTPatchAPIChannelJSONBody {
 	 *
 	 * Channel types: forum
 	 */
-	available_tags?: APIGuildForumTag[] | undefined;
+	available_tags?: (Partial<APIGuildForumTag> & Pick<APIGuildForumTag, 'name'>)[] | undefined;
 	/**
 	 * The emoji to show in the add reaction button on a thread in a forum channel
 	 *

--- a/rest/v9/channel.ts
+++ b/rest/v9/channel.ts
@@ -150,7 +150,7 @@ export interface RESTPatchAPIChannelJSONBody {
 	 *
 	 * Channel types: forum
 	 */
-	available_tags?: APIGuildForumTag[] | undefined;
+	available_tags?: (Partial<APIGuildForumTag> & Pick<APIGuildForumTag, 'name'>)[] | undefined;
 	/**
 	 * The emoji to show in the add reaction button on a thread in a forum channel
 	 *


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The `id` is currently required when updating a tag for a forum channel which cannot be obtained for tags that do not exist. Per the documentation, only the `name` is required.

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**

- https://github.com/discord/discord-api-docs/pull/5458