### PR TITLE
fix(rest/oauth2): correct string literal types containing bot scope

### DIFF
--- a/deno/rest/v10/oauth2.ts
+++ b/deno/rest/v10/oauth2.ts
@@ -134,10 +134,10 @@ export interface RESTOAuth2BotAuthorizationQuery {
 	 * Needs to include bot for the bot flow
 	 */
 	scope:
-		| OAuth2Scopes.Bot
-		| `${OAuth2Scopes.Bot}${' ' | '%20'}${string}`
-		| `${string}${' ' | '%20'}${OAuth2Scopes.Bot}`
-		| `${string}${' ' | '%20'}${OAuth2Scopes.Bot}${string}${' ' | '%20'}`;
+		| `${OAuth2Scopes.Bot} ${string}`
+		| `${OAuth2Scopes.Bot}`
+		| `${string} ${OAuth2Scopes.Bot} ${string}`
+		| `${string} ${OAuth2Scopes.Bot}`;
 	/**
 	 * The permissions you're requesting
 	 *
@@ -163,10 +163,10 @@ export interface RESTOAuth2AdvancedBotAuthorizationQuery {
 	 * This assumes you include the `bot` scope alongside others (like `identify` for example)
 	 */
 	scope:
-		| OAuth2Scopes.Bot
-		| `${OAuth2Scopes.Bot}${' ' | '%20'}${string}`
-		| `${string}${' ' | '%20'}${OAuth2Scopes.Bot}`
-		| `${string}${' ' | '%20'}${OAuth2Scopes.Bot}${string}${' ' | '%20'}`;
+		| `${OAuth2Scopes.Bot} ${string}`
+		| `${OAuth2Scopes.Bot}`
+		| `${string} ${OAuth2Scopes.Bot} ${string}`
+		| `${string} ${OAuth2Scopes.Bot}`;
 	/**
 	 * The required permissions bitfield, stringified
 	 */

--- a/deno/rest/v9/oauth2.ts
+++ b/deno/rest/v9/oauth2.ts
@@ -134,10 +134,10 @@ export interface RESTOAuth2BotAuthorizationQuery {
 	 * Needs to include bot for the bot flow
 	 */
 	scope:
-		| OAuth2Scopes.Bot
-		| `${OAuth2Scopes.Bot}${' ' | '%20'}${string}`
-		| `${string}${' ' | '%20'}${OAuth2Scopes.Bot}`
-		| `${string}${' ' | '%20'}${OAuth2Scopes.Bot}${string}${' ' | '%20'}`;
+		| `${OAuth2Scopes.Bot} ${string}`
+		| `${OAuth2Scopes.Bot}`
+		| `${string} ${OAuth2Scopes.Bot} ${string}`
+		| `${string} ${OAuth2Scopes.Bot}`;
 	/**
 	 * The permissions you're requesting
 	 *
@@ -163,10 +163,10 @@ export interface RESTOAuth2AdvancedBotAuthorizationQuery {
 	 * This assumes you include the `bot` scope alongside others (like `identify` for example)
 	 */
 	scope:
-		| OAuth2Scopes.Bot
-		| `${OAuth2Scopes.Bot}${' ' | '%20'}${string}`
-		| `${string}${' ' | '%20'}${OAuth2Scopes.Bot}`
-		| `${string}${' ' | '%20'}${OAuth2Scopes.Bot}${string}${' ' | '%20'}`;
+		| `${OAuth2Scopes.Bot} ${string}`
+		| `${OAuth2Scopes.Bot}`
+		| `${string} ${OAuth2Scopes.Bot} ${string}`
+		| `${string} ${OAuth2Scopes.Bot}`;
 	/**
 	 * The required permissions bitfield, stringified
 	 */

--- a/rest/v10/oauth2.ts
+++ b/rest/v10/oauth2.ts
@@ -134,10 +134,10 @@ export interface RESTOAuth2BotAuthorizationQuery {
 	 * Needs to include bot for the bot flow
 	 */
 	scope:
-		| OAuth2Scopes.Bot
-		| `${OAuth2Scopes.Bot}${' ' | '%20'}${string}`
-		| `${string}${' ' | '%20'}${OAuth2Scopes.Bot}`
-		| `${string}${' ' | '%20'}${OAuth2Scopes.Bot}${string}${' ' | '%20'}`;
+		| `${OAuth2Scopes.Bot} ${string}`
+		| `${OAuth2Scopes.Bot}`
+		| `${string} ${OAuth2Scopes.Bot} ${string}`
+		| `${string} ${OAuth2Scopes.Bot}`;
 	/**
 	 * The permissions you're requesting
 	 *
@@ -163,10 +163,10 @@ export interface RESTOAuth2AdvancedBotAuthorizationQuery {
 	 * This assumes you include the `bot` scope alongside others (like `identify` for example)
 	 */
 	scope:
-		| OAuth2Scopes.Bot
-		| `${OAuth2Scopes.Bot}${' ' | '%20'}${string}`
-		| `${string}${' ' | '%20'}${OAuth2Scopes.Bot}`
-		| `${string}${' ' | '%20'}${OAuth2Scopes.Bot}${string}${' ' | '%20'}`;
+		| `${OAuth2Scopes.Bot} ${string}`
+		| `${OAuth2Scopes.Bot}`
+		| `${string} ${OAuth2Scopes.Bot} ${string}`
+		| `${string} ${OAuth2Scopes.Bot}`;
 	/**
 	 * The required permissions bitfield, stringified
 	 */

--- a/rest/v9/oauth2.ts
+++ b/rest/v9/oauth2.ts
@@ -134,10 +134,10 @@ export interface RESTOAuth2BotAuthorizationQuery {
 	 * Needs to include bot for the bot flow
 	 */
 	scope:
-		| OAuth2Scopes.Bot
-		| `${OAuth2Scopes.Bot}${' ' | '%20'}${string}`
-		| `${string}${' ' | '%20'}${OAuth2Scopes.Bot}`
-		| `${string}${' ' | '%20'}${OAuth2Scopes.Bot}${string}${' ' | '%20'}`;
+		| `${OAuth2Scopes.Bot} ${string}`
+		| `${OAuth2Scopes.Bot}`
+		| `${string} ${OAuth2Scopes.Bot} ${string}`
+		| `${string} ${OAuth2Scopes.Bot}`;
 	/**
 	 * The permissions you're requesting
 	 *
@@ -163,10 +163,10 @@ export interface RESTOAuth2AdvancedBotAuthorizationQuery {
 	 * This assumes you include the `bot` scope alongside others (like `identify` for example)
 	 */
 	scope:
-		| OAuth2Scopes.Bot
-		| `${OAuth2Scopes.Bot}${' ' | '%20'}${string}`
-		| `${string}${' ' | '%20'}${OAuth2Scopes.Bot}`
-		| `${string}${' ' | '%20'}${OAuth2Scopes.Bot}${string}${' ' | '%20'}`;
+		| `${OAuth2Scopes.Bot} ${string}`
+		| `${OAuth2Scopes.Bot}`
+		| `${string} ${OAuth2Scopes.Bot} ${string}`
+		| `${string} ${OAuth2Scopes.Bot}`;
 	/**
 	 * The required permissions bitfield, stringified
 	 */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Minor fixes for the `scope` property type unions within the bot-specific query interfaces in rest/oauth2:
- Wrap the bare case (`OAuth2Scopes.Bot`) in a template literal, so that passing `scope: "bot"` is valid and doesn't raise a compilation error.
- No longer consider `%20` a valid space. For the parameters to exist in object form, they are by definition not yet URL-encoded, and passing a property like `scope: "bot%20identify"` to URLSearchParams would just re-encode the percent sign, resulting in an invalid OAuth2 query.
- Fix the order of the "sandwich" case (`"activities.read bot identify"`). Previously, this string would raise a compilation error, due to the misplaced final space in the template literal type.
