### PR TITLE
fix(isInteractionButton): handle `ButtonStyle.Premium`

### DIFF
--- a/deno/utils/v10.ts
+++ b/deno/utils/v10.ts
@@ -111,7 +111,7 @@ export function isLinkButton(component: APIButtonComponent): component is APIBut
  * @returns A boolean that indicates if the button has a `custom_id` attached to it
  */
 export function isInteractionButton(component: APIButtonComponent): component is APIButtonComponentWithCustomId {
-	return component.style !== ButtonStyle.Link;
+	return ![ButtonStyle.Link, ButtonStyle.Premium].includes(component.style);
 }
 
 // Message Components

--- a/deno/utils/v9.ts
+++ b/deno/utils/v9.ts
@@ -111,7 +111,7 @@ export function isLinkButton(component: APIButtonComponent): component is APIBut
  * @returns A boolean that indicates if the button has a `custom_id` attached to it
  */
 export function isInteractionButton(component: APIButtonComponent): component is APIButtonComponentWithCustomId {
-	return component.style !== ButtonStyle.Link;
+	return ![ButtonStyle.Link, ButtonStyle.Premium].includes(component.style);
 }
 
 // Message Components

--- a/utils/v10.ts
+++ b/utils/v10.ts
@@ -111,7 +111,7 @@ export function isLinkButton(component: APIButtonComponent): component is APIBut
  * @returns A boolean that indicates if the button has a `custom_id` attached to it
  */
 export function isInteractionButton(component: APIButtonComponent): component is APIButtonComponentWithCustomId {
-	return component.style !== ButtonStyle.Link;
+	return ![ButtonStyle.Link, ButtonStyle.Premium].includes(component.style);
 }
 
 // Message Components

--- a/utils/v9.ts
+++ b/utils/v9.ts
@@ -111,7 +111,7 @@ export function isLinkButton(component: APIButtonComponent): component is APIBut
  * @returns A boolean that indicates if the button has a `custom_id` attached to it
  */
 export function isInteractionButton(component: APIButtonComponent): component is APIButtonComponentWithCustomId {
-	return component.style !== ButtonStyle.Link;
+	return ![ButtonStyle.Link, ButtonStyle.Premium].includes(component.style);
 }
 
 // Message Components


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
It was addressed internally [here](https://canary.discord.com/channels/222078108977594368/1209960895141388389/1303096590772211884). Fixes `isInteractionButton` to check for `ButtonStyle.Premium`

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
- https://github.com/discord/discord-api-docs/pull/6875