### PR TITLE
feat: add premium buttons

### DIFF
--- a/deno/payloads/v10/_interactions/responses.ts
+++ b/deno/payloads/v10/_interactions/responses.ts
@@ -98,6 +98,8 @@ export enum InteractionResponseType {
 	Modal,
 	/**
 	 * Respond to an interaction with an upgrade button, only available for apps with monetization enabled
+	 *
+	 * @deprecated See https://discord.com/developers/docs/change-log#premium-apps-new-premium-button-style-deep-linking-url-schemes
 	 */
 	PremiumRequired,
 }

--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -1652,7 +1652,18 @@ export interface APIButtonComponentWithURL extends APIButtonComponentBase<Button
 	url: string;
 }
 
-export type APIButtonComponent = APIButtonComponentWithCustomId | APIButtonComponentWithURL;
+export interface APIButtonComponentWithSKUId
+	extends Omit<APIButtonComponentBase<ButtonStyle.Premium>, 'custom_id' | 'emoji' | 'label'> {
+	/**
+	 * The id for a purchasable SKU
+	 */
+	sku_id: Snowflake;
+}
+
+export type APIButtonComponent =
+	| APIButtonComponentWithCustomId
+	| APIButtonComponentWithSKUId
+	| APIButtonComponentWithURL;
 
 /**
  * https://discord.com/developers/docs/interactions/message-components#button-object-button-styles
@@ -1663,6 +1674,7 @@ export enum ButtonStyle {
 	Success,
 	Danger,
 	Link,
+	Premium,
 }
 
 /**

--- a/deno/payloads/v9/_interactions/responses.ts
+++ b/deno/payloads/v9/_interactions/responses.ts
@@ -98,6 +98,8 @@ export enum InteractionResponseType {
 	Modal,
 	/**
 	 * Respond to an interaction with an upgrade button, only available for apps with monetization enabled
+	 *
+	 * @deprecated See https://discord.com/developers/docs/change-log#premium-apps-new-premium-button-style-deep-linking-url-schemes
 	 */
 	PremiumRequired,
 }

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -1619,7 +1619,18 @@ export interface APIButtonComponentWithURL extends APIButtonComponentBase<Button
 	url: string;
 }
 
-export type APIButtonComponent = APIButtonComponentWithCustomId | APIButtonComponentWithURL;
+export interface APIButtonComponentWithSKUId
+	extends Omit<APIButtonComponentBase<ButtonStyle.Premium>, 'custom_id' | 'emoji' | 'label'> {
+	/**
+	 * The id for a purchasable SKU
+	 */
+	sku_id: Snowflake;
+}
+
+export type APIButtonComponent =
+	| APIButtonComponentWithCustomId
+	| APIButtonComponentWithSKUId
+	| APIButtonComponentWithURL;
 
 /**
  * https://discord.com/developers/docs/interactions/message-components#button-object-button-styles
@@ -1630,6 +1641,7 @@ export enum ButtonStyle {
 	Success,
 	Danger,
 	Link,
+	Premium,
 }
 
 /**

--- a/payloads/v10/_interactions/responses.ts
+++ b/payloads/v10/_interactions/responses.ts
@@ -98,6 +98,8 @@ export enum InteractionResponseType {
 	Modal,
 	/**
 	 * Respond to an interaction with an upgrade button, only available for apps with monetization enabled
+	 *
+	 * @deprecated See https://discord.com/developers/docs/change-log#premium-apps-new-premium-button-style-deep-linking-url-schemes
 	 */
 	PremiumRequired,
 }

--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -1652,7 +1652,18 @@ export interface APIButtonComponentWithURL extends APIButtonComponentBase<Button
 	url: string;
 }
 
-export type APIButtonComponent = APIButtonComponentWithCustomId | APIButtonComponentWithURL;
+export interface APIButtonComponentWithSKUId
+	extends Omit<APIButtonComponentBase<ButtonStyle.Premium>, 'custom_id' | 'emoji' | 'label'> {
+	/**
+	 * The id for a purchasable SKU
+	 */
+	sku_id: Snowflake;
+}
+
+export type APIButtonComponent =
+	| APIButtonComponentWithCustomId
+	| APIButtonComponentWithSKUId
+	| APIButtonComponentWithURL;
 
 /**
  * https://discord.com/developers/docs/interactions/message-components#button-object-button-styles
@@ -1663,6 +1674,7 @@ export enum ButtonStyle {
 	Success,
 	Danger,
 	Link,
+	Premium,
 }
 
 /**

--- a/payloads/v9/_interactions/responses.ts
+++ b/payloads/v9/_interactions/responses.ts
@@ -98,6 +98,8 @@ export enum InteractionResponseType {
 	Modal,
 	/**
 	 * Respond to an interaction with an upgrade button, only available for apps with monetization enabled
+	 *
+	 * @deprecated See https://discord.com/developers/docs/change-log#premium-apps-new-premium-button-style-deep-linking-url-schemes
 	 */
 	PremiumRequired,
 }

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -1619,7 +1619,18 @@ export interface APIButtonComponentWithURL extends APIButtonComponentBase<Button
 	url: string;
 }
 
-export type APIButtonComponent = APIButtonComponentWithCustomId | APIButtonComponentWithURL;
+export interface APIButtonComponentWithSKUId
+	extends Omit<APIButtonComponentBase<ButtonStyle.Premium>, 'custom_id' | 'emoji' | 'label'> {
+	/**
+	 * The id for a purchasable SKU
+	 */
+	sku_id: Snowflake;
+}
+
+export type APIButtonComponent =
+	| APIButtonComponentWithCustomId
+	| APIButtonComponentWithSKUId
+	| APIButtonComponentWithURL;
 
 /**
  * https://discord.com/developers/docs/interactions/message-components#button-object-button-styles
@@ -1630,6 +1641,7 @@ export enum ButtonStyle {
 	Success,
 	Danger,
 	Link,
+	Premium,
 }
 
 /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Adds support for premium button types and deprecates premium interaction response types.

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
https://github.com/discord/discord-api-docs/pull/6875