### PR TITLE
fix(CDNRoutes): fix store page wrong extension

### DIFF
--- a/deno/rest/v10/mod.ts
+++ b/deno/rest/v10/mod.ts
@@ -1112,8 +1112,8 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	storePageAsset(applicationId: Snowflake, assetId: string) {
-		return `/app-assets/${applicationId}/store/${assetId}.png` as const;
+	storePageAsset(applicationId: Snowflake, assetId: string, format: StorePageAssetFormat) {
+		return `/app-assets/${applicationId}/store/${assetId}.${format}` as const;
 	},
 
 	/**
@@ -1188,6 +1188,7 @@ export type ApplicationAssetFormat = Exclude<ImageFormat, ImageFormat.Lottie | I
 export type AchievementIconFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
 export type StickerPackBannerFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
 export type TeamIconFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+export type StorePageAssetFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
 export type StickerFormat = Extract<ImageFormat, ImageFormat.PNG | ImageFormat.Lottie | ImageFormat.GIF>;
 export type RoleIconFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
 export type GuildScheduledEventCoverFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;

--- a/deno/rest/v9/mod.ts
+++ b/deno/rest/v9/mod.ts
@@ -1121,8 +1121,8 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	storePageAsset(applicationId: Snowflake, assetId: string) {
-		return `/app-assets/${applicationId}/store/${assetId}.png` as const;
+	storePageAsset(applicationId: Snowflake, assetId: string, format: StorePageAssetFormat) {
+		return `/app-assets/${applicationId}/store/${assetId}.${format}` as const;
 	},
 
 	/**
@@ -1196,6 +1196,7 @@ export type ApplicationCoverFormat = Exclude<ImageFormat, ImageFormat.Lottie | I
 export type ApplicationAssetFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
 export type AchievementIconFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
 export type StickerPackBannerFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+export type StorePageAssetFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
 export type TeamIconFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
 export type StickerFormat = Extract<ImageFormat, ImageFormat.PNG | ImageFormat.Lottie | ImageFormat.GIF>;
 export type RoleIconFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;

--- a/rest/v10/index.ts
+++ b/rest/v10/index.ts
@@ -1112,8 +1112,8 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	storePageAsset(applicationId: Snowflake, assetId: string) {
-		return `/app-assets/${applicationId}/store/${assetId}.png` as const;
+	storePageAsset(applicationId: Snowflake, assetId: string, format: StorePageAssetFormat) {
+		return `/app-assets/${applicationId}/store/${assetId}.${format}` as const;
 	},
 
 	/**
@@ -1188,6 +1188,7 @@ export type ApplicationAssetFormat = Exclude<ImageFormat, ImageFormat.Lottie | I
 export type AchievementIconFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
 export type StickerPackBannerFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
 export type TeamIconFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+export type StorePageAssetFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
 export type StickerFormat = Extract<ImageFormat, ImageFormat.PNG | ImageFormat.Lottie | ImageFormat.GIF>;
 export type RoleIconFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
 export type GuildScheduledEventCoverFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;

--- a/rest/v9/index.ts
+++ b/rest/v9/index.ts
@@ -1121,8 +1121,8 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	storePageAsset(applicationId: Snowflake, assetId: string) {
-		return `/app-assets/${applicationId}/store/${assetId}.png` as const;
+	storePageAsset(applicationId: Snowflake, assetId: string, format: StorePageAssetFormat) {
+		return `/app-assets/${applicationId}/store/${assetId}.${format}` as const;
 	},
 
 	/**
@@ -1196,6 +1196,7 @@ export type ApplicationCoverFormat = Exclude<ImageFormat, ImageFormat.Lottie | I
 export type ApplicationAssetFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
 export type AchievementIconFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
 export type StickerPackBannerFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
+export type StorePageAssetFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
 export type TeamIconFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
 export type StickerFormat = Extract<ImageFormat, ImageFormat.PNG | ImageFormat.Lottie | ImageFormat.GIF>;
 export type RoleIconFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixes the issue addressed in #866, `storePageAsset` only returns the PNG route but the Discord documentation says that route supports PNG, JPEG, and WebP.

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
