### PR TITLE
fix(RESTPostAPIChannelMessageJSONBody): `number` for attachment ids

### DIFF
--- a/deno/rest/v10/channel.ts
+++ b/deno/rest/v10/channel.ts
@@ -289,7 +289,14 @@ export interface RESTPostAPIChannelMessageJSONBody {
 	/**
 	 * Attachment objects with filename and description
 	 */
-	attachments?: (Pick<APIAttachment, 'id' | 'description'> & Partial<Pick<APIAttachment, 'filename'>>)[] | undefined;
+	attachments?:
+		| (Pick<APIAttachment, 'description'> & {
+				/**
+				 * Attachment id or a number that matches `n` in `files[n]`
+				 */
+				id: Snowflake | number;
+		  } & Partial<Pick<APIAttachment, 'filename'>>)[]
+		| undefined;
 	/**
 	 * Message flags combined as a bitfield
 	 */

--- a/deno/rest/v10/channel.ts
+++ b/deno/rest/v10/channel.ts
@@ -2,7 +2,6 @@ import type { Permissions, Snowflake } from '../../globals.ts';
 import type {
 	APIActionRowComponent,
 	APIAllowedMentions,
-	APIAttachment,
 	APIChannel,
 	APIEmbed,
 	APIExtendedInvite,
@@ -241,6 +240,24 @@ export type APIMessageReferenceSend = StrictPartial<APIMessageReference> &
 	};
 
 /**
+ * https://discord.com/developers/docs/resources/channel#attachment-object
+ */
+export interface RESTAPIAttachment {
+	/**
+	 * Attachment id or a number that matches `n` in `files[n]`
+	 */
+	id: Snowflake | number;
+	/**
+	 * Name of the file
+	 */
+	filename?: string | undefined;
+	/**
+	 * Description of the file
+	 */
+	description?: string | undefined;
+}
+
+/**
  * https://discord.com/developers/docs/resources/channel#create-message
  */
 export interface RESTPostAPIChannelMessageJSONBody {
@@ -289,14 +306,7 @@ export interface RESTPostAPIChannelMessageJSONBody {
 	/**
 	 * Attachment objects with filename and description
 	 */
-	attachments?:
-		| (Pick<APIAttachment, 'description'> & {
-				/**
-				 * Attachment id or a number that matches `n` in `files[n]`
-				 */
-				id: Snowflake | number;
-		  } & Partial<Pick<APIAttachment, 'filename'>>)[]
-		| undefined;
+	attachments?: RESTAPIAttachment[] | undefined;
 	/**
 	 * Message flags combined as a bitfield
 	 */
@@ -407,7 +417,7 @@ export interface RESTPatchAPIChannelMessageJSONBody {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#attachment-object
 	 */
-	attachments?: (Pick<APIAttachment, 'id'> & Partial<Pick<APIAttachment, 'filename' | 'description'>>)[] | undefined;
+	attachments?: RESTAPIAttachment[] | undefined;
 	/**
 	 * The components to include with the message
 	 *

--- a/deno/rest/v10/webhook.ts
+++ b/deno/rest/v10/webhook.ts
@@ -5,11 +5,11 @@ import type {
 	APIEmbed,
 	APIMessage,
 	APIWebhook,
-	APIAttachment,
 	MessageFlags,
 	APIMessageActionRowComponent,
 } from '../../payloads/v10/mod.ts';
 import type { AddUndefinedToPossiblyUndefinedPropertiesOfInterface, Nullable } from '../../utils/internals.ts';
+import type { RESTAPIAttachment } from './channel.ts';
 /**
  * https://discord.com/developers/docs/resources/webhook#create-webhook
  */
@@ -139,7 +139,7 @@ export interface RESTPostAPIWebhookWithTokenJSONBody {
 	/**
 	 * Attachment objects with filename and description
 	 */
-	attachments?: (Pick<APIAttachment, 'id' | 'description'> & Partial<Pick<APIAttachment, 'filename'>>)[] | undefined;
+	attachments?: RESTAPIAttachment[] | undefined;
 	/**
 	 * Message flags combined as a bitfield
 	 */
@@ -257,7 +257,7 @@ export type RESTPatchAPIWebhookWithTokenMessageJSONBody = AddUndefinedToPossibly
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#attachment-object
 	 */
-	attachments?: (Pick<APIAttachment, 'id'> & Partial<Pick<APIAttachment, 'filename' | 'description'>>)[] | undefined;
+	attachments?: RESTAPIAttachment[] | undefined;
 };
 
 /**

--- a/deno/rest/v9/channel.ts
+++ b/deno/rest/v9/channel.ts
@@ -297,7 +297,14 @@ export interface RESTPostAPIChannelMessageJSONBody {
 	/**
 	 * Attachment objects with filename and description
 	 */
-	attachments?: (Pick<APIAttachment, 'id' | 'description'> & Partial<Pick<APIAttachment, 'filename'>>)[] | undefined;
+	attachments?:
+		| (Pick<APIAttachment, 'description'> & {
+				/**
+				 * Attachment id or a number that matches `n` in `files[n]`
+				 */
+				id: Snowflake | number;
+		  } & Partial<Pick<APIAttachment, 'filename'>>)[]
+		| undefined;
 	/**
 	 * Message flags combined as a bitfield
 	 */

--- a/deno/rest/v9/channel.ts
+++ b/deno/rest/v9/channel.ts
@@ -2,7 +2,6 @@ import type { Permissions, Snowflake } from '../../globals.ts';
 import type {
 	APIActionRowComponent,
 	APIAllowedMentions,
-	APIAttachment,
 	APIChannel,
 	APIEmbed,
 	APIExtendedInvite,
@@ -241,6 +240,24 @@ export type APIMessageReferenceSend = StrictPartial<APIMessageReference> &
 	};
 
 /**
+ * https://discord.com/developers/docs/resources/channel#attachment-object
+ */
+export interface RESTAPIAttachment {
+	/**
+	 * Attachment id or a number that matches `n` in `files[n]`
+	 */
+	id: Snowflake | number;
+	/**
+	 * Name of the file
+	 */
+	filename?: string | undefined;
+	/**
+	 * Description of the file
+	 */
+	description?: string | undefined;
+}
+
+/**
  * https://discord.com/developers/docs/resources/channel#create-message
  */
 export interface RESTPostAPIChannelMessageJSONBody {
@@ -297,14 +314,7 @@ export interface RESTPostAPIChannelMessageJSONBody {
 	/**
 	 * Attachment objects with filename and description
 	 */
-	attachments?:
-		| (Pick<APIAttachment, 'description'> & {
-				/**
-				 * Attachment id or a number that matches `n` in `files[n]`
-				 */
-				id: Snowflake | number;
-		  } & Partial<Pick<APIAttachment, 'filename'>>)[]
-		| undefined;
+	attachments?: RESTAPIAttachment[] | undefined;
 	/**
 	 * Message flags combined as a bitfield
 	 */
@@ -423,7 +433,7 @@ export interface RESTPatchAPIChannelMessageJSONBody {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#attachment-object
 	 */
-	attachments?: (Pick<APIAttachment, 'id'> & Partial<Pick<APIAttachment, 'filename' | 'description'>>)[] | undefined;
+	attachments?: RESTAPIAttachment[] | undefined;
 	/**
 	 * The components to include with the message
 	 *

--- a/deno/rest/v9/webhook.ts
+++ b/deno/rest/v9/webhook.ts
@@ -5,11 +5,11 @@ import type {
 	APIEmbed,
 	APIMessage,
 	APIWebhook,
-	APIAttachment,
 	MessageFlags,
 	APIMessageActionRowComponent,
 } from '../../payloads/v9/mod.ts';
 import type { AddUndefinedToPossiblyUndefinedPropertiesOfInterface, Nullable } from '../../utils/internals.ts';
+import type { RESTAPIAttachment } from './channel.ts';
 /**
  * https://discord.com/developers/docs/resources/webhook#create-webhook
  */
@@ -139,7 +139,7 @@ export interface RESTPostAPIWebhookWithTokenJSONBody {
 	/**
 	 * Attachment objects with filename and description
 	 */
-	attachments?: (Pick<APIAttachment, 'id' | 'description'> & Partial<Pick<APIAttachment, 'filename'>>)[] | undefined;
+	attachments?: RESTAPIAttachment[] | undefined;
 	/**
 	 * Message flags combined as a bitfield
 	 */
@@ -257,7 +257,7 @@ export type RESTPatchAPIWebhookWithTokenMessageJSONBody = AddUndefinedToPossibly
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#attachment-object
 	 */
-	attachments?: (Pick<APIAttachment, 'id'> & Partial<Pick<APIAttachment, 'filename' | 'description'>>)[] | undefined;
+	attachments?: RESTAPIAttachment[] | undefined;
 };
 
 /**

--- a/rest/v10/channel.ts
+++ b/rest/v10/channel.ts
@@ -289,7 +289,14 @@ export interface RESTPostAPIChannelMessageJSONBody {
 	/**
 	 * Attachment objects with filename and description
 	 */
-	attachments?: (Pick<APIAttachment, 'id' | 'description'> & Partial<Pick<APIAttachment, 'filename'>>)[] | undefined;
+	attachments?:
+		| (Pick<APIAttachment, 'description'> & {
+				/**
+				 * Attachment id or a number that matches `n` in `files[n]`
+				 */
+				id: Snowflake | number;
+		  } & Partial<Pick<APIAttachment, 'filename'>>)[]
+		| undefined;
 	/**
 	 * Message flags combined as a bitfield
 	 */

--- a/rest/v10/channel.ts
+++ b/rest/v10/channel.ts
@@ -2,7 +2,6 @@ import type { Permissions, Snowflake } from '../../globals';
 import type {
 	APIActionRowComponent,
 	APIAllowedMentions,
-	APIAttachment,
 	APIChannel,
 	APIEmbed,
 	APIExtendedInvite,
@@ -241,6 +240,24 @@ export type APIMessageReferenceSend = StrictPartial<APIMessageReference> &
 	};
 
 /**
+ * https://discord.com/developers/docs/resources/channel#attachment-object
+ */
+export interface RESTAPIAttachment {
+	/**
+	 * Attachment id or a number that matches `n` in `files[n]`
+	 */
+	id: Snowflake | number;
+	/**
+	 * Name of the file
+	 */
+	filename?: string | undefined;
+	/**
+	 * Description of the file
+	 */
+	description?: string | undefined;
+}
+
+/**
  * https://discord.com/developers/docs/resources/channel#create-message
  */
 export interface RESTPostAPIChannelMessageJSONBody {
@@ -289,14 +306,7 @@ export interface RESTPostAPIChannelMessageJSONBody {
 	/**
 	 * Attachment objects with filename and description
 	 */
-	attachments?:
-		| (Pick<APIAttachment, 'description'> & {
-				/**
-				 * Attachment id or a number that matches `n` in `files[n]`
-				 */
-				id: Snowflake | number;
-		  } & Partial<Pick<APIAttachment, 'filename'>>)[]
-		| undefined;
+	attachments?: RESTAPIAttachment[] | undefined;
 	/**
 	 * Message flags combined as a bitfield
 	 */
@@ -407,7 +417,7 @@ export interface RESTPatchAPIChannelMessageJSONBody {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#attachment-object
 	 */
-	attachments?: (Pick<APIAttachment, 'id'> & Partial<Pick<APIAttachment, 'filename' | 'description'>>)[] | undefined;
+	attachments?: RESTAPIAttachment[] | undefined;
 	/**
 	 * The components to include with the message
 	 *

--- a/rest/v10/webhook.ts
+++ b/rest/v10/webhook.ts
@@ -5,11 +5,11 @@ import type {
 	APIEmbed,
 	APIMessage,
 	APIWebhook,
-	APIAttachment,
 	MessageFlags,
 	APIMessageActionRowComponent,
 } from '../../payloads/v10/index';
 import type { AddUndefinedToPossiblyUndefinedPropertiesOfInterface, Nullable } from '../../utils/internals';
+import type { RESTAPIAttachment } from './channel';
 /**
  * https://discord.com/developers/docs/resources/webhook#create-webhook
  */
@@ -139,7 +139,7 @@ export interface RESTPostAPIWebhookWithTokenJSONBody {
 	/**
 	 * Attachment objects with filename and description
 	 */
-	attachments?: (Pick<APIAttachment, 'id' | 'description'> & Partial<Pick<APIAttachment, 'filename'>>)[] | undefined;
+	attachments?: RESTAPIAttachment[] | undefined;
 	/**
 	 * Message flags combined as a bitfield
 	 */
@@ -257,7 +257,7 @@ export type RESTPatchAPIWebhookWithTokenMessageJSONBody = AddUndefinedToPossibly
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#attachment-object
 	 */
-	attachments?: (Pick<APIAttachment, 'id'> & Partial<Pick<APIAttachment, 'filename' | 'description'>>)[] | undefined;
+	attachments?: RESTAPIAttachment[] | undefined;
 };
 
 /**

--- a/rest/v9/channel.ts
+++ b/rest/v9/channel.ts
@@ -2,7 +2,6 @@ import type { Permissions, Snowflake } from '../../globals';
 import type {
 	APIActionRowComponent,
 	APIAllowedMentions,
-	APIAttachment,
 	APIChannel,
 	APIEmbed,
 	APIExtendedInvite,
@@ -241,6 +240,24 @@ export type APIMessageReferenceSend = StrictPartial<APIMessageReference> &
 	};
 
 /**
+ * https://discord.com/developers/docs/resources/channel#attachment-object
+ */
+export interface RESTAPIAttachment {
+	/**
+	 * Attachment id or a number that matches `n` in `files[n]`
+	 */
+	id: Snowflake | number;
+	/**
+	 * Name of the file
+	 */
+	filename?: string | undefined;
+	/**
+	 * Description of the file
+	 */
+	description?: string | undefined;
+}
+
+/**
  * https://discord.com/developers/docs/resources/channel#create-message
  */
 export interface RESTPostAPIChannelMessageJSONBody {
@@ -297,14 +314,7 @@ export interface RESTPostAPIChannelMessageJSONBody {
 	/**
 	 * Attachment objects with filename and description
 	 */
-	attachments?:
-		| (Pick<APIAttachment, 'description'> & {
-				/**
-				 * Attachment id or a number that matches `n` in `files[n]`
-				 */
-				id: Snowflake | number;
-		  } & Partial<Pick<APIAttachment, 'filename'>>)[]
-		| undefined;
+	attachments?: RESTAPIAttachment[] | undefined;
 	/**
 	 * Message flags combined as a bitfield
 	 */
@@ -423,7 +433,7 @@ export interface RESTPatchAPIChannelMessageJSONBody {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#attachment-object
 	 */
-	attachments?: (Pick<APIAttachment, 'id'> & Partial<Pick<APIAttachment, 'filename' | 'description'>>)[] | undefined;
+	attachments?: RESTAPIAttachment[] | undefined;
 	/**
 	 * The components to include with the message
 	 *

--- a/rest/v9/channel.ts
+++ b/rest/v9/channel.ts
@@ -297,7 +297,14 @@ export interface RESTPostAPIChannelMessageJSONBody {
 	/**
 	 * Attachment objects with filename and description
 	 */
-	attachments?: (Pick<APIAttachment, 'id' | 'description'> & Partial<Pick<APIAttachment, 'filename'>>)[] | undefined;
+	attachments?:
+		| (Pick<APIAttachment, 'description'> & {
+				/**
+				 * Attachment id or a number that matches `n` in `files[n]`
+				 */
+				id: Snowflake | number;
+		  } & Partial<Pick<APIAttachment, 'filename'>>)[]
+		| undefined;
 	/**
 	 * Message flags combined as a bitfield
 	 */

--- a/rest/v9/webhook.ts
+++ b/rest/v9/webhook.ts
@@ -5,11 +5,11 @@ import type {
 	APIEmbed,
 	APIMessage,
 	APIWebhook,
-	APIAttachment,
 	MessageFlags,
 	APIMessageActionRowComponent,
 } from '../../payloads/v9/index';
 import type { AddUndefinedToPossiblyUndefinedPropertiesOfInterface, Nullable } from '../../utils/internals';
+import type { RESTAPIAttachment } from './channel';
 /**
  * https://discord.com/developers/docs/resources/webhook#create-webhook
  */
@@ -139,7 +139,7 @@ export interface RESTPostAPIWebhookWithTokenJSONBody {
 	/**
 	 * Attachment objects with filename and description
 	 */
-	attachments?: (Pick<APIAttachment, 'id' | 'description'> & Partial<Pick<APIAttachment, 'filename'>>)[] | undefined;
+	attachments?: RESTAPIAttachment[] | undefined;
 	/**
 	 * Message flags combined as a bitfield
 	 */
@@ -257,7 +257,7 @@ export type RESTPatchAPIWebhookWithTokenMessageJSONBody = AddUndefinedToPossibly
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#attachment-object
 	 */
-	attachments?: (Pick<APIAttachment, 'id'> & Partial<Pick<APIAttachment, 'filename' | 'description'>>)[] | undefined;
+	attachments?: RESTAPIAttachment[] | undefined;
 };
 
 /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`id`s in the `attachments` array should also be typed as `number`s to match `files[n]`, if necessary.

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
https://discord.com/developers/docs/reference#uploading-files