### PR TITLE
feat: audit log change key for boost bar

### DIFF
--- a/deno/payloads/v10/auditLog.ts
+++ b/deno/payloads/v10/auditLog.ts
@@ -405,6 +405,7 @@ export type APIAuditLogChange =
 	| APIAuditLogChangeKeyPermissions
 	| APIAuditLogChangeKeyPosition
 	| APIAuditLogChangeKeyPreferredLocale
+	| APIAuditLogChangeKeyPremiumProgressBarEnabled
 	| APIAuditLogChangeKeyPrivacyLevel
 	| APIAuditLogChangeKeyPruneDeleteDays
 	| APIAuditLogChangeKeyPublicUpdatesChannelId
@@ -534,6 +535,11 @@ export type APIAuditLogChangeKeyDefaultMessageNotifications = AuditLogChangeData
  * Returned when a guild's vanity_url_code is changed
  */
 export type APIAuditLogChangeKeyVanityURLCode = AuditLogChangeData<'vanity_url_code', string>;
+
+/**
+ * Returned when a guild's boost progress bar is enabled
+ */
+export type APIAuditLogChangeKeyPremiumProgressBarEnabled = AuditLogChangeData<'premium_progress_bar_enabled', boolean>;
 
 /**
  * Returned when new role(s) are added

--- a/deno/payloads/v9/auditLog.ts
+++ b/deno/payloads/v9/auditLog.ts
@@ -405,6 +405,7 @@ export type APIAuditLogChange =
 	| APIAuditLogChangeKeyPermissions
 	| APIAuditLogChangeKeyPosition
 	| APIAuditLogChangeKeyPreferredLocale
+	| APIAuditLogChangeKeyPremiumProgressBarEnabled
 	| APIAuditLogChangeKeyPrivacyLevel
 	| APIAuditLogChangeKeyPruneDeleteDays
 	| APIAuditLogChangeKeyPublicUpdatesChannelId
@@ -534,6 +535,11 @@ export type APIAuditLogChangeKeyDefaultMessageNotifications = AuditLogChangeData
  * Returned when a guild's vanity_url_code is changed
  */
 export type APIAuditLogChangeKeyVanityURLCode = AuditLogChangeData<'vanity_url_code', string>;
+
+/**
+ * Returned when a guild's boost progress bar is enabled
+ */
+export type APIAuditLogChangeKeyPremiumProgressBarEnabled = AuditLogChangeData<'premium_progress_bar_enabled', boolean>;
 
 /**
  * Returned when new role(s) are added

--- a/payloads/v10/auditLog.ts
+++ b/payloads/v10/auditLog.ts
@@ -405,6 +405,7 @@ export type APIAuditLogChange =
 	| APIAuditLogChangeKeyPermissions
 	| APIAuditLogChangeKeyPosition
 	| APIAuditLogChangeKeyPreferredLocale
+	| APIAuditLogChangeKeyPremiumProgressBarEnabled
 	| APIAuditLogChangeKeyPrivacyLevel
 	| APIAuditLogChangeKeyPruneDeleteDays
 	| APIAuditLogChangeKeyPublicUpdatesChannelId
@@ -534,6 +535,11 @@ export type APIAuditLogChangeKeyDefaultMessageNotifications = AuditLogChangeData
  * Returned when a guild's vanity_url_code is changed
  */
 export type APIAuditLogChangeKeyVanityURLCode = AuditLogChangeData<'vanity_url_code', string>;
+
+/**
+ * Returned when a guild's boost progress bar is enabled
+ */
+export type APIAuditLogChangeKeyPremiumProgressBarEnabled = AuditLogChangeData<'premium_progress_bar_enabled', boolean>;
 
 /**
  * Returned when new role(s) are added

--- a/payloads/v9/auditLog.ts
+++ b/payloads/v9/auditLog.ts
@@ -405,6 +405,7 @@ export type APIAuditLogChange =
 	| APIAuditLogChangeKeyPermissions
 	| APIAuditLogChangeKeyPosition
 	| APIAuditLogChangeKeyPreferredLocale
+	| APIAuditLogChangeKeyPremiumProgressBarEnabled
 	| APIAuditLogChangeKeyPrivacyLevel
 	| APIAuditLogChangeKeyPruneDeleteDays
 	| APIAuditLogChangeKeyPublicUpdatesChannelId
@@ -534,6 +535,11 @@ export type APIAuditLogChangeKeyDefaultMessageNotifications = AuditLogChangeData
  * Returned when a guild's vanity_url_code is changed
  */
 export type APIAuditLogChangeKeyVanityURLCode = AuditLogChangeData<'vanity_url_code', string>;
+
+/**
+ * Returned when a guild's boost progress bar is enabled
+ */
+export type APIAuditLogChangeKeyPremiumProgressBarEnabled = AuditLogChangeData<'premium_progress_bar_enabled', boolean>;
 
 /**
  * Returned when new role(s) are added


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Includes the `premium_progress_bar_enabled` key for the Audit Log Change object

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
_None_

Completes #1119 
