### PR TITLE
feat(RouteBases): Add media URL

### DIFF
--- a/deno/rest/v10/mod.ts
+++ b/deno/rest/v10/mod.ts
@@ -1294,6 +1294,7 @@ export interface CDNQuery {
 export const RouteBases = {
 	api: `https://discord.com/api/v${APIVersion}`,
 	cdn: 'https://cdn.discordapp.com',
+	media: 'https://media.discordapp.net',
 	invite: 'https://discord.gg',
 	template: 'https://discord.new',
 	gift: 'https://discord.gift',

--- a/rest/v10/index.ts
+++ b/rest/v10/index.ts
@@ -1294,6 +1294,7 @@ export interface CDNQuery {
 export const RouteBases = {
 	api: `https://discord.com/api/v${APIVersion}`,
 	cdn: 'https://cdn.discordapp.com',
+	media: 'https://media.discordapp.net',
 	invite: 'https://discord.gg',
 	template: 'https://discord.new',
 	gift: 'https://discord.gift',


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Adds the media proxy URL as GIF stickers are accessed there.

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
https://discord.com/developers/docs/reference#image-formatting-cdn-endpoints