### PR TITLE
fix: replace deprecated `RESTAPIPollCreate` with `RESTAPIPoll`

### DIFF
--- a/deno/rest/v10/webhook.ts
+++ b/deno/rest/v10/webhook.ts
@@ -273,7 +273,7 @@ export type RESTPatchAPIWebhookWithTokenMessageJSONBody = AddUndefinedToPossibly
 	 * @remarks
 	 * Polls can only be added when editing a deferred interaction response.
 	 */
-	poll?: RESTAPIPollCreate | undefined;
+	poll?: RESTAPIPoll | undefined;
 };
 
 /**

--- a/deno/rest/v9/webhook.ts
+++ b/deno/rest/v9/webhook.ts
@@ -273,7 +273,7 @@ export type RESTPatchAPIWebhookWithTokenMessageJSONBody = AddUndefinedToPossibly
 	 * @remarks
 	 * Polls can only be added when editing a deferred interaction response.
 	 */
-	poll?: RESTAPIPollCreate | undefined;
+	poll?: RESTAPIPoll | undefined;
 };
 
 /**

--- a/rest/v10/webhook.ts
+++ b/rest/v10/webhook.ts
@@ -273,7 +273,7 @@ export type RESTPatchAPIWebhookWithTokenMessageJSONBody = AddUndefinedToPossibly
 	 * @remarks
 	 * Polls can only be added when editing a deferred interaction response.
 	 */
-	poll?: RESTAPIPollCreate | undefined;
+	poll?: RESTAPIPoll | undefined;
 };
 
 /**

--- a/rest/v9/webhook.ts
+++ b/rest/v9/webhook.ts
@@ -273,7 +273,7 @@ export type RESTPatchAPIWebhookWithTokenMessageJSONBody = AddUndefinedToPossibly
 	 * @remarks
 	 * Polls can only be added when editing a deferred interaction response.
 	 */
-	poll?: RESTAPIPollCreate | undefined;
+	poll?: RESTAPIPoll | undefined;
 };
 
 /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Replaces the deprecated `RESTAPIPollCreate` with `RESTAPIPoll` after #1065. Stops the CI tests from failing

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
