### PR TITLE
chore(RoleFlags): add link to api docs

### DIFF
--- a/deno/payloads/v10/permissions.ts
+++ b/deno/payloads/v10/permissions.ts
@@ -90,6 +90,9 @@ export interface APIRoleTags {
 	guild_connections?: null;
 }
 
+/**
+ * https://discord.com/developers/docs/topics/permissions#role-object-role-flags
+ */
 export enum RoleFlags {
 	/**
 	 * Role can be selected by members in an onboarding prompt

--- a/deno/payloads/v9/permissions.ts
+++ b/deno/payloads/v9/permissions.ts
@@ -90,6 +90,9 @@ export interface APIRoleTags {
 	guild_connections?: null;
 }
 
+/**
+ * https://discord.com/developers/docs/topics/permissions#role-object-role-flags
+ */
 export enum RoleFlags {
 	/**
 	 * Role can be selected by members in an onboarding prompt

--- a/payloads/v10/permissions.ts
+++ b/payloads/v10/permissions.ts
@@ -90,6 +90,9 @@ export interface APIRoleTags {
 	guild_connections?: null;
 }
 
+/**
+ * https://discord.com/developers/docs/topics/permissions#role-object-role-flags
+ */
 export enum RoleFlags {
 	/**
 	 * Role can be selected by members in an onboarding prompt

--- a/payloads/v9/permissions.ts
+++ b/payloads/v9/permissions.ts
@@ -90,6 +90,9 @@ export interface APIRoleTags {
 	guild_connections?: null;
 }
 
+/**
+ * https://discord.com/developers/docs/topics/permissions#role-object-role-flags
+ */
 export enum RoleFlags {
 	/**
 	 * Role can be selected by members in an onboarding prompt


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Just adds discord docs url to enum descirption

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
