### PR TITLE
types(CDNRoutes): use generics for `format` options

### DIFF
--- a/deno/rest/v10/mod.ts
+++ b/deno/rest/v10/mod.ts
@@ -943,7 +943,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	emoji(emojiId: Snowflake, format: EmojiFormat) {
+	emoji<TFormat extends EmojiFormat>(emojiId: Snowflake, format: TFormat) {
 		return `/emojis/${emojiId}.${format}` as const;
 	},
 
@@ -955,7 +955,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildIcon(guildId: Snowflake, guildIcon: string, format: GuildIconFormat) {
+	guildIcon<TFormat extends GuildIconFormat>(guildId: Snowflake, guildIcon: string, format: TFormat) {
 		return `icons/${guildId}/${guildIcon}.${format}` as const;
 	},
 
@@ -965,7 +965,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildSplash(guildId: Snowflake, guildSplash: string, format: GuildSplashFormat) {
+	guildSplash<TFormat extends GuildSplashFormat>(guildId: Snowflake, guildSplash: string, format: TFormat) {
 		return `/splashes/${guildId}/${guildSplash}.${format}` as const;
 	},
 
@@ -975,7 +975,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildDiscoverySplash(guildId: Snowflake, guildDiscoverySplash: string, format: GuildDiscoverySplashFormat) {
+	guildDiscoverySplash<TFormat extends GuildDiscoverySplashFormat>(
+		guildId: Snowflake,
+		guildDiscoverySplash: string,
+		format: TFormat,
+	) {
 		return `/discovery-splashes/${guildId}/${guildDiscoverySplash}.${format}` as const;
 	},
 
@@ -987,7 +991,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildBanner(guildId: Snowflake, guildBanner: string, format: GuildBannerFormat) {
+	guildBanner<TFormat extends GuildBannerFormat>(guildId: Snowflake, guildBanner: string, format: TFormat) {
 		return `/banners/${guildId}/${guildBanner}.${format}` as const;
 	},
 
@@ -999,7 +1003,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	userBanner(userId: Snowflake, userBanner: string, format: UserBannerFormat) {
+	userBanner<TFormat extends UserBannerFormat>(userId: Snowflake, userBanner: string, format: TFormat) {
 		return `/banners/${userId}/${userBanner}.${format}` as const;
 	},
 
@@ -1013,7 +1017,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extension: PNG
 	 */
-	defaultUserAvatar(index: DefaultUserAvatarAssets) {
+	defaultUserAvatar<TIndex extends DefaultUserAvatarAssets>(index: TIndex) {
 		return `/embed/avatars/${index}.png` as const;
 	},
 
@@ -1025,7 +1029,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	userAvatar(userId: Snowflake, userAvatar: string, format: UserAvatarFormat) {
+	userAvatar<TFormat extends UserAvatarFormat>(userId: Snowflake, userAvatar: string, format: TFormat) {
 		return `/avatars/${userId}/${userAvatar}.${format}` as const;
 	},
 
@@ -1037,7 +1041,12 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildMemberAvatar(guildId: Snowflake, userId: Snowflake, memberAvatar: string, format: GuildMemberAvatarFormat) {
+	guildMemberAvatar<TFormat extends GuildMemberAvatarFormat>(
+		guildId: Snowflake,
+		userId: Snowflake,
+		memberAvatar: string,
+		format: TFormat,
+	) {
 		return `/guilds/${guildId}/users/${userId}/avatars/${memberAvatar}.${format}` as const;
 	},
 
@@ -1057,7 +1066,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationIcon(applicationId: Snowflake, applicationIcon: string, format: ApplicationIconFormat) {
+	applicationIcon<TFormat extends ApplicationIconFormat>(
+		applicationId: Snowflake,
+		applicationIcon: string,
+		format: TFormat,
+	) {
 		return `/app-icons/${applicationId}/${applicationIcon}.${format}` as const;
 	},
 
@@ -1067,7 +1080,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationCover(applicationId: Snowflake, applicationCoverImage: string, format: ApplicationCoverFormat) {
+	applicationCover<TFormat extends ApplicationCoverFormat>(
+		applicationId: Snowflake,
+		applicationCoverImage: string,
+		format: TFormat,
+	) {
 		return `/app-icons/${applicationId}/${applicationCoverImage}.${format}` as const;
 	},
 
@@ -1077,7 +1094,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationAsset(applicationId: Snowflake, applicationAssetId: string, format: ApplicationAssetFormat) {
+	applicationAsset<TFormat extends ApplicationAssetFormat>(
+		applicationId: Snowflake,
+		applicationAssetId: string,
+		format: TFormat,
+	) {
 		return `/app-assets/${applicationId}/${applicationAssetId}.${format}` as const;
 	},
 
@@ -1087,11 +1108,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	achievementIcon(
+	achievementIcon<TFormat extends AchievementIconFormat>(
 		applicationId: Snowflake,
 		achievementId: Snowflake,
 		achievementIconHash: string,
-		format: AchievementIconFormat,
+		format: TFormat,
 	) {
 		return `/app-assets/${applicationId}/achievements/${achievementId}/icons/${achievementIconHash}.${format}` as const;
 	},
@@ -1102,7 +1123,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	stickerPackBanner(stickerPackBannerAssetId: Snowflake, format: StickerPackBannerFormat) {
+	stickerPackBanner<TFormat extends StickerPackBannerFormat>(stickerPackBannerAssetId: Snowflake, format: TFormat) {
 		return `/app-assets/${StickerPackApplicationId}/store/${stickerPackBannerAssetId}.${format}` as const;
 	},
 
@@ -1112,7 +1133,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	storePageAsset(applicationId: Snowflake, assetId: string, format: StorePageAssetFormat) {
+	storePageAsset<TFormat extends StorePageAssetFormat>(applicationId: Snowflake, assetId: string, format: TFormat) {
 		return `/app-assets/${applicationId}/store/${assetId}.${format}` as const;
 	},
 
@@ -1122,7 +1143,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	teamIcon(teamId: Snowflake, teamIcon: string, format: TeamIconFormat) {
+	teamIcon<TFormat extends TeamIconFormat>(teamId: Snowflake, teamIcon: string, format: TFormat) {
 		return `/team-icons/${teamId}/${teamIcon}.${format}` as const;
 	},
 
@@ -1132,7 +1153,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, Lottie, GIF
 	 */
-	sticker(stickerId: Snowflake, format: StickerFormat) {
+	sticker<TFormat extends StickerFormat>(stickerId: Snowflake, format: TFormat) {
 		return `/stickers/${stickerId}.${format}` as const;
 	},
 
@@ -1142,7 +1163,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	roleIcon(roleId: Snowflake, roleIcon: string, format: RoleIconFormat) {
+	roleIcon<TFormat extends RoleIconFormat>(roleId: Snowflake, roleIcon: string, format: TFormat) {
 		return `/role-icons/${roleId}/${roleIcon}.${format}` as const;
 	},
 
@@ -1152,10 +1173,10 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildScheduledEventCover(
+	guildScheduledEventCover<TFormat extends GuildScheduledEventCoverFormat>(
 		guildScheduledEventId: Snowflake,
 		guildScheduledEventCoverImage: string,
-		format: GuildScheduledEventCoverFormat,
+		format: TFormat,
 	) {
 		return `/guild-events/${guildScheduledEventId}/${guildScheduledEventCoverImage}.${format}` as const;
 	},
@@ -1166,7 +1187,12 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildMemberBanner(guildId: Snowflake, userId: Snowflake, guildMemberBanner: string, format: GuildMemberBannerFormat) {
+	guildMemberBanner<TFormat extends GuildMemberBannerFormat>(
+		guildId: Snowflake,
+		userId: Snowflake,
+		guildMemberBanner: string,
+		format: TFormat,
+	) {
 		return `/guilds/${guildId}/users/${userId}/banners/${guildMemberBanner}.${format}` as const;
 	},
 };

--- a/deno/rest/v10/mod.ts
+++ b/deno/rest/v10/mod.ts
@@ -1141,7 +1141,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	storePageAsset(applicationId: Snowflake, assetId: string, format: StorePageAssetFormat = ImageFormat.PNG) {
+	storePageAsset<Format extends StorePageAssetFormat>(
+		applicationId: Snowflake,
+		assetId: string,
+		format: Format = ImageFormat.PNG as Format,
+	) {
 		return `/app-assets/${applicationId}/store/${assetId}.${format}` as const;
 	},
 

--- a/deno/rest/v10/mod.ts
+++ b/deno/rest/v10/mod.ts
@@ -943,7 +943,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	emoji<TFormat extends EmojiFormat>(emojiId: Snowflake, format: TFormat) {
+	emoji<Format extends EmojiFormat>(emojiId: Snowflake, format: Format) {
 		return `/emojis/${emojiId}.${format}` as const;
 	},
 
@@ -955,7 +955,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildIcon<TFormat extends GuildIconFormat>(guildId: Snowflake, guildIcon: string, format: TFormat) {
+	guildIcon<Format extends GuildIconFormat>(guildId: Snowflake, guildIcon: string, format: Format) {
 		return `icons/${guildId}/${guildIcon}.${format}` as const;
 	},
 
@@ -965,7 +965,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildSplash<TFormat extends GuildSplashFormat>(guildId: Snowflake, guildSplash: string, format: TFormat) {
+	guildSplash<Format extends GuildSplashFormat>(guildId: Snowflake, guildSplash: string, format: Format) {
 		return `/splashes/${guildId}/${guildSplash}.${format}` as const;
 	},
 
@@ -975,10 +975,10 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildDiscoverySplash<TFormat extends GuildDiscoverySplashFormat>(
+	guildDiscoverySplash<Format extends GuildDiscoverySplashFormat>(
 		guildId: Snowflake,
 		guildDiscoverySplash: string,
-		format: TFormat,
+		format: Format,
 	) {
 		return `/discovery-splashes/${guildId}/${guildDiscoverySplash}.${format}` as const;
 	},
@@ -991,7 +991,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildBanner<TFormat extends GuildBannerFormat>(guildId: Snowflake, guildBanner: string, format: TFormat) {
+	guildBanner<Format extends GuildBannerFormat>(guildId: Snowflake, guildBanner: string, format: Format) {
 		return `/banners/${guildId}/${guildBanner}.${format}` as const;
 	},
 
@@ -1003,7 +1003,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	userBanner<TFormat extends UserBannerFormat>(userId: Snowflake, userBanner: string, format: TFormat) {
+	userBanner<Format extends UserBannerFormat>(userId: Snowflake, userBanner: string, format: Format) {
 		return `/banners/${userId}/${userBanner}.${format}` as const;
 	},
 
@@ -1017,7 +1017,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extension: PNG
 	 */
-	defaultUserAvatar<TIndex extends DefaultUserAvatarAssets>(index: TIndex) {
+	defaultUserAvatar<Index extends DefaultUserAvatarAssets>(index: Index) {
 		return `/embed/avatars/${index}.png` as const;
 	},
 
@@ -1029,7 +1029,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	userAvatar<TFormat extends UserAvatarFormat>(userId: Snowflake, userAvatar: string, format: TFormat) {
+	userAvatar<Format extends UserAvatarFormat>(userId: Snowflake, userAvatar: string, format: Format) {
 		return `/avatars/${userId}/${userAvatar}.${format}` as const;
 	},
 
@@ -1041,11 +1041,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildMemberAvatar<TFormat extends GuildMemberAvatarFormat>(
+	guildMemberAvatar<Format extends GuildMemberAvatarFormat>(
 		guildId: Snowflake,
 		userId: Snowflake,
 		memberAvatar: string,
-		format: TFormat,
+		format: Format,
 	) {
 		return `/guilds/${guildId}/users/${userId}/avatars/${memberAvatar}.${format}` as const;
 	},
@@ -1066,10 +1066,10 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationIcon<TFormat extends ApplicationIconFormat>(
+	applicationIcon<Format extends ApplicationIconFormat>(
 		applicationId: Snowflake,
 		applicationIcon: string,
-		format: TFormat,
+		format: Format,
 	) {
 		return `/app-icons/${applicationId}/${applicationIcon}.${format}` as const;
 	},
@@ -1080,10 +1080,10 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationCover<TFormat extends ApplicationCoverFormat>(
+	applicationCover<Format extends ApplicationCoverFormat>(
 		applicationId: Snowflake,
 		applicationCoverImage: string,
-		format: TFormat,
+		format: Format,
 	) {
 		return `/app-icons/${applicationId}/${applicationCoverImage}.${format}` as const;
 	},
@@ -1094,10 +1094,10 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationAsset<TFormat extends ApplicationAssetFormat>(
+	applicationAsset<Format extends ApplicationAssetFormat>(
 		applicationId: Snowflake,
 		applicationAssetId: string,
-		format: TFormat,
+		format: Format,
 	) {
 		return `/app-assets/${applicationId}/${applicationAssetId}.${format}` as const;
 	},
@@ -1108,11 +1108,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	achievementIcon<TFormat extends AchievementIconFormat>(
+	achievementIcon<Format extends AchievementIconFormat>(
 		applicationId: Snowflake,
 		achievementId: Snowflake,
 		achievementIconHash: string,
-		format: TFormat,
+		format: Format,
 	) {
 		return `/app-assets/${applicationId}/achievements/${achievementId}/icons/${achievementIconHash}.${format}` as const;
 	},
@@ -1123,7 +1123,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	stickerPackBanner<TFormat extends StickerPackBannerFormat>(stickerPackBannerAssetId: Snowflake, format: TFormat) {
+	stickerPackBanner<Format extends StickerPackBannerFormat>(stickerPackBannerAssetId: Snowflake, format: Format) {
 		return `/app-assets/${StickerPackApplicationId}/store/${stickerPackBannerAssetId}.${format}` as const;
 	},
 
@@ -1133,7 +1133,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	storePageAsset<TFormat extends StorePageAssetFormat>(applicationId: Snowflake, assetId: string, format: TFormat) {
+	storePageAsset<Format extends StorePageAssetFormat>(applicationId: Snowflake, assetId: string, format: Format) {
 		return `/app-assets/${applicationId}/store/${assetId}.${format}` as const;
 	},
 
@@ -1143,7 +1143,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	teamIcon<TFormat extends TeamIconFormat>(teamId: Snowflake, teamIcon: string, format: TFormat) {
+	teamIcon<Format extends TeamIconFormat>(teamId: Snowflake, teamIcon: string, format: Format) {
 		return `/team-icons/${teamId}/${teamIcon}.${format}` as const;
 	},
 
@@ -1153,7 +1153,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, Lottie, GIF
 	 */
-	sticker<TFormat extends StickerFormat>(stickerId: Snowflake, format: TFormat) {
+	sticker<Format extends StickerFormat>(stickerId: Snowflake, format: Format) {
 		return `/stickers/${stickerId}.${format}` as const;
 	},
 
@@ -1163,7 +1163,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	roleIcon<TFormat extends RoleIconFormat>(roleId: Snowflake, roleIcon: string, format: TFormat) {
+	roleIcon<Format extends RoleIconFormat>(roleId: Snowflake, roleIcon: string, format: Format) {
 		return `/role-icons/${roleId}/${roleIcon}.${format}` as const;
 	},
 
@@ -1173,10 +1173,10 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildScheduledEventCover<TFormat extends GuildScheduledEventCoverFormat>(
+	guildScheduledEventCover<Format extends GuildScheduledEventCoverFormat>(
 		guildScheduledEventId: Snowflake,
 		guildScheduledEventCoverImage: string,
-		format: TFormat,
+		format: Format,
 	) {
 		return `/guild-events/${guildScheduledEventId}/${guildScheduledEventCoverImage}.${format}` as const;
 	},
@@ -1187,11 +1187,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildMemberBanner<TFormat extends GuildMemberBannerFormat>(
+	guildMemberBanner<Format extends GuildMemberBannerFormat>(
 		guildId: Snowflake,
 		userId: Snowflake,
 		guildMemberBanner: string,
-		format: TFormat,
+		format: Format,
 	) {
 		return `/guilds/${guildId}/users/${userId}/banners/${guildMemberBanner}.${format}` as const;
 	},

--- a/deno/rest/v10/mod.ts
+++ b/deno/rest/v10/mod.ts
@@ -1141,7 +1141,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	storePageAsset<Format extends StorePageAssetFormat>(
+	storePageAsset<Format extends StorePageAssetFormat = ImageFormat.PNG>(
 		applicationId: Snowflake,
 		assetId: string,
 		format: Format = ImageFormat.PNG as Format,

--- a/deno/rest/v9/mod.ts
+++ b/deno/rest/v9/mod.ts
@@ -1150,7 +1150,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	storePageAsset(applicationId: Snowflake, assetId: string, format: StorePageAssetFormat = ImageFormat.PNG) {
+	storePageAsset<Format extends StorePageAssetFormat>(
+		applicationId: Snowflake,
+		assetId: string,
+		format: Format = ImageFormat.PNG as Format,
+	) {
 		return `/app-assets/${applicationId}/store/${assetId}.${format}` as const;
 	},
 

--- a/deno/rest/v9/mod.ts
+++ b/deno/rest/v9/mod.ts
@@ -952,7 +952,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	emoji(emojiId: Snowflake, format: EmojiFormat) {
+	emoji<TFormat extends EmojiFormat>(emojiId: Snowflake, format: TFormat) {
 		return `/emojis/${emojiId}.${format}` as const;
 	},
 
@@ -964,7 +964,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildIcon(guildId: Snowflake, guildIcon: string, format: GuildIconFormat) {
+	guildIcon<TFormat extends GuildIconFormat>(guildId: Snowflake, guildIcon: string, format: TFormat) {
 		return `icons/${guildId}/${guildIcon}.${format}` as const;
 	},
 
@@ -974,7 +974,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildSplash(guildId: Snowflake, guildSplash: string, format: GuildSplashFormat) {
+	guildSplash<TFormat extends GuildSplashFormat>(guildId: Snowflake, guildSplash: string, format: TFormat) {
 		return `/splashes/${guildId}/${guildSplash}.${format}` as const;
 	},
 
@@ -984,7 +984,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildDiscoverySplash(guildId: Snowflake, guildDiscoverySplash: string, format: GuildDiscoverySplashFormat) {
+	guildDiscoverySplash<TFormat extends GuildDiscoverySplashFormat>(
+		guildId: Snowflake,
+		guildDiscoverySplash: string,
+		format: TFormat,
+	) {
 		return `/discovery-splashes/${guildId}/${guildDiscoverySplash}.${format}` as const;
 	},
 
@@ -996,7 +1000,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildBanner(guildId: Snowflake, guildBanner: string, format: GuildBannerFormat) {
+	guildBanner<TFormat extends GuildBannerFormat>(guildId: Snowflake, guildBanner: string, format: TFormat) {
 		return `/banners/${guildId}/${guildBanner}.${format}` as const;
 	},
 
@@ -1008,7 +1012,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	userBanner(userId: Snowflake, userBanner: string, format: UserBannerFormat) {
+	userBanner<TFormat extends UserBannerFormat>(userId: Snowflake, userBanner: string, format: TFormat) {
 		return `/banners/${userId}/${userBanner}.${format}` as const;
 	},
 
@@ -1022,7 +1026,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extension: PNG
 	 */
-	defaultUserAvatar(index: DefaultUserAvatarAssets) {
+	defaultUserAvatar<TIndex extends DefaultUserAvatarAssets>(index: TIndex) {
 		return `/embed/avatars/${index}.png` as const;
 	},
 
@@ -1034,7 +1038,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	userAvatar(userId: Snowflake, userAvatar: string, format: UserAvatarFormat) {
+	userAvatar<TFormat extends UserAvatarFormat>(userId: Snowflake, userAvatar: string, format: TFormat) {
 		return `/avatars/${userId}/${userAvatar}.${format}` as const;
 	},
 
@@ -1046,7 +1050,12 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildMemberAvatar(guildId: Snowflake, userId: Snowflake, memberAvatar: string, format: GuildMemberAvatarFormat) {
+	guildMemberAvatar<TFormat extends GuildMemberAvatarFormat>(
+		guildId: Snowflake,
+		userId: Snowflake,
+		memberAvatar: string,
+		format: TFormat,
+	) {
 		return `/guilds/${guildId}/users/${userId}/avatars/${memberAvatar}.${format}` as const;
 	},
 
@@ -1066,7 +1075,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationIcon(applicationId: Snowflake, applicationIcon: string, format: ApplicationIconFormat) {
+	applicationIcon<TFormat extends ApplicationIconFormat>(
+		applicationId: Snowflake,
+		applicationIcon: string,
+		format: TFormat,
+	) {
 		return `/app-icons/${applicationId}/${applicationIcon}.${format}` as const;
 	},
 
@@ -1076,7 +1089,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationCover(applicationId: Snowflake, applicationCoverImage: string, format: ApplicationCoverFormat) {
+	applicationCover<TFormat extends ApplicationCoverFormat>(
+		applicationId: Snowflake,
+		applicationCoverImage: string,
+		format: TFormat,
+	) {
 		return `/app-icons/${applicationId}/${applicationCoverImage}.${format}` as const;
 	},
 
@@ -1086,7 +1103,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationAsset(applicationId: Snowflake, applicationAssetId: string, format: ApplicationAssetFormat) {
+	applicationAsset<TFormat extends ApplicationAssetFormat>(
+		applicationId: Snowflake,
+		applicationAssetId: string,
+		format: TFormat,
+	) {
 		return `/app-assets/${applicationId}/${applicationAssetId}.${format}` as const;
 	},
 
@@ -1096,11 +1117,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	achievementIcon(
+	achievementIcon<TFormat extends AchievementIconFormat>(
 		applicationId: Snowflake,
 		achievementId: Snowflake,
 		achievementIconHash: string,
-		format: AchievementIconFormat,
+		format: TFormat,
 	) {
 		return `/app-assets/${applicationId}/achievements/${achievementId}/icons/${achievementIconHash}.${format}` as const;
 	},
@@ -1111,7 +1132,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	stickerPackBanner(stickerPackBannerAssetId: Snowflake, format: StickerPackBannerFormat) {
+	stickerPackBanner<TFormat extends StickerPackBannerFormat>(stickerPackBannerAssetId: Snowflake, format: TFormat) {
 		return `/app-assets/${StickerPackApplicationId}/store/${stickerPackBannerAssetId}.${format}` as const;
 	},
 
@@ -1121,7 +1142,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	storePageAsset(applicationId: Snowflake, assetId: string, format: StorePageAssetFormat) {
+	storePageAsset<TFormat extends StorePageAssetFormat>(applicationId: Snowflake, assetId: string, format: TFormat) {
 		return `/app-assets/${applicationId}/store/${assetId}.${format}` as const;
 	},
 
@@ -1131,7 +1152,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	teamIcon(teamId: Snowflake, teamIcon: string, format: TeamIconFormat) {
+	teamIcon<TFormat extends TeamIconFormat>(teamId: Snowflake, teamIcon: string, format: TFormat) {
 		return `/team-icons/${teamId}/${teamIcon}.${format}` as const;
 	},
 
@@ -1141,7 +1162,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, Lottie, GIF
 	 */
-	sticker(stickerId: Snowflake, format: StickerFormat) {
+	sticker<TFormat extends StickerFormat>(stickerId: Snowflake, format: TFormat) {
 		return `/stickers/${stickerId}.${format}` as const;
 	},
 
@@ -1151,7 +1172,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	roleIcon(roleId: Snowflake, roleIcon: string, format: RoleIconFormat) {
+	roleIcon<TFormat extends RoleIconFormat>(roleId: Snowflake, roleIcon: string, format: TFormat) {
 		return `/role-icons/${roleId}/${roleIcon}.${format}` as const;
 	},
 
@@ -1161,10 +1182,10 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildScheduledEventCover(
+	guildScheduledEventCover<TFormat extends GuildScheduledEventCoverFormat>(
 		guildScheduledEventId: Snowflake,
 		guildScheduledEventCoverImage: string,
-		format: GuildScheduledEventCoverFormat,
+		format: TFormat,
 	) {
 		return `/guild-events/${guildScheduledEventId}/${guildScheduledEventCoverImage}.${format}` as const;
 	},
@@ -1175,7 +1196,12 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildMemberBanner(guildId: Snowflake, userId: Snowflake, guildMemberBanner: string, format: GuildMemberBannerFormat) {
+	guildMemberBanner<TFormat extends GuildMemberBannerFormat>(
+		guildId: Snowflake,
+		userId: Snowflake,
+		guildMemberBanner: string,
+		format: TFormat,
+	) {
 		return `/guilds/${guildId}/users/${userId}/banners/${guildMemberBanner}.${format}` as const;
 	},
 };

--- a/deno/rest/v9/mod.ts
+++ b/deno/rest/v9/mod.ts
@@ -1150,7 +1150,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	storePageAsset<Format extends StorePageAssetFormat>(
+	storePageAsset<Format extends StorePageAssetFormat = ImageFormat.PNG>(
 		applicationId: Snowflake,
 		assetId: string,
 		format: Format = ImageFormat.PNG as Format,

--- a/deno/rest/v9/mod.ts
+++ b/deno/rest/v9/mod.ts
@@ -952,7 +952,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	emoji<TFormat extends EmojiFormat>(emojiId: Snowflake, format: TFormat) {
+	emoji<Format extends EmojiFormat>(emojiId: Snowflake, format: Format) {
 		return `/emojis/${emojiId}.${format}` as const;
 	},
 
@@ -964,7 +964,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildIcon<TFormat extends GuildIconFormat>(guildId: Snowflake, guildIcon: string, format: TFormat) {
+	guildIcon<Format extends GuildIconFormat>(guildId: Snowflake, guildIcon: string, format: Format) {
 		return `icons/${guildId}/${guildIcon}.${format}` as const;
 	},
 
@@ -974,7 +974,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildSplash<TFormat extends GuildSplashFormat>(guildId: Snowflake, guildSplash: string, format: TFormat) {
+	guildSplash<Format extends GuildSplashFormat>(guildId: Snowflake, guildSplash: string, format: Format) {
 		return `/splashes/${guildId}/${guildSplash}.${format}` as const;
 	},
 
@@ -984,10 +984,10 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildDiscoverySplash<TFormat extends GuildDiscoverySplashFormat>(
+	guildDiscoverySplash<Format extends GuildDiscoverySplashFormat>(
 		guildId: Snowflake,
 		guildDiscoverySplash: string,
-		format: TFormat,
+		format: Format,
 	) {
 		return `/discovery-splashes/${guildId}/${guildDiscoverySplash}.${format}` as const;
 	},
@@ -1000,7 +1000,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildBanner<TFormat extends GuildBannerFormat>(guildId: Snowflake, guildBanner: string, format: TFormat) {
+	guildBanner<Format extends GuildBannerFormat>(guildId: Snowflake, guildBanner: string, format: Format) {
 		return `/banners/${guildId}/${guildBanner}.${format}` as const;
 	},
 
@@ -1012,7 +1012,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	userBanner<TFormat extends UserBannerFormat>(userId: Snowflake, userBanner: string, format: TFormat) {
+	userBanner<Format extends UserBannerFormat>(userId: Snowflake, userBanner: string, format: Format) {
 		return `/banners/${userId}/${userBanner}.${format}` as const;
 	},
 
@@ -1026,7 +1026,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extension: PNG
 	 */
-	defaultUserAvatar<TIndex extends DefaultUserAvatarAssets>(index: TIndex) {
+	defaultUserAvatar<Index extends DefaultUserAvatarAssets>(index: Index) {
 		return `/embed/avatars/${index}.png` as const;
 	},
 
@@ -1038,7 +1038,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	userAvatar<TFormat extends UserAvatarFormat>(userId: Snowflake, userAvatar: string, format: TFormat) {
+	userAvatar<Format extends UserAvatarFormat>(userId: Snowflake, userAvatar: string, format: Format) {
 		return `/avatars/${userId}/${userAvatar}.${format}` as const;
 	},
 
@@ -1050,11 +1050,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildMemberAvatar<TFormat extends GuildMemberAvatarFormat>(
+	guildMemberAvatar<Format extends GuildMemberAvatarFormat>(
 		guildId: Snowflake,
 		userId: Snowflake,
 		memberAvatar: string,
-		format: TFormat,
+		format: Format,
 	) {
 		return `/guilds/${guildId}/users/${userId}/avatars/${memberAvatar}.${format}` as const;
 	},
@@ -1075,10 +1075,10 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationIcon<TFormat extends ApplicationIconFormat>(
+	applicationIcon<Format extends ApplicationIconFormat>(
 		applicationId: Snowflake,
 		applicationIcon: string,
-		format: TFormat,
+		format: Format,
 	) {
 		return `/app-icons/${applicationId}/${applicationIcon}.${format}` as const;
 	},
@@ -1089,10 +1089,10 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationCover<TFormat extends ApplicationCoverFormat>(
+	applicationCover<Format extends ApplicationCoverFormat>(
 		applicationId: Snowflake,
 		applicationCoverImage: string,
-		format: TFormat,
+		format: Format,
 	) {
 		return `/app-icons/${applicationId}/${applicationCoverImage}.${format}` as const;
 	},
@@ -1103,10 +1103,10 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationAsset<TFormat extends ApplicationAssetFormat>(
+	applicationAsset<Format extends ApplicationAssetFormat>(
 		applicationId: Snowflake,
 		applicationAssetId: string,
-		format: TFormat,
+		format: Format,
 	) {
 		return `/app-assets/${applicationId}/${applicationAssetId}.${format}` as const;
 	},
@@ -1117,11 +1117,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	achievementIcon<TFormat extends AchievementIconFormat>(
+	achievementIcon<Format extends AchievementIconFormat>(
 		applicationId: Snowflake,
 		achievementId: Snowflake,
 		achievementIconHash: string,
-		format: TFormat,
+		format: Format,
 	) {
 		return `/app-assets/${applicationId}/achievements/${achievementId}/icons/${achievementIconHash}.${format}` as const;
 	},
@@ -1132,7 +1132,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	stickerPackBanner<TFormat extends StickerPackBannerFormat>(stickerPackBannerAssetId: Snowflake, format: TFormat) {
+	stickerPackBanner<Format extends StickerPackBannerFormat>(stickerPackBannerAssetId: Snowflake, format: Format) {
 		return `/app-assets/${StickerPackApplicationId}/store/${stickerPackBannerAssetId}.${format}` as const;
 	},
 
@@ -1142,7 +1142,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	storePageAsset<TFormat extends StorePageAssetFormat>(applicationId: Snowflake, assetId: string, format: TFormat) {
+	storePageAsset<Format extends StorePageAssetFormat>(applicationId: Snowflake, assetId: string, format: Format) {
 		return `/app-assets/${applicationId}/store/${assetId}.${format}` as const;
 	},
 
@@ -1152,7 +1152,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	teamIcon<TFormat extends TeamIconFormat>(teamId: Snowflake, teamIcon: string, format: TFormat) {
+	teamIcon<Format extends TeamIconFormat>(teamId: Snowflake, teamIcon: string, format: Format) {
 		return `/team-icons/${teamId}/${teamIcon}.${format}` as const;
 	},
 
@@ -1162,7 +1162,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, Lottie, GIF
 	 */
-	sticker<TFormat extends StickerFormat>(stickerId: Snowflake, format: TFormat) {
+	sticker<Format extends StickerFormat>(stickerId: Snowflake, format: Format) {
 		return `/stickers/${stickerId}.${format}` as const;
 	},
 
@@ -1172,7 +1172,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	roleIcon<TFormat extends RoleIconFormat>(roleId: Snowflake, roleIcon: string, format: TFormat) {
+	roleIcon<Format extends RoleIconFormat>(roleId: Snowflake, roleIcon: string, format: Format) {
 		return `/role-icons/${roleId}/${roleIcon}.${format}` as const;
 	},
 
@@ -1182,10 +1182,10 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildScheduledEventCover<TFormat extends GuildScheduledEventCoverFormat>(
+	guildScheduledEventCover<Format extends GuildScheduledEventCoverFormat>(
 		guildScheduledEventId: Snowflake,
 		guildScheduledEventCoverImage: string,
-		format: TFormat,
+		format: Format,
 	) {
 		return `/guild-events/${guildScheduledEventId}/${guildScheduledEventCoverImage}.${format}` as const;
 	},
@@ -1196,11 +1196,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildMemberBanner<TFormat extends GuildMemberBannerFormat>(
+	guildMemberBanner<Format extends GuildMemberBannerFormat>(
 		guildId: Snowflake,
 		userId: Snowflake,
 		guildMemberBanner: string,
-		format: TFormat,
+		format: Format,
 	) {
 		return `/guilds/${guildId}/users/${userId}/banners/${guildMemberBanner}.${format}` as const;
 	},

--- a/rest/v10/index.ts
+++ b/rest/v10/index.ts
@@ -943,7 +943,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	emoji(emojiId: Snowflake, format: EmojiFormat) {
+	emoji<TFormat extends EmojiFormat>(emojiId: Snowflake, format: TFormat) {
 		return `/emojis/${emojiId}.${format}` as const;
 	},
 
@@ -955,7 +955,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildIcon(guildId: Snowflake, guildIcon: string, format: GuildIconFormat) {
+	guildIcon<TFormat extends GuildIconFormat>(guildId: Snowflake, guildIcon: string, format: TFormat) {
 		return `icons/${guildId}/${guildIcon}.${format}` as const;
 	},
 
@@ -965,7 +965,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildSplash(guildId: Snowflake, guildSplash: string, format: GuildSplashFormat) {
+	guildSplash<TFormat extends GuildSplashFormat>(guildId: Snowflake, guildSplash: string, format: TFormat) {
 		return `/splashes/${guildId}/${guildSplash}.${format}` as const;
 	},
 
@@ -975,7 +975,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildDiscoverySplash(guildId: Snowflake, guildDiscoverySplash: string, format: GuildDiscoverySplashFormat) {
+	guildDiscoverySplash<TFormat extends GuildDiscoverySplashFormat>(
+		guildId: Snowflake,
+		guildDiscoverySplash: string,
+		format: TFormat,
+	) {
 		return `/discovery-splashes/${guildId}/${guildDiscoverySplash}.${format}` as const;
 	},
 
@@ -987,7 +991,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildBanner(guildId: Snowflake, guildBanner: string, format: GuildBannerFormat) {
+	guildBanner<TFormat extends GuildBannerFormat>(guildId: Snowflake, guildBanner: string, format: TFormat) {
 		return `/banners/${guildId}/${guildBanner}.${format}` as const;
 	},
 
@@ -999,7 +1003,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	userBanner(userId: Snowflake, userBanner: string, format: UserBannerFormat) {
+	userBanner<TFormat extends UserBannerFormat>(userId: Snowflake, userBanner: string, format: TFormat) {
 		return `/banners/${userId}/${userBanner}.${format}` as const;
 	},
 
@@ -1013,7 +1017,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extension: PNG
 	 */
-	defaultUserAvatar(index: DefaultUserAvatarAssets) {
+	defaultUserAvatar<TIndex extends DefaultUserAvatarAssets>(index: TIndex) {
 		return `/embed/avatars/${index}.png` as const;
 	},
 
@@ -1025,7 +1029,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	userAvatar(userId: Snowflake, userAvatar: string, format: UserAvatarFormat) {
+	userAvatar<TFormat extends UserAvatarFormat>(userId: Snowflake, userAvatar: string, format: TFormat) {
 		return `/avatars/${userId}/${userAvatar}.${format}` as const;
 	},
 
@@ -1037,7 +1041,12 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildMemberAvatar(guildId: Snowflake, userId: Snowflake, memberAvatar: string, format: GuildMemberAvatarFormat) {
+	guildMemberAvatar<TFormat extends GuildMemberAvatarFormat>(
+		guildId: Snowflake,
+		userId: Snowflake,
+		memberAvatar: string,
+		format: TFormat,
+	) {
 		return `/guilds/${guildId}/users/${userId}/avatars/${memberAvatar}.${format}` as const;
 	},
 
@@ -1057,7 +1066,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationIcon(applicationId: Snowflake, applicationIcon: string, format: ApplicationIconFormat) {
+	applicationIcon<TFormat extends ApplicationIconFormat>(
+		applicationId: Snowflake,
+		applicationIcon: string,
+		format: TFormat,
+	) {
 		return `/app-icons/${applicationId}/${applicationIcon}.${format}` as const;
 	},
 
@@ -1067,7 +1080,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationCover(applicationId: Snowflake, applicationCoverImage: string, format: ApplicationCoverFormat) {
+	applicationCover<TFormat extends ApplicationCoverFormat>(
+		applicationId: Snowflake,
+		applicationCoverImage: string,
+		format: TFormat,
+	) {
 		return `/app-icons/${applicationId}/${applicationCoverImage}.${format}` as const;
 	},
 
@@ -1077,7 +1094,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationAsset(applicationId: Snowflake, applicationAssetId: string, format: ApplicationAssetFormat) {
+	applicationAsset<TFormat extends ApplicationAssetFormat>(
+		applicationId: Snowflake,
+		applicationAssetId: string,
+		format: TFormat,
+	) {
 		return `/app-assets/${applicationId}/${applicationAssetId}.${format}` as const;
 	},
 
@@ -1087,11 +1108,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	achievementIcon(
+	achievementIcon<TFormat extends AchievementIconFormat>(
 		applicationId: Snowflake,
 		achievementId: Snowflake,
 		achievementIconHash: string,
-		format: AchievementIconFormat,
+		format: TFormat,
 	) {
 		return `/app-assets/${applicationId}/achievements/${achievementId}/icons/${achievementIconHash}.${format}` as const;
 	},
@@ -1102,7 +1123,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	stickerPackBanner(stickerPackBannerAssetId: Snowflake, format: StickerPackBannerFormat) {
+	stickerPackBanner<TFormat extends StickerPackBannerFormat>(stickerPackBannerAssetId: Snowflake, format: TFormat) {
 		return `/app-assets/${StickerPackApplicationId}/store/${stickerPackBannerAssetId}.${format}` as const;
 	},
 
@@ -1112,7 +1133,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	storePageAsset(applicationId: Snowflake, assetId: string, format: StorePageAssetFormat) {
+	storePageAsset<TFormat extends StorePageAssetFormat>(applicationId: Snowflake, assetId: string, format: TFormat) {
 		return `/app-assets/${applicationId}/store/${assetId}.${format}` as const;
 	},
 
@@ -1122,7 +1143,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	teamIcon(teamId: Snowflake, teamIcon: string, format: TeamIconFormat) {
+	teamIcon<TFormat extends TeamIconFormat>(teamId: Snowflake, teamIcon: string, format: TFormat) {
 		return `/team-icons/${teamId}/${teamIcon}.${format}` as const;
 	},
 
@@ -1132,7 +1153,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, Lottie, GIF
 	 */
-	sticker(stickerId: Snowflake, format: StickerFormat) {
+	sticker<TFormat extends StickerFormat>(stickerId: Snowflake, format: TFormat) {
 		return `/stickers/${stickerId}.${format}` as const;
 	},
 
@@ -1142,7 +1163,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	roleIcon(roleId: Snowflake, roleIcon: string, format: RoleIconFormat) {
+	roleIcon<TFormat extends RoleIconFormat>(roleId: Snowflake, roleIcon: string, format: TFormat) {
 		return `/role-icons/${roleId}/${roleIcon}.${format}` as const;
 	},
 
@@ -1152,10 +1173,10 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildScheduledEventCover(
+	guildScheduledEventCover<TFormat extends GuildScheduledEventCoverFormat>(
 		guildScheduledEventId: Snowflake,
 		guildScheduledEventCoverImage: string,
-		format: GuildScheduledEventCoverFormat,
+		format: TFormat,
 	) {
 		return `/guild-events/${guildScheduledEventId}/${guildScheduledEventCoverImage}.${format}` as const;
 	},
@@ -1166,7 +1187,12 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildMemberBanner(guildId: Snowflake, userId: Snowflake, guildMemberBanner: string, format: GuildMemberBannerFormat) {
+	guildMemberBanner<TFormat extends GuildMemberBannerFormat>(
+		guildId: Snowflake,
+		userId: Snowflake,
+		guildMemberBanner: string,
+		format: TFormat,
+	) {
 		return `/guilds/${guildId}/users/${userId}/banners/${guildMemberBanner}.${format}` as const;
 	},
 };

--- a/rest/v10/index.ts
+++ b/rest/v10/index.ts
@@ -1141,7 +1141,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	storePageAsset(applicationId: Snowflake, assetId: string, format: StorePageAssetFormat = ImageFormat.PNG) {
+	storePageAsset<Format extends StorePageAssetFormat>(
+		applicationId: Snowflake,
+		assetId: string,
+		format: Format = ImageFormat.PNG as Format,
+	) {
 		return `/app-assets/${applicationId}/store/${assetId}.${format}` as const;
 	},
 

--- a/rest/v10/index.ts
+++ b/rest/v10/index.ts
@@ -943,7 +943,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	emoji<TFormat extends EmojiFormat>(emojiId: Snowflake, format: TFormat) {
+	emoji<Format extends EmojiFormat>(emojiId: Snowflake, format: Format) {
 		return `/emojis/${emojiId}.${format}` as const;
 	},
 
@@ -955,7 +955,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildIcon<TFormat extends GuildIconFormat>(guildId: Snowflake, guildIcon: string, format: TFormat) {
+	guildIcon<Format extends GuildIconFormat>(guildId: Snowflake, guildIcon: string, format: Format) {
 		return `icons/${guildId}/${guildIcon}.${format}` as const;
 	},
 
@@ -965,7 +965,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildSplash<TFormat extends GuildSplashFormat>(guildId: Snowflake, guildSplash: string, format: TFormat) {
+	guildSplash<Format extends GuildSplashFormat>(guildId: Snowflake, guildSplash: string, format: Format) {
 		return `/splashes/${guildId}/${guildSplash}.${format}` as const;
 	},
 
@@ -975,10 +975,10 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildDiscoverySplash<TFormat extends GuildDiscoverySplashFormat>(
+	guildDiscoverySplash<Format extends GuildDiscoverySplashFormat>(
 		guildId: Snowflake,
 		guildDiscoverySplash: string,
-		format: TFormat,
+		format: Format,
 	) {
 		return `/discovery-splashes/${guildId}/${guildDiscoverySplash}.${format}` as const;
 	},
@@ -991,7 +991,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildBanner<TFormat extends GuildBannerFormat>(guildId: Snowflake, guildBanner: string, format: TFormat) {
+	guildBanner<Format extends GuildBannerFormat>(guildId: Snowflake, guildBanner: string, format: Format) {
 		return `/banners/${guildId}/${guildBanner}.${format}` as const;
 	},
 
@@ -1003,7 +1003,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	userBanner<TFormat extends UserBannerFormat>(userId: Snowflake, userBanner: string, format: TFormat) {
+	userBanner<Format extends UserBannerFormat>(userId: Snowflake, userBanner: string, format: Format) {
 		return `/banners/${userId}/${userBanner}.${format}` as const;
 	},
 
@@ -1017,7 +1017,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extension: PNG
 	 */
-	defaultUserAvatar<TIndex extends DefaultUserAvatarAssets>(index: TIndex) {
+	defaultUserAvatar<Index extends DefaultUserAvatarAssets>(index: Index) {
 		return `/embed/avatars/${index}.png` as const;
 	},
 
@@ -1029,7 +1029,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	userAvatar<TFormat extends UserAvatarFormat>(userId: Snowflake, userAvatar: string, format: TFormat) {
+	userAvatar<Format extends UserAvatarFormat>(userId: Snowflake, userAvatar: string, format: Format) {
 		return `/avatars/${userId}/${userAvatar}.${format}` as const;
 	},
 
@@ -1041,11 +1041,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildMemberAvatar<TFormat extends GuildMemberAvatarFormat>(
+	guildMemberAvatar<Format extends GuildMemberAvatarFormat>(
 		guildId: Snowflake,
 		userId: Snowflake,
 		memberAvatar: string,
-		format: TFormat,
+		format: Format,
 	) {
 		return `/guilds/${guildId}/users/${userId}/avatars/${memberAvatar}.${format}` as const;
 	},
@@ -1066,10 +1066,10 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationIcon<TFormat extends ApplicationIconFormat>(
+	applicationIcon<Format extends ApplicationIconFormat>(
 		applicationId: Snowflake,
 		applicationIcon: string,
-		format: TFormat,
+		format: Format,
 	) {
 		return `/app-icons/${applicationId}/${applicationIcon}.${format}` as const;
 	},
@@ -1080,10 +1080,10 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationCover<TFormat extends ApplicationCoverFormat>(
+	applicationCover<Format extends ApplicationCoverFormat>(
 		applicationId: Snowflake,
 		applicationCoverImage: string,
-		format: TFormat,
+		format: Format,
 	) {
 		return `/app-icons/${applicationId}/${applicationCoverImage}.${format}` as const;
 	},
@@ -1094,10 +1094,10 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationAsset<TFormat extends ApplicationAssetFormat>(
+	applicationAsset<Format extends ApplicationAssetFormat>(
 		applicationId: Snowflake,
 		applicationAssetId: string,
-		format: TFormat,
+		format: Format,
 	) {
 		return `/app-assets/${applicationId}/${applicationAssetId}.${format}` as const;
 	},
@@ -1108,11 +1108,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	achievementIcon<TFormat extends AchievementIconFormat>(
+	achievementIcon<Format extends AchievementIconFormat>(
 		applicationId: Snowflake,
 		achievementId: Snowflake,
 		achievementIconHash: string,
-		format: TFormat,
+		format: Format,
 	) {
 		return `/app-assets/${applicationId}/achievements/${achievementId}/icons/${achievementIconHash}.${format}` as const;
 	},
@@ -1123,7 +1123,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	stickerPackBanner<TFormat extends StickerPackBannerFormat>(stickerPackBannerAssetId: Snowflake, format: TFormat) {
+	stickerPackBanner<Format extends StickerPackBannerFormat>(stickerPackBannerAssetId: Snowflake, format: Format) {
 		return `/app-assets/${StickerPackApplicationId}/store/${stickerPackBannerAssetId}.${format}` as const;
 	},
 
@@ -1133,7 +1133,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	storePageAsset<TFormat extends StorePageAssetFormat>(applicationId: Snowflake, assetId: string, format: TFormat) {
+	storePageAsset<Format extends StorePageAssetFormat>(applicationId: Snowflake, assetId: string, format: Format) {
 		return `/app-assets/${applicationId}/store/${assetId}.${format}` as const;
 	},
 
@@ -1143,7 +1143,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	teamIcon<TFormat extends TeamIconFormat>(teamId: Snowflake, teamIcon: string, format: TFormat) {
+	teamIcon<Format extends TeamIconFormat>(teamId: Snowflake, teamIcon: string, format: Format) {
 		return `/team-icons/${teamId}/${teamIcon}.${format}` as const;
 	},
 
@@ -1153,7 +1153,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, Lottie, GIF
 	 */
-	sticker<TFormat extends StickerFormat>(stickerId: Snowflake, format: TFormat) {
+	sticker<Format extends StickerFormat>(stickerId: Snowflake, format: Format) {
 		return `/stickers/${stickerId}.${format}` as const;
 	},
 
@@ -1163,7 +1163,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	roleIcon<TFormat extends RoleIconFormat>(roleId: Snowflake, roleIcon: string, format: TFormat) {
+	roleIcon<Format extends RoleIconFormat>(roleId: Snowflake, roleIcon: string, format: Format) {
 		return `/role-icons/${roleId}/${roleIcon}.${format}` as const;
 	},
 
@@ -1173,10 +1173,10 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildScheduledEventCover<TFormat extends GuildScheduledEventCoverFormat>(
+	guildScheduledEventCover<Format extends GuildScheduledEventCoverFormat>(
 		guildScheduledEventId: Snowflake,
 		guildScheduledEventCoverImage: string,
-		format: TFormat,
+		format: Format,
 	) {
 		return `/guild-events/${guildScheduledEventId}/${guildScheduledEventCoverImage}.${format}` as const;
 	},
@@ -1187,11 +1187,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildMemberBanner<TFormat extends GuildMemberBannerFormat>(
+	guildMemberBanner<Format extends GuildMemberBannerFormat>(
 		guildId: Snowflake,
 		userId: Snowflake,
 		guildMemberBanner: string,
-		format: TFormat,
+		format: Format,
 	) {
 		return `/guilds/${guildId}/users/${userId}/banners/${guildMemberBanner}.${format}` as const;
 	},

--- a/rest/v10/index.ts
+++ b/rest/v10/index.ts
@@ -1141,7 +1141,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	storePageAsset<Format extends StorePageAssetFormat>(
+	storePageAsset<Format extends StorePageAssetFormat = ImageFormat.PNG>(
 		applicationId: Snowflake,
 		assetId: string,
 		format: Format = ImageFormat.PNG as Format,

--- a/rest/v9/index.ts
+++ b/rest/v9/index.ts
@@ -1150,7 +1150,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	storePageAsset(applicationId: Snowflake, assetId: string, format: StorePageAssetFormat = ImageFormat.PNG) {
+	storePageAsset<Format extends StorePageAssetFormat>(
+		applicationId: Snowflake,
+		assetId: string,
+		format: Format = ImageFormat.PNG as Format,
+	) {
 		return `/app-assets/${applicationId}/store/${assetId}.${format}` as const;
 	},
 

--- a/rest/v9/index.ts
+++ b/rest/v9/index.ts
@@ -952,7 +952,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	emoji(emojiId: Snowflake, format: EmojiFormat) {
+	emoji<TFormat extends EmojiFormat>(emojiId: Snowflake, format: TFormat) {
 		return `/emojis/${emojiId}.${format}` as const;
 	},
 
@@ -964,7 +964,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildIcon(guildId: Snowflake, guildIcon: string, format: GuildIconFormat) {
+	guildIcon<TFormat extends GuildIconFormat>(guildId: Snowflake, guildIcon: string, format: TFormat) {
 		return `icons/${guildId}/${guildIcon}.${format}` as const;
 	},
 
@@ -974,7 +974,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildSplash(guildId: Snowflake, guildSplash: string, format: GuildSplashFormat) {
+	guildSplash<TFormat extends GuildSplashFormat>(guildId: Snowflake, guildSplash: string, format: TFormat) {
 		return `/splashes/${guildId}/${guildSplash}.${format}` as const;
 	},
 
@@ -984,7 +984,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildDiscoverySplash(guildId: Snowflake, guildDiscoverySplash: string, format: GuildDiscoverySplashFormat) {
+	guildDiscoverySplash<TFormat extends GuildDiscoverySplashFormat>(
+		guildId: Snowflake,
+		guildDiscoverySplash: string,
+		format: TFormat,
+	) {
 		return `/discovery-splashes/${guildId}/${guildDiscoverySplash}.${format}` as const;
 	},
 
@@ -996,7 +1000,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildBanner(guildId: Snowflake, guildBanner: string, format: GuildBannerFormat) {
+	guildBanner<TFormat extends GuildBannerFormat>(guildId: Snowflake, guildBanner: string, format: TFormat) {
 		return `/banners/${guildId}/${guildBanner}.${format}` as const;
 	},
 
@@ -1008,7 +1012,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	userBanner(userId: Snowflake, userBanner: string, format: UserBannerFormat) {
+	userBanner<TFormat extends UserBannerFormat>(userId: Snowflake, userBanner: string, format: TFormat) {
 		return `/banners/${userId}/${userBanner}.${format}` as const;
 	},
 
@@ -1022,7 +1026,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extension: PNG
 	 */
-	defaultUserAvatar(index: DefaultUserAvatarAssets) {
+	defaultUserAvatar<TIndex extends DefaultUserAvatarAssets>(index: TIndex) {
 		return `/embed/avatars/${index}.png` as const;
 	},
 
@@ -1034,7 +1038,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	userAvatar(userId: Snowflake, userAvatar: string, format: UserAvatarFormat) {
+	userAvatar<TFormat extends UserAvatarFormat>(userId: Snowflake, userAvatar: string, format: TFormat) {
 		return `/avatars/${userId}/${userAvatar}.${format}` as const;
 	},
 
@@ -1046,7 +1050,12 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildMemberAvatar(guildId: Snowflake, userId: Snowflake, memberAvatar: string, format: GuildMemberAvatarFormat) {
+	guildMemberAvatar<TFormat extends GuildMemberAvatarFormat>(
+		guildId: Snowflake,
+		userId: Snowflake,
+		memberAvatar: string,
+		format: TFormat,
+	) {
 		return `/guilds/${guildId}/users/${userId}/avatars/${memberAvatar}.${format}` as const;
 	},
 
@@ -1066,7 +1075,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationIcon(applicationId: Snowflake, applicationIcon: string, format: ApplicationIconFormat) {
+	applicationIcon<TFormat extends ApplicationIconFormat>(
+		applicationId: Snowflake,
+		applicationIcon: string,
+		format: TFormat,
+	) {
 		return `/app-icons/${applicationId}/${applicationIcon}.${format}` as const;
 	},
 
@@ -1076,7 +1089,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationCover(applicationId: Snowflake, applicationCoverImage: string, format: ApplicationCoverFormat) {
+	applicationCover<TFormat extends ApplicationCoverFormat>(
+		applicationId: Snowflake,
+		applicationCoverImage: string,
+		format: TFormat,
+	) {
 		return `/app-icons/${applicationId}/${applicationCoverImage}.${format}` as const;
 	},
 
@@ -1086,7 +1103,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationAsset(applicationId: Snowflake, applicationAssetId: string, format: ApplicationAssetFormat) {
+	applicationAsset<TFormat extends ApplicationAssetFormat>(
+		applicationId: Snowflake,
+		applicationAssetId: string,
+		format: TFormat,
+	) {
 		return `/app-assets/${applicationId}/${applicationAssetId}.${format}` as const;
 	},
 
@@ -1096,11 +1117,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	achievementIcon(
+	achievementIcon<TFormat extends AchievementIconFormat>(
 		applicationId: Snowflake,
 		achievementId: Snowflake,
 		achievementIconHash: string,
-		format: AchievementIconFormat,
+		format: TFormat,
 	) {
 		return `/app-assets/${applicationId}/achievements/${achievementId}/icons/${achievementIconHash}.${format}` as const;
 	},
@@ -1111,7 +1132,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	stickerPackBanner(stickerPackBannerAssetId: Snowflake, format: StickerPackBannerFormat) {
+	stickerPackBanner<TFormat extends StickerPackBannerFormat>(stickerPackBannerAssetId: Snowflake, format: TFormat) {
 		return `/app-assets/${StickerPackApplicationId}/store/${stickerPackBannerAssetId}.${format}` as const;
 	},
 
@@ -1121,7 +1142,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	storePageAsset(applicationId: Snowflake, assetId: string, format: StorePageAssetFormat) {
+	storePageAsset<TFormat extends StorePageAssetFormat>(applicationId: Snowflake, assetId: string, format: TFormat) {
 		return `/app-assets/${applicationId}/store/${assetId}.${format}` as const;
 	},
 
@@ -1131,7 +1152,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	teamIcon(teamId: Snowflake, teamIcon: string, format: TeamIconFormat) {
+	teamIcon<TFormat extends TeamIconFormat>(teamId: Snowflake, teamIcon: string, format: TFormat) {
 		return `/team-icons/${teamId}/${teamIcon}.${format}` as const;
 	},
 
@@ -1141,7 +1162,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, Lottie, GIF
 	 */
-	sticker(stickerId: Snowflake, format: StickerFormat) {
+	sticker<TFormat extends StickerFormat>(stickerId: Snowflake, format: TFormat) {
 		return `/stickers/${stickerId}.${format}` as const;
 	},
 
@@ -1151,7 +1172,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	roleIcon(roleId: Snowflake, roleIcon: string, format: RoleIconFormat) {
+	roleIcon<TFormat extends RoleIconFormat>(roleId: Snowflake, roleIcon: string, format: TFormat) {
 		return `/role-icons/${roleId}/${roleIcon}.${format}` as const;
 	},
 
@@ -1161,10 +1182,10 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildScheduledEventCover(
+	guildScheduledEventCover<TFormat extends GuildScheduledEventCoverFormat>(
 		guildScheduledEventId: Snowflake,
 		guildScheduledEventCoverImage: string,
-		format: GuildScheduledEventCoverFormat,
+		format: TFormat,
 	) {
 		return `/guild-events/${guildScheduledEventId}/${guildScheduledEventCoverImage}.${format}` as const;
 	},
@@ -1175,7 +1196,12 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildMemberBanner(guildId: Snowflake, userId: Snowflake, guildMemberBanner: string, format: GuildMemberBannerFormat) {
+	guildMemberBanner<TFormat extends GuildMemberBannerFormat>(
+		guildId: Snowflake,
+		userId: Snowflake,
+		guildMemberBanner: string,
+		format: TFormat,
+	) {
 		return `/guilds/${guildId}/users/${userId}/banners/${guildMemberBanner}.${format}` as const;
 	},
 };

--- a/rest/v9/index.ts
+++ b/rest/v9/index.ts
@@ -1150,7 +1150,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	storePageAsset<Format extends StorePageAssetFormat>(
+	storePageAsset<Format extends StorePageAssetFormat = ImageFormat.PNG>(
 		applicationId: Snowflake,
 		assetId: string,
 		format: Format = ImageFormat.PNG as Format,

--- a/rest/v9/index.ts
+++ b/rest/v9/index.ts
@@ -952,7 +952,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	emoji<TFormat extends EmojiFormat>(emojiId: Snowflake, format: TFormat) {
+	emoji<Format extends EmojiFormat>(emojiId: Snowflake, format: Format) {
 		return `/emojis/${emojiId}.${format}` as const;
 	},
 
@@ -964,7 +964,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildIcon<TFormat extends GuildIconFormat>(guildId: Snowflake, guildIcon: string, format: TFormat) {
+	guildIcon<Format extends GuildIconFormat>(guildId: Snowflake, guildIcon: string, format: Format) {
 		return `icons/${guildId}/${guildIcon}.${format}` as const;
 	},
 
@@ -974,7 +974,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildSplash<TFormat extends GuildSplashFormat>(guildId: Snowflake, guildSplash: string, format: TFormat) {
+	guildSplash<Format extends GuildSplashFormat>(guildId: Snowflake, guildSplash: string, format: Format) {
 		return `/splashes/${guildId}/${guildSplash}.${format}` as const;
 	},
 
@@ -984,10 +984,10 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildDiscoverySplash<TFormat extends GuildDiscoverySplashFormat>(
+	guildDiscoverySplash<Format extends GuildDiscoverySplashFormat>(
 		guildId: Snowflake,
 		guildDiscoverySplash: string,
-		format: TFormat,
+		format: Format,
 	) {
 		return `/discovery-splashes/${guildId}/${guildDiscoverySplash}.${format}` as const;
 	},
@@ -1000,7 +1000,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildBanner<TFormat extends GuildBannerFormat>(guildId: Snowflake, guildBanner: string, format: TFormat) {
+	guildBanner<Format extends GuildBannerFormat>(guildId: Snowflake, guildBanner: string, format: Format) {
 		return `/banners/${guildId}/${guildBanner}.${format}` as const;
 	},
 
@@ -1012,7 +1012,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	userBanner<TFormat extends UserBannerFormat>(userId: Snowflake, userBanner: string, format: TFormat) {
+	userBanner<Format extends UserBannerFormat>(userId: Snowflake, userBanner: string, format: Format) {
 		return `/banners/${userId}/${userBanner}.${format}` as const;
 	},
 
@@ -1026,7 +1026,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extension: PNG
 	 */
-	defaultUserAvatar<TIndex extends DefaultUserAvatarAssets>(index: TIndex) {
+	defaultUserAvatar<Index extends DefaultUserAvatarAssets>(index: Index) {
 		return `/embed/avatars/${index}.png` as const;
 	},
 
@@ -1038,7 +1038,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	userAvatar<TFormat extends UserAvatarFormat>(userId: Snowflake, userAvatar: string, format: TFormat) {
+	userAvatar<Format extends UserAvatarFormat>(userId: Snowflake, userAvatar: string, format: Format) {
 		return `/avatars/${userId}/${userAvatar}.${format}` as const;
 	},
 
@@ -1050,11 +1050,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildMemberAvatar<TFormat extends GuildMemberAvatarFormat>(
+	guildMemberAvatar<Format extends GuildMemberAvatarFormat>(
 		guildId: Snowflake,
 		userId: Snowflake,
 		memberAvatar: string,
-		format: TFormat,
+		format: Format,
 	) {
 		return `/guilds/${guildId}/users/${userId}/avatars/${memberAvatar}.${format}` as const;
 	},
@@ -1075,10 +1075,10 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationIcon<TFormat extends ApplicationIconFormat>(
+	applicationIcon<Format extends ApplicationIconFormat>(
 		applicationId: Snowflake,
 		applicationIcon: string,
-		format: TFormat,
+		format: Format,
 	) {
 		return `/app-icons/${applicationId}/${applicationIcon}.${format}` as const;
 	},
@@ -1089,10 +1089,10 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationCover<TFormat extends ApplicationCoverFormat>(
+	applicationCover<Format extends ApplicationCoverFormat>(
 		applicationId: Snowflake,
 		applicationCoverImage: string,
-		format: TFormat,
+		format: Format,
 	) {
 		return `/app-icons/${applicationId}/${applicationCoverImage}.${format}` as const;
 	},
@@ -1103,10 +1103,10 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	applicationAsset<TFormat extends ApplicationAssetFormat>(
+	applicationAsset<Format extends ApplicationAssetFormat>(
 		applicationId: Snowflake,
 		applicationAssetId: string,
-		format: TFormat,
+		format: Format,
 	) {
 		return `/app-assets/${applicationId}/${applicationAssetId}.${format}` as const;
 	},
@@ -1117,11 +1117,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	achievementIcon<TFormat extends AchievementIconFormat>(
+	achievementIcon<Format extends AchievementIconFormat>(
 		applicationId: Snowflake,
 		achievementId: Snowflake,
 		achievementIconHash: string,
-		format: TFormat,
+		format: Format,
 	) {
 		return `/app-assets/${applicationId}/achievements/${achievementId}/icons/${achievementIconHash}.${format}` as const;
 	},
@@ -1132,7 +1132,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	stickerPackBanner<TFormat extends StickerPackBannerFormat>(stickerPackBannerAssetId: Snowflake, format: TFormat) {
+	stickerPackBanner<Format extends StickerPackBannerFormat>(stickerPackBannerAssetId: Snowflake, format: Format) {
 		return `/app-assets/${StickerPackApplicationId}/store/${stickerPackBannerAssetId}.${format}` as const;
 	},
 
@@ -1142,7 +1142,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	storePageAsset<TFormat extends StorePageAssetFormat>(applicationId: Snowflake, assetId: string, format: TFormat) {
+	storePageAsset<Format extends StorePageAssetFormat>(applicationId: Snowflake, assetId: string, format: Format) {
 		return `/app-assets/${applicationId}/store/${assetId}.${format}` as const;
 	},
 
@@ -1152,7 +1152,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	teamIcon<TFormat extends TeamIconFormat>(teamId: Snowflake, teamIcon: string, format: TFormat) {
+	teamIcon<Format extends TeamIconFormat>(teamId: Snowflake, teamIcon: string, format: Format) {
 		return `/team-icons/${teamId}/${teamIcon}.${format}` as const;
 	},
 
@@ -1162,7 +1162,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, Lottie, GIF
 	 */
-	sticker<TFormat extends StickerFormat>(stickerId: Snowflake, format: TFormat) {
+	sticker<Format extends StickerFormat>(stickerId: Snowflake, format: Format) {
 		return `/stickers/${stickerId}.${format}` as const;
 	},
 
@@ -1172,7 +1172,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	roleIcon<TFormat extends RoleIconFormat>(roleId: Snowflake, roleIcon: string, format: TFormat) {
+	roleIcon<Format extends RoleIconFormat>(roleId: Snowflake, roleIcon: string, format: Format) {
 		return `/role-icons/${roleId}/${roleIcon}.${format}` as const;
 	},
 
@@ -1182,10 +1182,10 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	guildScheduledEventCover<TFormat extends GuildScheduledEventCoverFormat>(
+	guildScheduledEventCover<Format extends GuildScheduledEventCoverFormat>(
 		guildScheduledEventId: Snowflake,
 		guildScheduledEventCoverImage: string,
-		format: TFormat,
+		format: Format,
 	) {
 		return `/guild-events/${guildScheduledEventId}/${guildScheduledEventCoverImage}.${format}` as const;
 	},
@@ -1196,11 +1196,11 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
-	guildMemberBanner<TFormat extends GuildMemberBannerFormat>(
+	guildMemberBanner<Format extends GuildMemberBannerFormat>(
 		guildId: Snowflake,
 		userId: Snowflake,
 		guildMemberBanner: string,
-		format: TFormat,
+		format: Format,
 	) {
 		return `/guilds/${guildId}/users/${userId}/banners/${guildMemberBanner}.${format}` as const;
 	},


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Implements generics for `format` options. This removes the cumbersome template literal union typings that are returned, and allows those using CDNRoutes to more easily understand what's returned from a given route function. Retains strict boundaries for what extensions are allowed to be used for a given route.

close #866 
