### PR TITLE
ci: enable npm provenance

### DIFF
--- a/.github/workflows/create-pr-for-release-and-publish.yml
+++ b/.github/workflows/create-pr-for-release-and-publish.yml
@@ -65,6 +65,8 @@ jobs:
   create_release:
     name: Create release and publish
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     if: github.repository_owner == 'discordjs' && github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(release)') && !contains(github.event.head_commit.message, '[skip ci]')
 
     steps:

--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -10,6 +10,8 @@ jobs:
   publish:
     name: Publish @next release to npm
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     if: github.repository_owner == 'discordjs' && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(release)'))
     steps:
       - name: Cancel previous publish attempts

--- a/package.json
+++ b/package.json
@@ -157,6 +157,9 @@
 		"tsutils": "^3.21.0",
 		"typescript": "^4.9.5"
 	},
+	"publishConfig": {
+		"provenance": true
+	},
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/discordjs/discord-api-types"


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Basically discordjs/discord.js#10164 for discord-api-types

I didn't use the `--provenance` flag for the workflow this time as this repo contains only a single package (it's hard not to include provenance in `package.json` if there's only a single package to maintain). As long as the `package.json` file has it it should be good

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
