### PR TITLE
chore: ignore deprecated versions on linters

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,12 @@
 deno/
+
+gateway/v6/*
+payloads/v6/*
+rest/v6/*
+v6.ts
+
+gateway/v8/*
+payloads/v8/*
+rest/v8/*
+utils/v8.ts
+v8.ts

--- a/.prettierignore
+++ b/.prettierignore
@@ -24,3 +24,15 @@ CHANGELOG.md
 # Format all of scripts
 !scripts/**/*
 !.prettierrc.mjs
+
+# Deprecated versions
+gateway/v6/*
+payloads/v6/*
+rest/v6/*
+v6.ts
+
+gateway/v8/*
+payloads/v8/*
+rest/v8/*
+utils/v8.ts
+v8.ts

--- a/scripts/deno.mjs
+++ b/scripts/deno.mjs
@@ -18,6 +18,7 @@ await mkdir(denoPath);
  */
 function convertImports(source) {
 	return source.replaceAll(
+		// eslint-disable-next-line prefer-named-capture-group
 		/from '(.*)'/g,
 		/**
 		 * @param _ Something


### PR DESCRIPTION
The files for deprecated versions were still being linted and causing warnings in CI. Ignore them as they won't be updated anymore
