### PR TITLE
fix(GatewayGuildDeleteDispatchData): make unavailable optional

### DIFF
--- a/deno/gateway/v10.ts
+++ b/deno/gateway/v10.ts
@@ -847,7 +847,8 @@ export type GatewayGuildDeleteDispatch = DataPayload<GatewayDispatchEvents.Guild
 /**
  * https://discord.com/developers/docs/topics/gateway-events#guild-delete
  */
-export type GatewayGuildDeleteDispatchData = APIUnavailableGuild;
+export type GatewayGuildDeleteDispatchData = Omit<APIUnavailableGuild, 'unavailable'> &
+	Partial<Pick<APIUnavailableGuild, 'unavailable'>>;
 
 /**
  * https://discord.com/developers/docs/topics/gateway-events#guild-ban-add

--- a/deno/gateway/v9.ts
+++ b/deno/gateway/v9.ts
@@ -846,7 +846,8 @@ export type GatewayGuildDeleteDispatch = DataPayload<GatewayDispatchEvents.Guild
 /**
  * https://discord.com/developers/docs/topics/gateway-events#guild-delete
  */
-export type GatewayGuildDeleteDispatchData = APIUnavailableGuild;
+export type GatewayGuildDeleteDispatchData = Omit<APIUnavailableGuild, 'unavailable'> &
+	Partial<Pick<APIUnavailableGuild, 'unavailable'>>;
 
 /**
  * https://discord.com/developers/docs/topics/gateway-events#guild-ban-add

--- a/gateway/v10.ts
+++ b/gateway/v10.ts
@@ -847,7 +847,8 @@ export type GatewayGuildDeleteDispatch = DataPayload<GatewayDispatchEvents.Guild
 /**
  * https://discord.com/developers/docs/topics/gateway-events#guild-delete
  */
-export type GatewayGuildDeleteDispatchData = APIUnavailableGuild;
+export type GatewayGuildDeleteDispatchData = Omit<APIUnavailableGuild, 'unavailable'> &
+	Partial<Pick<APIUnavailableGuild, 'unavailable'>>;
 
 /**
  * https://discord.com/developers/docs/topics/gateway-events#guild-ban-add

--- a/gateway/v9.ts
+++ b/gateway/v9.ts
@@ -846,7 +846,8 @@ export type GatewayGuildDeleteDispatch = DataPayload<GatewayDispatchEvents.Guild
 /**
  * https://discord.com/developers/docs/topics/gateway-events#guild-delete
  */
-export type GatewayGuildDeleteDispatchData = APIUnavailableGuild;
+export type GatewayGuildDeleteDispatchData = Omit<APIUnavailableGuild, 'unavailable'> &
+	Partial<Pick<APIUnavailableGuild, 'unavailable'>>;
 
 /**
  * https://discord.com/developers/docs/topics/gateway-events#guild-ban-add


### PR DESCRIPTION
The `unavailable` field in `GatewayGuildDeleteDispatchData` can be undefined, but in the API types, it's marked as always present. Even though the [documentation](https://discord.com/developers/docs/topics/gateway-events#guild-delete) specifies that it's an unavailable guild, and the example object has the field present, it says that the field can be not set:

>  If the `unavailable` field is not set, the user was removed from the guild.

I also confirmed this with some of my own testing. I added and then kicked a bot from a guild, and got a guild delete event without the `unavailable` field. One thing I'm not sure about though is if the optional should be on `APIUnavailableGuild` instead of the dispatch, as the docs are vague on the details.