### PR TITLE
fix: Correct types for `APIAuditLogChangeKey$Add` and `APIAuditLogChangeKey$Remove`

### DIFF
--- a/deno/payloads/v10/auditLog.ts
+++ b/deno/payloads/v10/auditLog.ts
@@ -523,12 +523,12 @@ export type APIAuditLogChangeKeyVanityURLCode = AuditLogChangeData<'vanity_url_c
 /**
  * Returned when new role(s) are added
  */
-export type APIAuditLogChangeKey$Add = AuditLogChangeData<'$add', APIRole[]>;
+export type APIAuditLogChangeKey$Add = AuditLogChangeData<'$add', Pick<APIRole, "id" | "name">[]>;
 
 /**
  * Returned when role(s) are removed
  */
-export type APIAuditLogChangeKey$Remove = AuditLogChangeData<'$remove', APIRole[]>;
+export type APIAuditLogChangeKey$Remove = AuditLogChangeData<'$remove', Pick<APIRole, "id" | "name">[]>;
 
 /**
  * Returned when there is a change in number of days after which inactive and role-unassigned members are kicked

--- a/deno/payloads/v10/auditLog.ts
+++ b/deno/payloads/v10/auditLog.ts
@@ -523,12 +523,12 @@ export type APIAuditLogChangeKeyVanityURLCode = AuditLogChangeData<'vanity_url_c
 /**
  * Returned when new role(s) are added
  */
-export type APIAuditLogChangeKey$Add = AuditLogChangeData<'$add', Pick<APIRole, "id" | "name">[]>;
+export type APIAuditLogChangeKey$Add = AuditLogChangeData<'$add', Pick<APIRole, 'id' | 'name'>[]>;
 
 /**
  * Returned when role(s) are removed
  */
-export type APIAuditLogChangeKey$Remove = AuditLogChangeData<'$remove', Pick<APIRole, "id" | "name">[]>;
+export type APIAuditLogChangeKey$Remove = AuditLogChangeData<'$remove', Pick<APIRole, 'id' | 'name'>[]>;
 
 /**
  * Returned when there is a change in number of days after which inactive and role-unassigned members are kicked

--- a/deno/payloads/v9/auditLog.ts
+++ b/deno/payloads/v9/auditLog.ts
@@ -523,12 +523,12 @@ export type APIAuditLogChangeKeyVanityURLCode = AuditLogChangeData<'vanity_url_c
 /**
  * Returned when new role(s) are added
  */
-export type APIAuditLogChangeKey$Add = AuditLogChangeData<'$add', APIRole[]>;
+export type APIAuditLogChangeKey$Add = AuditLogChangeData<'$add', Pick<APIRole, "id" | "name">[]>;
 
 /**
  * Returned when role(s) are removed
  */
-export type APIAuditLogChangeKey$Remove = AuditLogChangeData<'$remove', APIRole[]>;
+export type APIAuditLogChangeKey$Remove = AuditLogChangeData<'$remove', Pick<APIRole, "id" | "name">[]>;
 
 /**
  * Returned when there is a change in number of days after which inactive and role-unassigned members are kicked

--- a/deno/payloads/v9/auditLog.ts
+++ b/deno/payloads/v9/auditLog.ts
@@ -523,12 +523,12 @@ export type APIAuditLogChangeKeyVanityURLCode = AuditLogChangeData<'vanity_url_c
 /**
  * Returned when new role(s) are added
  */
-export type APIAuditLogChangeKey$Add = AuditLogChangeData<'$add', Pick<APIRole, "id" | "name">[]>;
+export type APIAuditLogChangeKey$Add = AuditLogChangeData<'$add', Pick<APIRole, 'id' | 'name'>[]>;
 
 /**
  * Returned when role(s) are removed
  */
-export type APIAuditLogChangeKey$Remove = AuditLogChangeData<'$remove', Pick<APIRole, "id" | "name">[]>;
+export type APIAuditLogChangeKey$Remove = AuditLogChangeData<'$remove', Pick<APIRole, 'id' | 'name'>[]>;
 
 /**
  * Returned when there is a change in number of days after which inactive and role-unassigned members are kicked

--- a/payloads/v10/auditLog.ts
+++ b/payloads/v10/auditLog.ts
@@ -523,12 +523,12 @@ export type APIAuditLogChangeKeyVanityURLCode = AuditLogChangeData<'vanity_url_c
 /**
  * Returned when new role(s) are added
  */
-export type APIAuditLogChangeKey$Add = AuditLogChangeData<'$add', APIRole[]>;
+export type APIAuditLogChangeKey$Add = AuditLogChangeData<'$add', Pick<APIRole, "id" | "name">[]>;
 
 /**
  * Returned when role(s) are removed
  */
-export type APIAuditLogChangeKey$Remove = AuditLogChangeData<'$remove', APIRole[]>;
+export type APIAuditLogChangeKey$Remove = AuditLogChangeData<'$remove', Pick<APIRole, "id" | "name">[]>;
 
 /**
  * Returned when there is a change in number of days after which inactive and role-unassigned members are kicked

--- a/payloads/v10/auditLog.ts
+++ b/payloads/v10/auditLog.ts
@@ -523,12 +523,12 @@ export type APIAuditLogChangeKeyVanityURLCode = AuditLogChangeData<'vanity_url_c
 /**
  * Returned when new role(s) are added
  */
-export type APIAuditLogChangeKey$Add = AuditLogChangeData<'$add', Pick<APIRole, "id" | "name">[]>;
+export type APIAuditLogChangeKey$Add = AuditLogChangeData<'$add', Pick<APIRole, 'id' | 'name'>[]>;
 
 /**
  * Returned when role(s) are removed
  */
-export type APIAuditLogChangeKey$Remove = AuditLogChangeData<'$remove', Pick<APIRole, "id" | "name">[]>;
+export type APIAuditLogChangeKey$Remove = AuditLogChangeData<'$remove', Pick<APIRole, 'id' | 'name'>[]>;
 
 /**
  * Returned when there is a change in number of days after which inactive and role-unassigned members are kicked

--- a/payloads/v9/auditLog.ts
+++ b/payloads/v9/auditLog.ts
@@ -523,12 +523,12 @@ export type APIAuditLogChangeKeyVanityURLCode = AuditLogChangeData<'vanity_url_c
 /**
  * Returned when new role(s) are added
  */
-export type APIAuditLogChangeKey$Add = AuditLogChangeData<'$add', APIRole[]>;
+export type APIAuditLogChangeKey$Add = AuditLogChangeData<'$add', Pick<APIRole, "id" | "name">[]>;
 
 /**
  * Returned when role(s) are removed
  */
-export type APIAuditLogChangeKey$Remove = AuditLogChangeData<'$remove', APIRole[]>;
+export type APIAuditLogChangeKey$Remove = AuditLogChangeData<'$remove', Pick<APIRole, "id" | "name">[]>;
 
 /**
  * Returned when there is a change in number of days after which inactive and role-unassigned members are kicked

--- a/payloads/v9/auditLog.ts
+++ b/payloads/v9/auditLog.ts
@@ -523,12 +523,12 @@ export type APIAuditLogChangeKeyVanityURLCode = AuditLogChangeData<'vanity_url_c
 /**
  * Returned when new role(s) are added
  */
-export type APIAuditLogChangeKey$Add = AuditLogChangeData<'$add', Pick<APIRole, "id" | "name">[]>;
+export type APIAuditLogChangeKey$Add = AuditLogChangeData<'$add', Pick<APIRole, 'id' | 'name'>[]>;
 
 /**
  * Returned when role(s) are removed
  */
-export type APIAuditLogChangeKey$Remove = AuditLogChangeData<'$remove', Pick<APIRole, "id" | "name">[]>;
+export type APIAuditLogChangeKey$Remove = AuditLogChangeData<'$remove', Pick<APIRole, 'id' | 'name'>[]>;
 
 /**
  * Returned when there is a change in number of days after which inactive and role-unassigned members are kicked


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

> `new_value` is an array of objects that contain the role `id` and `name`

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**

https://canary.discord.com/developers/docs/resources/audit-log#audit-log-change-object-audit-log-change-exceptions:~:text=as%20keys-,new_value,name,-Webhook