### PR TITLE
feat(RESTAPIAttachment): add more properties

### DIFF
--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -573,7 +573,7 @@ export interface APIMessage {
 	/**
 	 * Any attached files
 	 *
-	 * See https://discord.com/developers/docs/resources/channel#attachment-object
+	 * See https://discord.com/developers/docs/resources/message#attachment-object-attachment-structure
 	 *
 	 * The `MESSAGE_CONTENT` privileged gateway intent is required for verified applications to receive a non-empty value from this field
 	 *
@@ -1415,7 +1415,7 @@ export interface APIEmbedField {
 }
 
 /**
- * https://discord.com/developers/docs/resources/channel#attachment-object-attachment-structure
+ * https://discord.com/developers/docs/resources/message#attachment-object-attachment-structure
  */
 export interface APIAttachment {
 	/**

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -567,7 +567,7 @@ export interface APIMessage {
 	/**
 	 * Any attached files
 	 *
-	 * See https://discord.com/developers/docs/resources/channel#attachment-object
+	 * See https://discord.com/developers/docs/resources/message#attachment-object-attachment-structure
 	 *
 	 * The `MESSAGE_CONTENT` privileged gateway intent will become required after **August 31, 2022** for verified applications to receive a non-empty value from this field
 	 *
@@ -1382,7 +1382,7 @@ export interface APIEmbedField {
 }
 
 /**
- * https://discord.com/developers/docs/resources/channel#attachment-object-attachment-structure
+ * https://discord.com/developers/docs/resources/message#attachment-object-attachment-structure
  */
 export interface APIAttachment {
 	/**

--- a/deno/rest/v10/channel.ts
+++ b/deno/rest/v10/channel.ts
@@ -24,6 +24,7 @@ import type {
 	SortOrderType,
 	ForumLayoutType,
 	ChannelFlags,
+	APIAttachment,
 } from '../../payloads/v10/mod.ts';
 import type { AddUndefinedToPossiblyUndefinedPropertiesOfInterface, StrictPartial } from '../../utils/internals.ts';
 import type { RESTAPIPoll } from './poll.ts';
@@ -260,22 +261,16 @@ export type RESTAPIMessageReference = AddUndefinedToPossiblyUndefinedPropertiesO
 export type APIMessageReferenceSend = RESTAPIMessageReference;
 
 /**
- * https://discord.com/developers/docs/resources/channel#attachment-object
+ * https://discord.com/developers/docs/resources/message#attachment-object-attachment-structure
  */
-export interface RESTAPIAttachment {
+export type RESTAPIAttachment = Partial<
+	Pick<APIAttachment, 'description' | 'duration_secs' | 'filename' | 'title' | 'waveform'>
+> & {
 	/**
 	 * Attachment id or a number that matches `n` in `files[n]`
 	 */
 	id: Snowflake | number;
-	/**
-	 * Name of the file
-	 */
-	filename?: string | undefined;
-	/**
-	 * Description of the file
-	 */
-	description?: string | undefined;
-}
+};
 
 /**
  * https://discord.com/developers/docs/resources/channel#create-message
@@ -461,7 +456,7 @@ export interface RESTPatchAPIChannelMessageJSONBody {
 	 *
 	 * Starting with API v10, the `attachments` array must contain all attachments that should be present after edit, including **retained and new** attachments provided in the request body.
 	 *
-	 * See https://discord.com/developers/docs/resources/channel#attachment-object
+	 * See https://discord.com/developers/docs/resources/message#attachment-object-attachment-structure
 	 */
 	attachments?: RESTAPIAttachment[] | undefined;
 	/**

--- a/deno/rest/v10/webhook.ts
+++ b/deno/rest/v10/webhook.ts
@@ -264,7 +264,7 @@ export type RESTPatchAPIWebhookWithTokenMessageJSONBody = AddUndefinedToPossibly
 	 *
 	 * Starting with API v10, the `attachments` array must contain all attachments that should be present after edit, including **retained and new** attachments provided in the request body.
 	 *
-	 * See https://discord.com/developers/docs/resources/channel#attachment-object
+	 * See https://discord.com/developers/docs/resources/message#attachment-object-attachment-structure
 	 */
 	attachments?: RESTAPIAttachment[] | undefined;
 };

--- a/deno/rest/v9/channel.ts
+++ b/deno/rest/v9/channel.ts
@@ -24,6 +24,7 @@ import type {
 	SortOrderType,
 	ForumLayoutType,
 	ChannelFlags,
+	APIAttachment,
 } from '../../payloads/v9/mod.ts';
 import type { AddUndefinedToPossiblyUndefinedPropertiesOfInterface, StrictPartial } from '../../utils/internals.ts';
 import type { RESTAPIPoll } from './poll.ts';
@@ -260,22 +261,16 @@ export type RESTAPIMessageReference = AddUndefinedToPossiblyUndefinedPropertiesO
 export type APIMessageReferenceSend = RESTAPIMessageReference;
 
 /**
- * https://discord.com/developers/docs/resources/channel#attachment-object
+ * https://discord.com/developers/docs/resources/message#attachment-object-attachment-structure
  */
-export interface RESTAPIAttachment {
+export type RESTAPIAttachment = Partial<
+	Pick<APIAttachment, 'description' | 'duration_secs' | 'filename' | 'title' | 'waveform'>
+> & {
 	/**
 	 * Attachment id or a number that matches `n` in `files[n]`
 	 */
 	id: Snowflake | number;
-	/**
-	 * Name of the file
-	 */
-	filename?: string | undefined;
-	/**
-	 * Description of the file
-	 */
-	description?: string | undefined;
-}
+};
 
 /**
  * https://discord.com/developers/docs/resources/channel#create-message
@@ -477,7 +472,7 @@ export interface RESTPatchAPIChannelMessageJSONBody {
 	 *
 	 * Starting with API v10, the `attachments` array must contain all attachments that should be present after edit, including **retained and new** attachments provided in the request body.
 	 *
-	 * See https://discord.com/developers/docs/resources/channel#attachment-object
+	 * See https://discord.com/developers/docs/resources/message#attachment-object-attachment-structure
 	 */
 	attachments?: RESTAPIAttachment[] | undefined;
 	/**

--- a/deno/rest/v9/webhook.ts
+++ b/deno/rest/v9/webhook.ts
@@ -264,7 +264,7 @@ export type RESTPatchAPIWebhookWithTokenMessageJSONBody = AddUndefinedToPossibly
 	 *
 	 * Starting with API v10, the `attachments` array must contain all attachments that should be present after edit, including **retained and new** attachments provided in the request body.
 	 *
-	 * See https://discord.com/developers/docs/resources/channel#attachment-object
+	 * See https://discord.com/developers/docs/resources/message#attachment-object-attachment-structure
 	 */
 	attachments?: RESTAPIAttachment[] | undefined;
 };

--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -573,7 +573,7 @@ export interface APIMessage {
 	/**
 	 * Any attached files
 	 *
-	 * See https://discord.com/developers/docs/resources/channel#attachment-object
+	 * See https://discord.com/developers/docs/resources/message#attachment-object-attachment-structure
 	 *
 	 * The `MESSAGE_CONTENT` privileged gateway intent is required for verified applications to receive a non-empty value from this field
 	 *
@@ -1415,7 +1415,7 @@ export interface APIEmbedField {
 }
 
 /**
- * https://discord.com/developers/docs/resources/channel#attachment-object-attachment-structure
+ * https://discord.com/developers/docs/resources/message#attachment-object-attachment-structure
  */
 export interface APIAttachment {
 	/**

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -567,7 +567,7 @@ export interface APIMessage {
 	/**
 	 * Any attached files
 	 *
-	 * See https://discord.com/developers/docs/resources/channel#attachment-object
+	 * See https://discord.com/developers/docs/resources/message#attachment-object-attachment-structure
 	 *
 	 * The `MESSAGE_CONTENT` privileged gateway intent will become required after **August 31, 2022** for verified applications to receive a non-empty value from this field
 	 *
@@ -1382,7 +1382,7 @@ export interface APIEmbedField {
 }
 
 /**
- * https://discord.com/developers/docs/resources/channel#attachment-object-attachment-structure
+ * https://discord.com/developers/docs/resources/message#attachment-object-attachment-structure
  */
 export interface APIAttachment {
 	/**

--- a/rest/v10/channel.ts
+++ b/rest/v10/channel.ts
@@ -24,6 +24,7 @@ import type {
 	SortOrderType,
 	ForumLayoutType,
 	ChannelFlags,
+	APIAttachment,
 } from '../../payloads/v10/index';
 import type { AddUndefinedToPossiblyUndefinedPropertiesOfInterface, StrictPartial } from '../../utils/internals';
 import type { RESTAPIPoll } from './poll';
@@ -260,22 +261,16 @@ export type RESTAPIMessageReference = AddUndefinedToPossiblyUndefinedPropertiesO
 export type APIMessageReferenceSend = RESTAPIMessageReference;
 
 /**
- * https://discord.com/developers/docs/resources/channel#attachment-object
+ * https://discord.com/developers/docs/resources/message#attachment-object-attachment-structure
  */
-export interface RESTAPIAttachment {
+export type RESTAPIAttachment = Partial<
+	Pick<APIAttachment, 'description' | 'duration_secs' | 'filename' | 'title' | 'waveform'>
+> & {
 	/**
 	 * Attachment id or a number that matches `n` in `files[n]`
 	 */
 	id: Snowflake | number;
-	/**
-	 * Name of the file
-	 */
-	filename?: string | undefined;
-	/**
-	 * Description of the file
-	 */
-	description?: string | undefined;
-}
+};
 
 /**
  * https://discord.com/developers/docs/resources/channel#create-message
@@ -461,7 +456,7 @@ export interface RESTPatchAPIChannelMessageJSONBody {
 	 *
 	 * Starting with API v10, the `attachments` array must contain all attachments that should be present after edit, including **retained and new** attachments provided in the request body.
 	 *
-	 * See https://discord.com/developers/docs/resources/channel#attachment-object
+	 * See https://discord.com/developers/docs/resources/message#attachment-object-attachment-structure
 	 */
 	attachments?: RESTAPIAttachment[] | undefined;
 	/**

--- a/rest/v10/webhook.ts
+++ b/rest/v10/webhook.ts
@@ -264,7 +264,7 @@ export type RESTPatchAPIWebhookWithTokenMessageJSONBody = AddUndefinedToPossibly
 	 *
 	 * Starting with API v10, the `attachments` array must contain all attachments that should be present after edit, including **retained and new** attachments provided in the request body.
 	 *
-	 * See https://discord.com/developers/docs/resources/channel#attachment-object
+	 * See https://discord.com/developers/docs/resources/message#attachment-object-attachment-structure
 	 */
 	attachments?: RESTAPIAttachment[] | undefined;
 };

--- a/rest/v9/channel.ts
+++ b/rest/v9/channel.ts
@@ -24,6 +24,7 @@ import type {
 	SortOrderType,
 	ForumLayoutType,
 	ChannelFlags,
+	APIAttachment,
 } from '../../payloads/v9/index';
 import type { AddUndefinedToPossiblyUndefinedPropertiesOfInterface, StrictPartial } from '../../utils/internals';
 import type { RESTAPIPoll } from './poll';
@@ -260,22 +261,16 @@ export type RESTAPIMessageReference = AddUndefinedToPossiblyUndefinedPropertiesO
 export type APIMessageReferenceSend = RESTAPIMessageReference;
 
 /**
- * https://discord.com/developers/docs/resources/channel#attachment-object
+ * https://discord.com/developers/docs/resources/message#attachment-object-attachment-structure
  */
-export interface RESTAPIAttachment {
+export type RESTAPIAttachment = Partial<
+	Pick<APIAttachment, 'description' | 'duration_secs' | 'filename' | 'title' | 'waveform'>
+> & {
 	/**
 	 * Attachment id or a number that matches `n` in `files[n]`
 	 */
 	id: Snowflake | number;
-	/**
-	 * Name of the file
-	 */
-	filename?: string | undefined;
-	/**
-	 * Description of the file
-	 */
-	description?: string | undefined;
-}
+};
 
 /**
  * https://discord.com/developers/docs/resources/channel#create-message
@@ -477,7 +472,7 @@ export interface RESTPatchAPIChannelMessageJSONBody {
 	 *
 	 * Starting with API v10, the `attachments` array must contain all attachments that should be present after edit, including **retained and new** attachments provided in the request body.
 	 *
-	 * See https://discord.com/developers/docs/resources/channel#attachment-object
+	 * See https://discord.com/developers/docs/resources/message#attachment-object-attachment-structure
 	 */
 	attachments?: RESTAPIAttachment[] | undefined;
 	/**

--- a/rest/v9/webhook.ts
+++ b/rest/v9/webhook.ts
@@ -264,7 +264,7 @@ export type RESTPatchAPIWebhookWithTokenMessageJSONBody = AddUndefinedToPossibly
 	 *
 	 * Starting with API v10, the `attachments` array must contain all attachments that should be present after edit, including **retained and new** attachments provided in the request body.
 	 *
-	 * See https://discord.com/developers/docs/resources/channel#attachment-object
+	 * See https://discord.com/developers/docs/resources/message#attachment-object-attachment-structure
 	 */
 	attachments?: RESTAPIAttachment[] | undefined;
 };


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The documentation isn't clear about what fields can be sent when creating messages, so I checked the spec and added the missing fields

- <https://discord.com/developers/docs/resources/message#create-message-jsonform-params>

https://github.com/discord/discord-api-spec/blob/f31843808734a58e4c351fba6fd5768bb480b066/specs/openapi.json#L22778-L22831

Ignored `is_remix` since that field isn't documented at all

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
