### PR TITLE
chore: use string values in vs code settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,9 +2,9 @@
 	"files.eol": "\n",
 	"typescript.tsdk": "node_modules/typescript/lib",
 	"editor.codeActionsOnSave": {
-		"source.organizeImports": false,
-		"source.fixAll": true,
-		"source.fixAll.eslint": true
+		"source.organizeImports": "never",
+		"source.fixAll": "explicit",
+		"source.fixAll.eslint": "explicit"
 	},
 	"cSpell.enableFiletypes": ["mdx"]
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Boolean values will soon be deprecated, and these values are automatically changed whenever you launch Visual Studio Code (only Insiders for now as far as I know).

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
