### PR TITLE
docs: mark `APIApplication#summary` and `APISticker#asset` as unstable

### DIFF
--- a/deno/payloads/v10/application.ts
+++ b/deno/payloads/v10/application.ts
@@ -64,6 +64,7 @@ export interface APIApplication {
 	 * An empty string
 	 *
 	 * @deprecated This field will be removed in v11
+	 * @unstable This field is no longer documented by Discord and will be removed in v11
 	 */
 	summary: '';
 	/**

--- a/deno/payloads/v10/sticker.ts
+++ b/deno/payloads/v10/sticker.ts
@@ -33,6 +33,7 @@ export interface APISticker {
 	 * Previously the sticker asset hash, now an empty string
 	 *
 	 * @deprecated
+	 * @unstable This field is no longer documented by Discord and will be removed in v11
 	 */
 	asset?: '';
 	/**

--- a/deno/payloads/v9/application.ts
+++ b/deno/payloads/v9/application.ts
@@ -64,6 +64,7 @@ export interface APIApplication {
 	 * An empty string
 	 *
 	 * @deprecated This field will be removed in v11
+	 * @unstable This field is no longer documented by Discord and will be removed in v11
 	 */
 	summary: '';
 	/**

--- a/deno/payloads/v9/sticker.ts
+++ b/deno/payloads/v9/sticker.ts
@@ -33,6 +33,7 @@ export interface APISticker {
 	 * Previously the sticker asset hash, now an empty string
 	 *
 	 * @deprecated
+	 * @unstable This field is no longer documented by Discord and will be removed in v11
 	 */
 	asset?: '';
 	/**

--- a/payloads/v10/application.ts
+++ b/payloads/v10/application.ts
@@ -64,6 +64,7 @@ export interface APIApplication {
 	 * An empty string
 	 *
 	 * @deprecated This field will be removed in v11
+	 * @unstable This field is no longer documented by Discord and will be removed in v11
 	 */
 	summary: '';
 	/**

--- a/payloads/v10/sticker.ts
+++ b/payloads/v10/sticker.ts
@@ -33,6 +33,7 @@ export interface APISticker {
 	 * Previously the sticker asset hash, now an empty string
 	 *
 	 * @deprecated
+	 * @unstable This field is no longer documented by Discord and will be removed in v11
 	 */
 	asset?: '';
 	/**

--- a/payloads/v9/application.ts
+++ b/payloads/v9/application.ts
@@ -64,6 +64,7 @@ export interface APIApplication {
 	 * An empty string
 	 *
 	 * @deprecated This field will be removed in v11
+	 * @unstable This field is no longer documented by Discord and will be removed in v11
 	 */
 	summary: '';
 	/**

--- a/payloads/v9/sticker.ts
+++ b/payloads/v9/sticker.ts
@@ -33,6 +33,7 @@ export interface APISticker {
 	 * Previously the sticker asset hash, now an empty string
 	 *
 	 * @deprecated
+	 * @unstable This field is no longer documented by Discord and will be removed in v11
 	 */
 	asset?: '';
 	/**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**

- https://github.com/discord/discord-api-docs/pull/7114