### PR TITLE
refactor(APIInteractionDataResolvedChannel): thread channels

### DIFF
--- a/deno/payloads/v10/_interactions/base.ts
+++ b/deno/payloads/v10/_interactions/base.ts
@@ -1,6 +1,14 @@
 import type { Permissions, Snowflake } from '../../../globals.ts';
 import type { APIRole, LocaleString } from '../../../v10.ts';
-import type { APIAttachment, APIChannel, APIMessage, APIPartialChannel, APIThreadMetadata } from '../channel.ts';
+import type {
+	APIAttachment,
+	APIChannel,
+	APIMessage,
+	APIPartialChannel,
+	APIThreadChannel,
+	ChannelType,
+	ThreadChannelType,
+} from '../channel.ts';
 import type { APIGuildMember } from '../guild.ts';
 import type { APIUser } from '../user.ts';
 import type { InteractionType } from './responses.ts';
@@ -136,14 +144,18 @@ export type APIGuildInteractionWrapper<Original extends APIBaseInteraction<Inter
 > &
 	Required<Pick<Original, 'member' | 'guild_id'>>;
 
+export interface APIInteractionDataResolvedChannelBase<T extends ChannelType> extends Required<APIPartialChannel> {
+	type: T;
+	permissions: Permissions;
+}
+
 /**
  * https://discord.com/developers/docs/resources/channel#channel-object
  */
-export interface APIInteractionDataResolvedChannel extends Required<APIPartialChannel> {
-	thread_metadata?: APIThreadMetadata | null;
-	permissions: Permissions;
-	parent_id?: string | null;
-}
+export type APIInteractionDataResolvedChannel =
+	| APIInteractionDataResolvedChannelBase<Exclude<ChannelType, ThreadChannelType>>
+	| (APIInteractionDataResolvedChannelBase<ThreadChannelType> &
+			Pick<APIThreadChannel, 'thread_metadata' | 'parent_id'>);
 
 /**
  * https://discord.com/developers/docs/resources/guild#guild-member-object

--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -206,12 +206,11 @@ export interface APIGroupDMChannel extends Omit<APIDMChannelBase<ChannelType.Gro
 	managed?: boolean;
 }
 
+export type ThreadChannelType = ChannelType.PublicThread | ChannelType.PrivateThread | ChannelType.AnnouncementThread;
+
 export interface APIThreadChannel
-	extends Omit<
-			APITextBasedChannel<ChannelType.PublicThread | ChannelType.PrivateThread | ChannelType.AnnouncementThread>,
-			'name'
-		>,
-		APIGuildChannel<ChannelType.PublicThread | ChannelType.PrivateThread | ChannelType.AnnouncementThread> {
+	extends Omit<APITextBasedChannel<ThreadChannelType>, 'name'>,
+		APIGuildChannel<ThreadChannelType> {
 	/**
 	 * The client users member for the thread, only included in select endpoints
 	 */

--- a/deno/payloads/v9/_interactions/base.ts
+++ b/deno/payloads/v9/_interactions/base.ts
@@ -1,6 +1,14 @@
 import type { Permissions, Snowflake } from '../../../globals.ts';
 import type { APIRole, LocaleString } from '../../../v9.ts';
-import type { APIAttachment, APIChannel, APIMessage, APIPartialChannel, APIThreadMetadata } from '../channel.ts';
+import type {
+	APIAttachment,
+	APIChannel,
+	APIMessage,
+	APIPartialChannel,
+	APIThreadChannel,
+	ChannelType,
+	ThreadChannelType,
+} from '../channel.ts';
 import type { APIGuildMember } from '../guild.ts';
 import type { APIUser } from '../user.ts';
 import type { InteractionType } from './responses.ts';
@@ -136,14 +144,18 @@ export type APIGuildInteractionWrapper<Original extends APIBaseInteraction<Inter
 > &
 	Required<Pick<Original, 'member' | 'guild_id'>>;
 
+export interface APIInteractionDataResolvedChannelBase<T extends ChannelType> extends Required<APIPartialChannel> {
+	type: T;
+	permissions: Permissions;
+}
+
 /**
  * https://discord.com/developers/docs/resources/channel#channel-object
  */
-export interface APIInteractionDataResolvedChannel extends Required<APIPartialChannel> {
-	thread_metadata?: APIThreadMetadata | null;
-	permissions: Permissions;
-	parent_id?: string | null;
-}
+export type APIInteractionDataResolvedChannel =
+	| APIInteractionDataResolvedChannelBase<Exclude<ChannelType, ThreadChannelType>>
+	| (APIInteractionDataResolvedChannelBase<ThreadChannelType> &
+			Pick<APIThreadChannel, 'thread_metadata' | 'parent_id'>);
 
 /**
  * https://discord.com/developers/docs/resources/guild#guild-member-object

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -202,12 +202,11 @@ export interface APIGroupDMChannel extends Omit<APIDMChannelBase<ChannelType.Gro
 	managed?: boolean;
 }
 
+export type ThreadChannelType = ChannelType.PublicThread | ChannelType.PrivateThread | ChannelType.AnnouncementThread;
+
 export interface APIThreadChannel
-	extends Omit<
-			APITextBasedChannel<ChannelType.PublicThread | ChannelType.PrivateThread | ChannelType.AnnouncementThread>,
-			'name'
-		>,
-		APIGuildChannel<ChannelType.PublicThread | ChannelType.PrivateThread | ChannelType.AnnouncementThread> {
+	extends Omit<APITextBasedChannel<ThreadChannelType>, 'name'>,
+		APIGuildChannel<ThreadChannelType> {
 	/**
 	 * The client users member for the thread, only included in select endpoints
 	 */

--- a/deno/rest/v10/channel.ts
+++ b/deno/rest/v10/channel.ts
@@ -17,6 +17,7 @@ import type {
 	MessageFlags,
 	OverwriteType,
 	ThreadAutoArchiveDuration,
+	ThreadChannelType,
 	VideoQualityMode,
 	APIGuildForumTag,
 	APIGuildForumDefaultReactionEmoji,
@@ -678,7 +679,7 @@ export interface RESTPostAPIChannelThreadsJSONBody extends RESTPostAPIChannelMes
 	 *
 	 * @default ChannelType.PrivateThread
 	 */
-	type?: ChannelType.AnnouncementThread | ChannelType.PublicThread | ChannelType.PrivateThread | undefined;
+	type?: ThreadChannelType | undefined;
 	/**
 	 * Whether non-moderators can add other non-moderators to the thread; only available when creating a private thread
 	 */

--- a/deno/rest/v9/channel.ts
+++ b/deno/rest/v9/channel.ts
@@ -17,6 +17,7 @@ import type {
 	MessageFlags,
 	OverwriteType,
 	ThreadAutoArchiveDuration,
+	ThreadChannelType,
 	VideoQualityMode,
 	APIGuildForumTag,
 	APIGuildForumDefaultReactionEmoji,
@@ -694,7 +695,7 @@ export interface RESTPostAPIChannelThreadsJSONBody extends RESTPostAPIChannelMes
 	 *
 	 * @default ChannelType.PrivateThread
 	 */
-	type?: ChannelType.AnnouncementThread | ChannelType.PublicThread | ChannelType.PrivateThread | undefined;
+	type?: ThreadChannelType | undefined;
 	/**
 	 * Whether non-moderators can add other non-moderators to the thread; only available when creating a private thread
 	 */

--- a/payloads/v10/_interactions/base.ts
+++ b/payloads/v10/_interactions/base.ts
@@ -1,6 +1,14 @@
 import type { Permissions, Snowflake } from '../../../globals';
 import type { APIRole, LocaleString } from '../../../v10';
-import type { APIAttachment, APIChannel, APIMessage, APIPartialChannel, APIThreadMetadata } from '../channel';
+import type {
+	APIAttachment,
+	APIChannel,
+	APIMessage,
+	APIPartialChannel,
+	APIThreadChannel,
+	ChannelType,
+	ThreadChannelType,
+} from '../channel';
 import type { APIGuildMember } from '../guild';
 import type { APIUser } from '../user';
 import type { InteractionType } from './responses';
@@ -136,14 +144,18 @@ export type APIGuildInteractionWrapper<Original extends APIBaseInteraction<Inter
 > &
 	Required<Pick<Original, 'member' | 'guild_id'>>;
 
+export interface APIInteractionDataResolvedChannelBase<T extends ChannelType> extends Required<APIPartialChannel> {
+	type: T;
+	permissions: Permissions;
+}
+
 /**
  * https://discord.com/developers/docs/resources/channel#channel-object
  */
-export interface APIInteractionDataResolvedChannel extends Required<APIPartialChannel> {
-	thread_metadata?: APIThreadMetadata | null;
-	permissions: Permissions;
-	parent_id?: string | null;
-}
+export type APIInteractionDataResolvedChannel =
+	| APIInteractionDataResolvedChannelBase<Exclude<ChannelType, ThreadChannelType>>
+	| (APIInteractionDataResolvedChannelBase<ThreadChannelType> &
+			Pick<APIThreadChannel, 'thread_metadata' | 'parent_id'>);
 
 /**
  * https://discord.com/developers/docs/resources/guild#guild-member-object

--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -206,12 +206,11 @@ export interface APIGroupDMChannel extends Omit<APIDMChannelBase<ChannelType.Gro
 	managed?: boolean;
 }
 
+export type ThreadChannelType = ChannelType.PublicThread | ChannelType.PrivateThread | ChannelType.AnnouncementThread;
+
 export interface APIThreadChannel
-	extends Omit<
-			APITextBasedChannel<ChannelType.PublicThread | ChannelType.PrivateThread | ChannelType.AnnouncementThread>,
-			'name'
-		>,
-		APIGuildChannel<ChannelType.PublicThread | ChannelType.PrivateThread | ChannelType.AnnouncementThread> {
+	extends Omit<APITextBasedChannel<ThreadChannelType>, 'name'>,
+		APIGuildChannel<ThreadChannelType> {
 	/**
 	 * The client users member for the thread, only included in select endpoints
 	 */

--- a/payloads/v9/_interactions/base.ts
+++ b/payloads/v9/_interactions/base.ts
@@ -1,6 +1,14 @@
 import type { Permissions, Snowflake } from '../../../globals';
 import type { APIRole, LocaleString } from '../../../v9';
-import type { APIAttachment, APIChannel, APIMessage, APIPartialChannel, APIThreadMetadata } from '../channel';
+import type {
+	APIAttachment,
+	APIChannel,
+	APIMessage,
+	APIPartialChannel,
+	APIThreadChannel,
+	ChannelType,
+	ThreadChannelType,
+} from '../channel';
 import type { APIGuildMember } from '../guild';
 import type { APIUser } from '../user';
 import type { InteractionType } from './responses';
@@ -136,14 +144,18 @@ export type APIGuildInteractionWrapper<Original extends APIBaseInteraction<Inter
 > &
 	Required<Pick<Original, 'member' | 'guild_id'>>;
 
+export interface APIInteractionDataResolvedChannelBase<T extends ChannelType> extends Required<APIPartialChannel> {
+	type: T;
+	permissions: Permissions;
+}
+
 /**
  * https://discord.com/developers/docs/resources/channel#channel-object
  */
-export interface APIInteractionDataResolvedChannel extends Required<APIPartialChannel> {
-	thread_metadata?: APIThreadMetadata | null;
-	permissions: Permissions;
-	parent_id?: string | null;
-}
+export type APIInteractionDataResolvedChannel =
+	| APIInteractionDataResolvedChannelBase<Exclude<ChannelType, ThreadChannelType>>
+	| (APIInteractionDataResolvedChannelBase<ThreadChannelType> &
+			Pick<APIThreadChannel, 'thread_metadata' | 'parent_id'>);
 
 /**
  * https://discord.com/developers/docs/resources/guild#guild-member-object

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -202,12 +202,11 @@ export interface APIGroupDMChannel extends Omit<APIDMChannelBase<ChannelType.Gro
 	managed?: boolean;
 }
 
+export type ThreadChannelType = ChannelType.PublicThread | ChannelType.PrivateThread | ChannelType.AnnouncementThread;
+
 export interface APIThreadChannel
-	extends Omit<
-			APITextBasedChannel<ChannelType.PublicThread | ChannelType.PrivateThread | ChannelType.AnnouncementThread>,
-			'name'
-		>,
-		APIGuildChannel<ChannelType.PublicThread | ChannelType.PrivateThread | ChannelType.AnnouncementThread> {
+	extends Omit<APITextBasedChannel<ThreadChannelType>, 'name'>,
+		APIGuildChannel<ThreadChannelType> {
 	/**
 	 * The client users member for the thread, only included in select endpoints
 	 */

--- a/rest/v10/channel.ts
+++ b/rest/v10/channel.ts
@@ -17,6 +17,7 @@ import type {
 	MessageFlags,
 	OverwriteType,
 	ThreadAutoArchiveDuration,
+	ThreadChannelType,
 	VideoQualityMode,
 	APIGuildForumTag,
 	APIGuildForumDefaultReactionEmoji,
@@ -678,7 +679,7 @@ export interface RESTPostAPIChannelThreadsJSONBody extends RESTPostAPIChannelMes
 	 *
 	 * @default ChannelType.PrivateThread
 	 */
-	type?: ChannelType.AnnouncementThread | ChannelType.PublicThread | ChannelType.PrivateThread | undefined;
+	type?: ThreadChannelType | undefined;
 	/**
 	 * Whether non-moderators can add other non-moderators to the thread; only available when creating a private thread
 	 */

--- a/rest/v9/channel.ts
+++ b/rest/v9/channel.ts
@@ -17,6 +17,7 @@ import type {
 	MessageFlags,
 	OverwriteType,
 	ThreadAutoArchiveDuration,
+	ThreadChannelType,
 	VideoQualityMode,
 	APIGuildForumTag,
 	APIGuildForumDefaultReactionEmoji,
@@ -694,7 +695,7 @@ export interface RESTPostAPIChannelThreadsJSONBody extends RESTPostAPIChannelMes
 	 *
 	 * @default ChannelType.PrivateThread
 	 */
-	type?: ChannelType.AnnouncementThread | ChannelType.PublicThread | ChannelType.PrivateThread | undefined;
+	type?: ThreadChannelType | undefined;
 	/**
 	 * Whether non-moderators can add other non-moderators to the thread; only available when creating a private thread
 	 */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
- Brings `APIInteractionDataResolvedChannel`  into line with the [API specification](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-resolved-data-structure) (`thread_metadata`, `parent_id` only exist on thread channel partials)
- adds the utility type `ThreadChannelType` to facilitate the above, which also allows some deduping in the type declaration for `APIThreadChannel`