### PR TITLE
docs(APISelectMenuOption): correct character limit

### DIFF
--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -1766,7 +1766,7 @@ export type APISelectMenuComponent =
  */
 export interface APISelectMenuOption {
 	/**
-	 * The user-facing name of the option (max 25 chars)
+	 * The user-facing name of the option (max 100 chars)
 	 */
 	label: string;
 	/**
@@ -1774,7 +1774,7 @@ export interface APISelectMenuOption {
 	 */
 	value: string;
 	/**
-	 * An additional description of the option (max 50 chars)
+	 * An additional description of the option (max 100 chars)
 	 */
 	description?: string;
 	/**

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -1735,7 +1735,7 @@ export type APISelectMenuComponent =
  */
 export interface APISelectMenuOption {
 	/**
-	 * The user-facing name of the option (max 25 chars)
+	 * The user-facing name of the option (max 100 chars)
 	 */
 	label: string;
 	/**
@@ -1743,7 +1743,7 @@ export interface APISelectMenuOption {
 	 */
 	value: string;
 	/**
-	 * An additional description of the option (max 50 chars)
+	 * An additional description of the option (max 100 chars)
 	 */
 	description?: string;
 	/**

--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -1766,7 +1766,7 @@ export type APISelectMenuComponent =
  */
 export interface APISelectMenuOption {
 	/**
-	 * The user-facing name of the option (max 25 chars)
+	 * The user-facing name of the option (max 100 chars)
 	 */
 	label: string;
 	/**
@@ -1774,7 +1774,7 @@ export interface APISelectMenuOption {
 	 */
 	value: string;
 	/**
-	 * An additional description of the option (max 50 chars)
+	 * An additional description of the option (max 100 chars)
 	 */
 	description?: string;
 	/**

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -1735,7 +1735,7 @@ export type APISelectMenuComponent =
  */
 export interface APISelectMenuOption {
 	/**
-	 * The user-facing name of the option (max 25 chars)
+	 * The user-facing name of the option (max 100 chars)
 	 */
 	label: string;
 	/**
@@ -1743,7 +1743,7 @@ export interface APISelectMenuOption {
 	 */
 	value: string;
 	/**
-	 * An additional description of the option (max 50 chars)
+	 * An additional description of the option (max 100 chars)
 	 */
 	description?: string;
 	/**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
https://discord.com/developers/docs/interactions/message-components#select-menu-object-select-option-structure
