### PR TITLE
chore(StageInstancePrivacyLevel): mark public PrivacyLevel as deprecated

### DIFF
--- a/deno/payloads/v10/stageInstance.ts
+++ b/deno/payloads/v10/stageInstance.ts
@@ -45,7 +45,7 @@ export interface APIStageInstance {
 export enum StageInstancePrivacyLevel {
 	/**
 	 * The stage instance is visible publicly, such as on stage discovery
-	 * 
+	 *
 	 * @deprecated
 	 */
 	Public = 1,

--- a/deno/payloads/v10/stageInstance.ts
+++ b/deno/payloads/v10/stageInstance.ts
@@ -45,6 +45,8 @@ export interface APIStageInstance {
 export enum StageInstancePrivacyLevel {
 	/**
 	 * The stage instance is visible publicly, such as on stage discovery
+	 * 
+	 * @deprecated
 	 */
 	Public = 1,
 	/**

--- a/payloads/v10/stageInstance.ts
+++ b/payloads/v10/stageInstance.ts
@@ -45,7 +45,7 @@ export interface APIStageInstance {
 export enum StageInstancePrivacyLevel {
 	/**
 	 * The stage instance is visible publicly, such as on stage discovery
-	 * 
+	 *
 	 * @deprecated
 	 */
 	Public = 1,

--- a/payloads/v10/stageInstance.ts
+++ b/payloads/v10/stageInstance.ts
@@ -45,6 +45,8 @@ export interface APIStageInstance {
 export enum StageInstancePrivacyLevel {
 	/**
 	 * The stage instance is visible publicly, such as on stage discovery
+	 * 
+	 * @deprecated
 	 */
 	Public = 1,
 	/**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The public `StageInstancePrivacyLevel` is marked as deprecated because the first pull request #317 missed this in v10.

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
