### PR TITLE
fix(APIMessageSnapshot): mark `guild_id` as deprecated

### DIFF
--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -1916,6 +1916,13 @@ export interface APIMessageSnapshot {
 	message: APIMessageSnapshotFields;
 	/**
 	 * Id of the origin message's guild
+	 *
+	 * @deprecated This field doesn't accurately reflect the Discord API as it doesn't exist nor is documented and will
+	 * be removed in the next major version.
+	 *
+	 * It was added in {@link https://github.com/discord/discord-api-docs/pull/6833/commits/d18f72d06d62e6b1d51ca2c1ef308ddc29ff3348 | d18f72d}
+	 * but was later removed before the PR ({@link https://github.com/discord/discord-api-docs/pull/6833 | discord-api-docs#6833}) was merged.
+	 * See {@link https://github.com/discordjs/discord-api-types/pull/1084 | discord-api-types#1084} for more information.
 	 */
 	guild_id?: Snowflake;
 }

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -1883,6 +1883,13 @@ export interface APIMessageSnapshot {
 	message: APIMessageSnapshotFields;
 	/**
 	 * Id of the origin message's guild
+	 *
+	 * @deprecated This field doesn't accurately reflect the Discord API as it doesn't exist nor is documented and will
+	 * be removed in the next major version.
+	 *
+	 * It was added in {@link https://github.com/discord/discord-api-docs/pull/6833/commits/d18f72d06d62e6b1d51ca2c1ef308ddc29ff3348 | d18f72d}
+	 * but was later removed before the PR ({@link https://github.com/discord/discord-api-docs/pull/6833 | discord-api-docs#6833}) was merged.
+	 * See {@link https://github.com/discordjs/discord-api-types/pull/1084 | discord-api-types#1084} for more information.
 	 */
 	guild_id?: Snowflake;
 }

--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -1916,6 +1916,13 @@ export interface APIMessageSnapshot {
 	message: APIMessageSnapshotFields;
 	/**
 	 * Id of the origin message's guild
+	 *
+	 * @deprecated This field doesn't accurately reflect the Discord API as it doesn't exist nor is documented and will
+	 * be removed in the next major version.
+	 *
+	 * It was added in {@link https://github.com/discord/discord-api-docs/pull/6833/commits/d18f72d06d62e6b1d51ca2c1ef308ddc29ff3348 | d18f72d}
+	 * but was later removed before the PR ({@link https://github.com/discord/discord-api-docs/pull/6833 | discord-api-docs#6833}) was merged.
+	 * See {@link https://github.com/discordjs/discord-api-types/pull/1084 | discord-api-types#1084} for more information.
 	 */
 	guild_id?: Snowflake;
 }

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -1883,6 +1883,13 @@ export interface APIMessageSnapshot {
 	message: APIMessageSnapshotFields;
 	/**
 	 * Id of the origin message's guild
+	 *
+	 * @deprecated This field doesn't accurately reflect the Discord API as it doesn't exist nor is documented and will
+	 * be removed in the next major version.
+	 *
+	 * It was added in {@link https://github.com/discord/discord-api-docs/pull/6833/commits/d18f72d06d62e6b1d51ca2c1ef308ddc29ff3348 | d18f72d}
+	 * but was later removed before the PR ({@link https://github.com/discord/discord-api-docs/pull/6833 | discord-api-docs#6833}) was merged.
+	 * See {@link https://github.com/discordjs/discord-api-types/pull/1084 | discord-api-types#1084} for more information.
 	 */
 	guild_id?: Snowflake;
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This field was in the initial commits of Discord API Docs PR but was later removed before the PR being merged

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**

- https://github.com/discord/discord-api-docs/pull/6833
- https://github.com/discordjs/discord-api-types/pull/971