### PR TITLE
fix(CDNRoutes): make format optional and default to png

### DIFF
--- a/deno/rest/v10/mod.ts
+++ b/deno/rest/v10/mod.ts
@@ -934,6 +934,14 @@ export const Routes = {
 
 export const StickerPackApplicationId = '710982414301790216';
 
+export enum ImageFormat {
+	JPEG = 'jpeg',
+	PNG = 'png',
+	WebP = 'webp',
+	GIF = 'gif',
+	Lottie = 'json',
+}
+
 export const CDNRoutes = {
 	/**
 	 * Route for:
@@ -1112,7 +1120,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	storePageAsset(applicationId: Snowflake, assetId: string, format: StorePageAssetFormat) {
+	storePageAsset(applicationId: Snowflake, assetId: string, format: StorePageAssetFormat = ImageFormat.PNG) {
 		return `/app-assets/${applicationId}/store/${assetId}.${format}` as const;
 	},
 
@@ -1193,14 +1201,6 @@ export type StickerFormat = Extract<ImageFormat, ImageFormat.PNG | ImageFormat.L
 export type RoleIconFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
 export type GuildScheduledEventCoverFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
 export type GuildMemberBannerFormat = Exclude<ImageFormat, ImageFormat.Lottie>;
-
-export enum ImageFormat {
-	JPEG = 'jpeg',
-	PNG = 'png',
-	WebP = 'webp',
-	GIF = 'gif',
-	Lottie = 'json',
-}
 
 export interface CDNQuery {
 	/**

--- a/deno/rest/v9/mod.ts
+++ b/deno/rest/v9/mod.ts
@@ -943,6 +943,14 @@ export const Routes = {
 
 export const StickerPackApplicationId = '710982414301790216';
 
+export enum ImageFormat {
+	JPEG = 'jpeg',
+	PNG = 'png',
+	WebP = 'webp',
+	GIF = 'gif',
+	Lottie = 'json',
+}
+
 export const CDNRoutes = {
 	/**
 	 * Route for:
@@ -1121,7 +1129,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	storePageAsset(applicationId: Snowflake, assetId: string, format: StorePageAssetFormat) {
+	storePageAsset(applicationId: Snowflake, assetId: string, format: StorePageAssetFormat = ImageFormat.PNG) {
 		return `/app-assets/${applicationId}/store/${assetId}.${format}` as const;
 	},
 
@@ -1202,14 +1210,6 @@ export type StickerFormat = Extract<ImageFormat, ImageFormat.PNG | ImageFormat.L
 export type RoleIconFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
 export type GuildScheduledEventCoverFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
 export type GuildMemberBannerFormat = Exclude<ImageFormat, ImageFormat.Lottie>;
-
-export enum ImageFormat {
-	JPEG = 'jpeg',
-	PNG = 'png',
-	WebP = 'webp',
-	GIF = 'gif',
-	Lottie = 'json',
-}
 
 export interface CDNQuery {
 	/**

--- a/rest/v10/index.ts
+++ b/rest/v10/index.ts
@@ -934,6 +934,14 @@ export const Routes = {
 
 export const StickerPackApplicationId = '710982414301790216';
 
+export enum ImageFormat {
+	JPEG = 'jpeg',
+	PNG = 'png',
+	WebP = 'webp',
+	GIF = 'gif',
+	Lottie = 'json',
+}
+
 export const CDNRoutes = {
 	/**
 	 * Route for:
@@ -1112,7 +1120,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	storePageAsset(applicationId: Snowflake, assetId: string, format: StorePageAssetFormat) {
+	storePageAsset(applicationId: Snowflake, assetId: string, format: StorePageAssetFormat = ImageFormat.PNG) {
 		return `/app-assets/${applicationId}/store/${assetId}.${format}` as const;
 	},
 
@@ -1193,14 +1201,6 @@ export type StickerFormat = Extract<ImageFormat, ImageFormat.PNG | ImageFormat.L
 export type RoleIconFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
 export type GuildScheduledEventCoverFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
 export type GuildMemberBannerFormat = Exclude<ImageFormat, ImageFormat.Lottie>;
-
-export enum ImageFormat {
-	JPEG = 'jpeg',
-	PNG = 'png',
-	WebP = 'webp',
-	GIF = 'gif',
-	Lottie = 'json',
-}
 
 export interface CDNQuery {
 	/**

--- a/rest/v9/index.ts
+++ b/rest/v9/index.ts
@@ -943,6 +943,14 @@ export const Routes = {
 
 export const StickerPackApplicationId = '710982414301790216';
 
+export enum ImageFormat {
+	JPEG = 'jpeg',
+	PNG = 'png',
+	WebP = 'webp',
+	GIF = 'gif',
+	Lottie = 'json',
+}
+
 export const CDNRoutes = {
 	/**
 	 * Route for:
@@ -1121,7 +1129,7 @@ export const CDNRoutes = {
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
-	storePageAsset(applicationId: Snowflake, assetId: string, format: StorePageAssetFormat) {
+	storePageAsset(applicationId: Snowflake, assetId: string, format: StorePageAssetFormat = ImageFormat.PNG) {
 		return `/app-assets/${applicationId}/store/${assetId}.${format}` as const;
 	},
 
@@ -1202,14 +1210,6 @@ export type StickerFormat = Extract<ImageFormat, ImageFormat.PNG | ImageFormat.L
 export type RoleIconFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
 export type GuildScheduledEventCoverFormat = Exclude<ImageFormat, ImageFormat.Lottie | ImageFormat.GIF>;
 export type GuildMemberBannerFormat = Exclude<ImageFormat, ImageFormat.Lottie>;
-
-export enum ImageFormat {
-	JPEG = 'jpeg',
-	PNG = 'png',
-	WebP = 'webp',
-	GIF = 'gif',
-	Lottie = 'json',
-}
 
 export interface CDNQuery {
 	/**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Didn't realize #867 would be a breaking change, oops! This makes format parameter optional and defaults to PNG to make sure nothing breaks.

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
