### PR TITLE
feat(RESTPostAPIChannelMessageJSONBody): add enforce_nonce

### DIFF
--- a/deno/rest/v10/channel.ts
+++ b/deno/rest/v10/channel.ts
@@ -318,6 +318,11 @@ export interface RESTPostAPIChannelMessageJSONBody {
 	 * Message flags combined as a bitfield
 	 */
 	flags?: MessageFlags | undefined;
+	/**
+	 * If true and nonce is present, it will be checked for uniqueness in the past few minutes.
+	 * If another message was created by the same author with the same nonce, that message will be returned and no new message will be created.
+	 */
+	enforce_nonce?: boolean | undefined;
 }
 
 /**

--- a/deno/rest/v10/channel.ts
+++ b/deno/rest/v10/channel.ts
@@ -319,7 +319,7 @@ export interface RESTPostAPIChannelMessageJSONBody {
 	 */
 	flags?: MessageFlags | undefined;
 	/**
-	 * If true and nonce is present, it will be checked for uniqueness in the past few minutes.
+	 * If `true` and nonce is present, it will be checked for uniqueness in the past few minutes.
 	 * If another message was created by the same author with the same nonce, that message will be returned and no new message will be created.
 	 */
 	enforce_nonce?: boolean | undefined;

--- a/deno/rest/v9/channel.ts
+++ b/deno/rest/v9/channel.ts
@@ -327,7 +327,7 @@ export interface RESTPostAPIChannelMessageJSONBody {
 	 */
 	flags?: MessageFlags | undefined;
 	/**
-	 * If true and nonce is present, it will be checked for uniqueness in the past few minutes.
+	 * If `true` and nonce is present, it will be checked for uniqueness in the past few minutes.
 	 * If another message was created by the same author with the same nonce, that message will be returned and no new message will be created.
 	 */
 	enforce_nonce?: boolean | undefined;

--- a/deno/rest/v9/channel.ts
+++ b/deno/rest/v9/channel.ts
@@ -326,6 +326,11 @@ export interface RESTPostAPIChannelMessageJSONBody {
 	 * Message flags combined as a bitfield
 	 */
 	flags?: MessageFlags | undefined;
+	/**
+	 * If true and nonce is present, it will be checked for uniqueness in the past few minutes.
+	 * If another message was created by the same author with the same nonce, that message will be returned and no new message will be created.
+	 */
+	enforce_nonce?: boolean | undefined;
 }
 
 /**

--- a/rest/v10/channel.ts
+++ b/rest/v10/channel.ts
@@ -318,6 +318,11 @@ export interface RESTPostAPIChannelMessageJSONBody {
 	 * Message flags combined as a bitfield
 	 */
 	flags?: MessageFlags | undefined;
+	/**
+	 * If true and nonce is present, it will be checked for uniqueness in the past few minutes.
+	 * If another message was created by the same author with the same nonce, that message will be returned and no new message will be created.
+	 */
+	enforce_nonce?: boolean | undefined;
 }
 
 /**

--- a/rest/v10/channel.ts
+++ b/rest/v10/channel.ts
@@ -319,7 +319,7 @@ export interface RESTPostAPIChannelMessageJSONBody {
 	 */
 	flags?: MessageFlags | undefined;
 	/**
-	 * If true and nonce is present, it will be checked for uniqueness in the past few minutes.
+	 * If `true` and nonce is present, it will be checked for uniqueness in the past few minutes.
 	 * If another message was created by the same author with the same nonce, that message will be returned and no new message will be created.
 	 */
 	enforce_nonce?: boolean | undefined;

--- a/rest/v9/channel.ts
+++ b/rest/v9/channel.ts
@@ -327,7 +327,7 @@ export interface RESTPostAPIChannelMessageJSONBody {
 	 */
 	flags?: MessageFlags | undefined;
 	/**
-	 * If true and nonce is present, it will be checked for uniqueness in the past few minutes.
+	 * If `true` and nonce is present, it will be checked for uniqueness in the past few minutes.
 	 * If another message was created by the same author with the same nonce, that message will be returned and no new message will be created.
 	 */
 	enforce_nonce?: boolean | undefined;

--- a/rest/v9/channel.ts
+++ b/rest/v9/channel.ts
@@ -326,6 +326,11 @@ export interface RESTPostAPIChannelMessageJSONBody {
 	 * Message flags combined as a bitfield
 	 */
 	flags?: MessageFlags | undefined;
+	/**
+	 * If true and nonce is present, it will be checked for uniqueness in the past few minutes.
+	 * If another message was created by the same author with the same nonce, that message will be returned and no new message will be created.
+	 */
+	enforce_nonce?: boolean | undefined;
 }
 
 /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
- https://github.com/discord/discord-api-docs/pull/6647
