### PR TITLE
fix(CDNRoutes): inconsistency in route and wrong JSDoc

### DIFF
--- a/deno/rest/v10/mod.ts
+++ b/deno/rest/v10/mod.ts
@@ -995,14 +995,14 @@ export const CDNRoutes = {
 
 	/**
 	 * Route for:
-	 * - GET `/guilds/{guild.id}/icons/{guild.id}.{png|jpeg|webp|gif}`
+	 * - GET `/icons/{guild.id}.{png|jpeg|webp|gif}`
 	 *
 	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
 	guildIcon<Format extends GuildIconFormat>(guildId: Snowflake, guildIcon: string, format: Format) {
-		return `icons/${guildId}/${guildIcon}.${format}` as const;
+		return `/icons/${guildId}/${guildIcon}.${format}` as const;
 	},
 
 	/**

--- a/deno/rest/v10/mod.ts
+++ b/deno/rest/v10/mod.ts
@@ -1081,7 +1081,7 @@ export const CDNRoutes = {
 
 	/**
 	 * Route for:
-	 * - GET `/guilds/{guild.id}/users/{user.id}/{guild_member.avatar}.{png|jpeg|webp|gif}`
+	 * - GET `/guilds/{guild.id}/users/{user.id}/avatars/{guild_member.avatar}.{png|jpeg|webp|gif}`
 	 *
 	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
 	 *

--- a/deno/rest/v10/mod.ts
+++ b/deno/rest/v10/mod.ts
@@ -1201,7 +1201,7 @@ export const CDNRoutes = {
 
 	/**
 	 * Route for:
-	 * - GET `team-icons/{team.id}/{team.icon}.{png|jpeg|webp}`
+	 * - GET `/team-icons/{team.id}/{team.icon}.{png|jpeg|webp}`
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */

--- a/deno/rest/v10/mod.ts
+++ b/deno/rest/v10/mod.ts
@@ -995,7 +995,7 @@ export const CDNRoutes = {
 
 	/**
 	 * Route for:
-	 * - GET `/icons/{guild.id}.{png|jpeg|webp|gif}`
+	 * - GET `/icons/{guild.id}/{guild.icon}.{png|jpeg|webp|gif}`
 	 *
 	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
 	 *

--- a/deno/rest/v9/mod.ts
+++ b/deno/rest/v9/mod.ts
@@ -1004,7 +1004,7 @@ export const CDNRoutes = {
 
 	/**
 	 * Route for:
-	 * - GET `/icons/{guild.id}.{png|jpeg|webp|gif}`
+	 * - GET `/icons/{guild.id}/{guild.icon}.{png|jpeg|webp|gif}`
 	 *
 	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
 	 *

--- a/deno/rest/v9/mod.ts
+++ b/deno/rest/v9/mod.ts
@@ -1210,7 +1210,7 @@ export const CDNRoutes = {
 
 	/**
 	 * Route for:
-	 * - GET `team-icons/{team.id}/{team.icon}.{png|jpeg|webp}`
+	 * - GET `/team-icons/{team.id}/{team.icon}.{png|jpeg|webp}`
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */

--- a/deno/rest/v9/mod.ts
+++ b/deno/rest/v9/mod.ts
@@ -1004,14 +1004,14 @@ export const CDNRoutes = {
 
 	/**
 	 * Route for:
-	 * - GET `/guilds/{guild.id}/icons/{guild.id}.{png|jpeg|webp|gif}`
+	 * - GET `/icons/{guild.id}.{png|jpeg|webp|gif}`
 	 *
 	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
 	guildIcon<Format extends GuildIconFormat>(guildId: Snowflake, guildIcon: string, format: Format) {
-		return `icons/${guildId}/${guildIcon}.${format}` as const;
+		return `/icons/${guildId}/${guildIcon}.${format}` as const;
 	},
 
 	/**

--- a/deno/rest/v9/mod.ts
+++ b/deno/rest/v9/mod.ts
@@ -1090,7 +1090,7 @@ export const CDNRoutes = {
 
 	/**
 	 * Route for:
-	 * - GET `/guilds/{guild.id}/users/{user.id}/{guild_member.avatar}.{png|jpeg|webp|gif}`
+	 * - GET `/guilds/{guild.id}/users/{user.id}/avatars/{guild_member.avatar}.{png|jpeg|webp|gif}`
 	 *
 	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
 	 *

--- a/rest/v10/index.ts
+++ b/rest/v10/index.ts
@@ -995,14 +995,14 @@ export const CDNRoutes = {
 
 	/**
 	 * Route for:
-	 * - GET `/guilds/{guild.id}/icons/{guild.id}.{png|jpeg|webp|gif}`
+	 * - GET `/icons/{guild.id}.{png|jpeg|webp|gif}`
 	 *
 	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
 	guildIcon<Format extends GuildIconFormat>(guildId: Snowflake, guildIcon: string, format: Format) {
-		return `icons/${guildId}/${guildIcon}.${format}` as const;
+		return `/icons/${guildId}/${guildIcon}.${format}` as const;
 	},
 
 	/**

--- a/rest/v10/index.ts
+++ b/rest/v10/index.ts
@@ -1201,7 +1201,7 @@ export const CDNRoutes = {
 
 	/**
 	 * Route for:
-	 * - GET `team-icons/{team.id}/{team.icon}.{png|jpeg|webp}`
+	 * - GET `/team-icons/{team.id}/{team.icon}.{png|jpeg|webp}`
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */

--- a/rest/v10/index.ts
+++ b/rest/v10/index.ts
@@ -995,7 +995,7 @@ export const CDNRoutes = {
 
 	/**
 	 * Route for:
-	 * - GET `/icons/{guild.id}.{png|jpeg|webp|gif}`
+	 * - GET `/icons/{guild.id}/{guild.icon}.{png|jpeg|webp|gif}`
 	 *
 	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
 	 *
@@ -1081,7 +1081,7 @@ export const CDNRoutes = {
 
 	/**
 	 * Route for:
-	 * - GET `/guilds/{guild.id}/users/{user.id}/{guild_member.avatar}.{png|jpeg|webp|gif}`
+	 * - GET `/guilds/{guild.id}/users/{user.id}/avatars/{guild_member.avatar}.{png|jpeg|webp|gif}`
 	 *
 	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
 	 *

--- a/rest/v9/index.ts
+++ b/rest/v9/index.ts
@@ -1004,7 +1004,7 @@ export const CDNRoutes = {
 
 	/**
 	 * Route for:
-	 * - GET `/icons/{guild.id}.{png|jpeg|webp|gif}`
+	 * - GET `/icons/{guild.id}/{guild.icon}.{png|jpeg|webp|gif}`
 	 *
 	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
 	 *
@@ -1090,7 +1090,7 @@ export const CDNRoutes = {
 
 	/**
 	 * Route for:
-	 * - GET `/guilds/{guild.id}/users/{user.id}/{guild_member.avatar}.{png|jpeg|webp|gif}`
+	 * - GET `/guilds/{guild.id}/users/{user.id}/avatars/{guild_member.avatar}.{png|jpeg|webp|gif}`
 	 *
 	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
 	 *

--- a/rest/v9/index.ts
+++ b/rest/v9/index.ts
@@ -1210,7 +1210,7 @@ export const CDNRoutes = {
 
 	/**
 	 * Route for:
-	 * - GET `team-icons/{team.id}/{team.icon}.{png|jpeg|webp}`
+	 * - GET `/team-icons/{team.id}/{team.icon}.{png|jpeg|webp}`
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */

--- a/rest/v9/index.ts
+++ b/rest/v9/index.ts
@@ -1004,14 +1004,14 @@ export const CDNRoutes = {
 
 	/**
 	 * Route for:
-	 * - GET `/guilds/{guild.id}/icons/{guild.id}.{png|jpeg|webp|gif}`
+	 * - GET `/icons/{guild.id}.{png|jpeg|webp|gif}`
 	 *
 	 * As this route supports GIFs, the hash will begin with `a_` if it is available in GIF format
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP, GIF
 	 */
 	guildIcon<Format extends GuildIconFormat>(guildId: Snowflake, guildIcon: string, format: Format) {
-		return `icons/${guildId}/${guildIcon}.${format}` as const;
+		return `/icons/${guildId}/${guildIcon}.${format}` as const;
 	},
 
 	/**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:** It fixes an inconsistency in the guildIcon cdn route. This route does not start with `/` like the rest of the routes. It also fixes it's JSDoc which is completely wrong.

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:** None
