### PR TITLE
fix: nullable fields for scheduled event editing

### DIFF
--- a/deno/rest/v10/guildScheduledEvent.ts
+++ b/deno/rest/v10/guildScheduledEvent.ts
@@ -97,7 +97,9 @@ export type RESTGetAPIGuildScheduledEventResult = APIGuildScheduledEvent;
 export type RESTPatchAPIGuildScheduledEventJSONBody = Nullable<
 	Pick<RESTPostAPIGuildScheduledEventJSONBody, 'description' | 'entity_metadata' | 'recurrence_rule'>
 > &
-	StrictPartial<Omit<RESTPostAPIGuildScheduledEventJSONBody, 'recurrence_rule'>> & {
+	StrictPartial<
+		Omit<RESTPostAPIGuildScheduledEventJSONBody, 'description' | 'entity_metadata' | 'recurrence_rule'>
+	> & {
 		/**
 		 * The status of the scheduled event
 		 */

--- a/deno/rest/v9/guildScheduledEvent.ts
+++ b/deno/rest/v9/guildScheduledEvent.ts
@@ -97,7 +97,9 @@ export type RESTGetAPIGuildScheduledEventResult = APIGuildScheduledEvent;
 export type RESTPatchAPIGuildScheduledEventJSONBody = Nullable<
 	Pick<RESTPostAPIGuildScheduledEventJSONBody, 'description' | 'entity_metadata' | 'recurrence_rule'>
 > &
-	StrictPartial<Omit<RESTPostAPIGuildScheduledEventJSONBody, 'recurrence_rule'>> & {
+	StrictPartial<
+		Omit<RESTPostAPIGuildScheduledEventJSONBody, 'description' | 'entity_metadata' | 'recurrence_rule'>
+	> & {
 		/**
 		 * The status of the scheduled event
 		 */

--- a/rest/v10/guildScheduledEvent.ts
+++ b/rest/v10/guildScheduledEvent.ts
@@ -97,7 +97,9 @@ export type RESTGetAPIGuildScheduledEventResult = APIGuildScheduledEvent;
 export type RESTPatchAPIGuildScheduledEventJSONBody = Nullable<
 	Pick<RESTPostAPIGuildScheduledEventJSONBody, 'description' | 'entity_metadata' | 'recurrence_rule'>
 > &
-	StrictPartial<Omit<RESTPostAPIGuildScheduledEventJSONBody, 'recurrence_rule'>> & {
+	StrictPartial<
+		Omit<RESTPostAPIGuildScheduledEventJSONBody, 'description' | 'entity_metadata' | 'recurrence_rule'>
+	> & {
 		/**
 		 * The status of the scheduled event
 		 */

--- a/rest/v9/guildScheduledEvent.ts
+++ b/rest/v9/guildScheduledEvent.ts
@@ -97,7 +97,9 @@ export type RESTGetAPIGuildScheduledEventResult = APIGuildScheduledEvent;
 export type RESTPatchAPIGuildScheduledEventJSONBody = Nullable<
 	Pick<RESTPostAPIGuildScheduledEventJSONBody, 'description' | 'entity_metadata' | 'recurrence_rule'>
 > &
-	StrictPartial<Omit<RESTPostAPIGuildScheduledEventJSONBody, 'recurrence_rule'>> & {
+	StrictPartial<
+		Omit<RESTPostAPIGuildScheduledEventJSONBody, 'description' | 'entity_metadata' | 'recurrence_rule'>
+	> & {
 		/**
 		 * The status of the scheduled event
 		 */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Missed some fields

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
