### PR TITLE
feat(RESTOAuth2): add RESTPostOAuth2TokenRevocationQuery

### DIFF
--- a/deno/rest/v10/oauth2.ts
+++ b/deno/rest/v10/oauth2.ts
@@ -41,6 +41,14 @@ export interface RESTOAuth2AuthorizationQuery {
 }
 
 /**
+ * https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-token-revocation-example
+ */
+export interface RESTPostOAuth2TokenRevocationQuery {
+	token: string;
+	token_type_hint?: 'access_token' | 'refresh_token';
+}
+
+/**
  * https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-redirect-url-example
  */
 export interface RESTOAuth2AuthorizationQueryResult {

--- a/deno/rest/v9/oauth2.ts
+++ b/deno/rest/v9/oauth2.ts
@@ -41,6 +41,14 @@ export interface RESTOAuth2AuthorizationQuery {
 }
 
 /**
+ * https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-token-revocation-example
+ */
+export interface RESTPostOAuth2TokenRevocationQuery {
+	token: string;
+	token_type_hint?: 'access_token' | 'refresh_token';
+}
+
+/**
  * https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-redirect-url-example
  */
 export interface RESTOAuth2AuthorizationQueryResult {

--- a/rest/v10/oauth2.ts
+++ b/rest/v10/oauth2.ts
@@ -41,6 +41,14 @@ export interface RESTOAuth2AuthorizationQuery {
 }
 
 /**
+ * https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-token-revocation-example
+ */
+export interface RESTPostOAuth2TokenRevocationQuery {
+	token: string;
+	token_type_hint?: 'access_token' | 'refresh_token';
+}
+
+/**
  * https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-redirect-url-example
  */
 export interface RESTOAuth2AuthorizationQueryResult {

--- a/rest/v9/oauth2.ts
+++ b/rest/v9/oauth2.ts
@@ -41,6 +41,14 @@ export interface RESTOAuth2AuthorizationQuery {
 }
 
 /**
+ * https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-token-revocation-example
+ */
+export interface RESTPostOAuth2TokenRevocationQuery {
+	token: string;
+	token_type_hint?: 'access_token' | 'refresh_token';
+}
+
+/**
  * https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-redirect-url-example
  */
 export interface RESTOAuth2AuthorizationQueryResult {


### PR DESCRIPTION
The `RESTPostOAuth2TokenRevocationQuery` provides expected types for the [`Token Revocation URL`](https://discord.com/developers/docs/topics/oauth2)

Please let me know if you have any further requests or modifications!