### PR TITLE
refactor: Deprecate `LocaleString`

### DIFF
--- a/deno/payloads/common.ts
+++ b/deno/payloads/common.ts
@@ -1,4 +1,4 @@
-import type { LocaleString } from '../rest/common.ts';
+import type { Locale } from '../rest/common.ts';
 
 /**
  * https://discord.com/developers/docs/topics/permissions#permissions-bitwise-permission-flags
@@ -297,7 +297,7 @@ export const PermissionFlagsBits = {
  */
 Object.freeze(PermissionFlagsBits);
 
-export type LocalizationMap = Partial<Record<LocaleString, string | null>>;
+export type LocalizationMap = Partial<Record<Locale, string | null>>;
 
 /**
  * https://discord.com/developers/docs/topics/opcodes-and-status-codes#json

--- a/deno/payloads/v10/_interactions/base.ts
+++ b/deno/payloads/v10/_interactions/base.ts
@@ -1,5 +1,5 @@
 import type { Permissions, Snowflake } from '../../../globals.ts';
-import type { APIRole, ApplicationIntegrationType, InteractionContextType, LocaleString } from '../../../v10.ts';
+import type { APIRole, ApplicationIntegrationType, InteractionContextType, Locale } from '../../../v10.ts';
 import type {
 	APIAttachment,
 	APIChannel,
@@ -160,11 +160,11 @@ export interface APIBaseInteraction<Type extends InteractionType, Data> {
 	/**
 	 * The selected language of the invoking user
 	 */
-	locale: LocaleString;
+	locale: Locale;
 	/**
 	 * The guild's preferred locale, if invoked in a guild
 	 */
-	guild_locale?: LocaleString;
+	guild_locale?: Locale;
 	/**
 	 * For monetized apps, any entitlements for the invoking user, representing access to premium SKUs
 	 */

--- a/deno/payloads/v10/guild.ts
+++ b/deno/payloads/v10/guild.ts
@@ -3,6 +3,7 @@
  */
 
 import type { Permissions, Snowflake } from '../../globals.ts';
+import type { Locale } from '../../rest/common.ts';
 import type { APIEmoji, APIPartialEmoji } from './emoji.ts';
 import type { PresenceUpdateReceiveStatus } from './gateway.ts';
 import type { OAuth2Scopes } from './oauth2.ts';
@@ -227,7 +228,7 @@ export interface APIGuild extends APIPartialGuild {
 	 *
 	 * @default "en-US"
 	 */
-	preferred_locale: string;
+	preferred_locale: Locale;
 	/**
 	 * The id of the channel where admins and moderators of Community guilds receive notices from Discord
 	 */

--- a/deno/payloads/v10/template.ts
+++ b/deno/payloads/v10/template.ts
@@ -3,6 +3,7 @@
  */
 
 import type { Snowflake } from '../../globals.ts';
+import type { Locale } from '../../rest/common.ts';
 import type { RESTPostAPIGuildsJSONBody } from '../../rest/v10/mod.ts';
 import type { APIUser } from './user.ts';
 
@@ -60,6 +61,6 @@ export interface APITemplate {
 
 export interface APITemplateSerializedSourceGuild extends Omit<RESTPostAPIGuildsJSONBody, 'icon'> {
 	description: string | null;
-	preferred_locale: string;
+	preferred_locale: Locale;
 	icon_hash: string | null;
 }

--- a/deno/payloads/v9/_interactions/base.ts
+++ b/deno/payloads/v9/_interactions/base.ts
@@ -1,5 +1,5 @@
 import type { Permissions, Snowflake } from '../../../globals.ts';
-import type { APIRole, ApplicationIntegrationType, InteractionContextType, LocaleString } from '../../../v9.ts';
+import type { APIRole, ApplicationIntegrationType, InteractionContextType, Locale } from '../../../v9.ts';
 import type {
 	APIAttachment,
 	APIChannel,
@@ -160,11 +160,11 @@ export interface APIBaseInteraction<Type extends InteractionType, Data> {
 	/**
 	 * The selected language of the invoking user
 	 */
-	locale: LocaleString;
+	locale: Locale;
 	/**
 	 * The guild's preferred locale, if invoked in a guild
 	 */
-	guild_locale?: LocaleString;
+	guild_locale?: Locale;
 	/**
 	 * For monetized apps, any entitlements for the invoking user, representing access to premium SKUs
 	 */

--- a/deno/payloads/v9/guild.ts
+++ b/deno/payloads/v9/guild.ts
@@ -3,6 +3,7 @@
  */
 
 import type { Permissions, Snowflake } from '../../globals.ts';
+import type { Locale } from '../../rest/common.ts';
 import type { APIEmoji, APIPartialEmoji } from './emoji.ts';
 import type { PresenceUpdateReceiveStatus } from './gateway.ts';
 import type { OAuth2Scopes } from './oauth2.ts';
@@ -227,7 +228,7 @@ export interface APIGuild extends APIPartialGuild {
 	 *
 	 * @default "en-US"
 	 */
-	preferred_locale: string;
+	preferred_locale: Locale;
 	/**
 	 * The id of the channel where admins and moderators of Community guilds receive notices from Discord
 	 */

--- a/deno/payloads/v9/template.ts
+++ b/deno/payloads/v9/template.ts
@@ -3,6 +3,7 @@
  */
 
 import type { Snowflake } from '../../globals.ts';
+import type { Locale } from '../../rest/common.ts';
 import type { RESTPostAPIGuildsJSONBody } from '../../rest/v9/mod.ts';
 import type { APIUser } from './user.ts';
 
@@ -60,6 +61,6 @@ export interface APITemplate {
 
 export interface APITemplateSerializedSourceGuild extends Omit<RESTPostAPIGuildsJSONBody, 'icon'> {
 	description: string | null;
-	preferred_locale: string;
+	preferred_locale: Locale;
 	icon_hash: string | null;
 }

--- a/deno/rest/common.ts
+++ b/deno/rest/common.ts
@@ -362,4 +362,7 @@ export enum Locale {
 	Vietnamese = 'vi',
 }
 
+/**
+ * @deprecated Use {@apilink Locale} instead.
+ */
 export type LocaleString = `${Locale}`;

--- a/deno/rest/v10/guild.ts
+++ b/deno/rest/v10/guild.ts
@@ -35,6 +35,7 @@ import type {
 	StrictPartial,
 	StrictRequired,
 } from '../../utils/internals.ts';
+import type { Locale } from '../common.ts';
 import type { RESTPutAPIChannelPermissionJSONBody } from './channel.ts';
 
 export interface RESTAPIGuildCreateOverwrite extends RESTPutAPIChannelPermissionJSONBody {
@@ -315,7 +316,7 @@ export interface RESTPatchAPIGuildJSONBody {
 	 *
 	 * @default "en-US" (if the value is set to `null`)
 	 */
-	preferred_locale?: string | null | undefined;
+	preferred_locale?: Locale | null | undefined;
 	/**
 	 * Enabled guild features
 	 *

--- a/deno/rest/v9/guild.ts
+++ b/deno/rest/v9/guild.ts
@@ -35,6 +35,7 @@ import type {
 	StrictPartial,
 	StrictRequired,
 } from '../../utils/internals.ts';
+import type { Locale } from '../common.ts';
 import type { RESTPutAPIChannelPermissionJSONBody } from './channel.ts';
 
 export interface RESTAPIGuildCreateOverwrite extends RESTPutAPIChannelPermissionJSONBody {
@@ -315,7 +316,7 @@ export interface RESTPatchAPIGuildJSONBody {
 	 *
 	 * @default "en-US" (if the value is set to `null`)
 	 */
-	preferred_locale?: string | null | undefined;
+	preferred_locale?: Locale | null | undefined;
 	/**
 	 * Enabled guild features
 	 *

--- a/payloads/common.ts
+++ b/payloads/common.ts
@@ -1,4 +1,4 @@
-import type { LocaleString } from '../rest/common';
+import type { Locale } from '../rest/common';
 
 /**
  * https://discord.com/developers/docs/topics/permissions#permissions-bitwise-permission-flags
@@ -297,7 +297,7 @@ export const PermissionFlagsBits = {
  */
 Object.freeze(PermissionFlagsBits);
 
-export type LocalizationMap = Partial<Record<LocaleString, string | null>>;
+export type LocalizationMap = Partial<Record<Locale, string | null>>;
 
 /**
  * https://discord.com/developers/docs/topics/opcodes-and-status-codes#json

--- a/payloads/v10/_interactions/base.ts
+++ b/payloads/v10/_interactions/base.ts
@@ -1,5 +1,5 @@
 import type { Permissions, Snowflake } from '../../../globals';
-import type { APIRole, ApplicationIntegrationType, InteractionContextType, LocaleString } from '../../../v10';
+import type { APIRole, ApplicationIntegrationType, InteractionContextType, Locale } from '../../../v10';
 import type {
 	APIAttachment,
 	APIChannel,
@@ -160,11 +160,11 @@ export interface APIBaseInteraction<Type extends InteractionType, Data> {
 	/**
 	 * The selected language of the invoking user
 	 */
-	locale: LocaleString;
+	locale: Locale;
 	/**
 	 * The guild's preferred locale, if invoked in a guild
 	 */
-	guild_locale?: LocaleString;
+	guild_locale?: Locale;
 	/**
 	 * For monetized apps, any entitlements for the invoking user, representing access to premium SKUs
 	 */

--- a/payloads/v10/guild.ts
+++ b/payloads/v10/guild.ts
@@ -3,6 +3,7 @@
  */
 
 import type { Permissions, Snowflake } from '../../globals';
+import type { Locale } from '../../rest/common';
 import type { APIEmoji, APIPartialEmoji } from './emoji';
 import type { PresenceUpdateReceiveStatus } from './gateway';
 import type { OAuth2Scopes } from './oauth2';
@@ -227,7 +228,7 @@ export interface APIGuild extends APIPartialGuild {
 	 *
 	 * @default "en-US"
 	 */
-	preferred_locale: string;
+	preferred_locale: Locale;
 	/**
 	 * The id of the channel where admins and moderators of Community guilds receive notices from Discord
 	 */

--- a/payloads/v10/template.ts
+++ b/payloads/v10/template.ts
@@ -3,6 +3,7 @@
  */
 
 import type { Snowflake } from '../../globals';
+import type { Locale } from '../../rest/common';
 import type { RESTPostAPIGuildsJSONBody } from '../../rest/v10/index';
 import type { APIUser } from './user';
 
@@ -60,6 +61,6 @@ export interface APITemplate {
 
 export interface APITemplateSerializedSourceGuild extends Omit<RESTPostAPIGuildsJSONBody, 'icon'> {
 	description: string | null;
-	preferred_locale: string;
+	preferred_locale: Locale;
 	icon_hash: string | null;
 }

--- a/payloads/v9/_interactions/base.ts
+++ b/payloads/v9/_interactions/base.ts
@@ -1,5 +1,5 @@
 import type { Permissions, Snowflake } from '../../../globals';
-import type { APIRole, ApplicationIntegrationType, InteractionContextType, LocaleString } from '../../../v9';
+import type { APIRole, ApplicationIntegrationType, InteractionContextType, Locale } from '../../../v9';
 import type {
 	APIAttachment,
 	APIChannel,
@@ -160,11 +160,11 @@ export interface APIBaseInteraction<Type extends InteractionType, Data> {
 	/**
 	 * The selected language of the invoking user
 	 */
-	locale: LocaleString;
+	locale: Locale;
 	/**
 	 * The guild's preferred locale, if invoked in a guild
 	 */
-	guild_locale?: LocaleString;
+	guild_locale?: Locale;
 	/**
 	 * For monetized apps, any entitlements for the invoking user, representing access to premium SKUs
 	 */

--- a/payloads/v9/guild.ts
+++ b/payloads/v9/guild.ts
@@ -3,6 +3,7 @@
  */
 
 import type { Permissions, Snowflake } from '../../globals';
+import type { Locale } from '../../rest/common';
 import type { APIEmoji, APIPartialEmoji } from './emoji';
 import type { PresenceUpdateReceiveStatus } from './gateway';
 import type { OAuth2Scopes } from './oauth2';
@@ -227,7 +228,7 @@ export interface APIGuild extends APIPartialGuild {
 	 *
 	 * @default "en-US"
 	 */
-	preferred_locale: string;
+	preferred_locale: Locale;
 	/**
 	 * The id of the channel where admins and moderators of Community guilds receive notices from Discord
 	 */

--- a/payloads/v9/template.ts
+++ b/payloads/v9/template.ts
@@ -3,6 +3,7 @@
  */
 
 import type { Snowflake } from '../../globals';
+import type { Locale } from '../../rest/common';
 import type { RESTPostAPIGuildsJSONBody } from '../../rest/v9/index';
 import type { APIUser } from './user';
 
@@ -60,6 +61,6 @@ export interface APITemplate {
 
 export interface APITemplateSerializedSourceGuild extends Omit<RESTPostAPIGuildsJSONBody, 'icon'> {
 	description: string | null;
-	preferred_locale: string;
+	preferred_locale: Locale;
 	icon_hash: string | null;
 }

--- a/rest/common.ts
+++ b/rest/common.ts
@@ -362,4 +362,7 @@ export enum Locale {
 	Vietnamese = 'vi',
 }
 
+/**
+ * @deprecated Use {@apilink Locale} instead.
+ */
 export type LocaleString = `${Locale}`;

--- a/rest/v10/guild.ts
+++ b/rest/v10/guild.ts
@@ -35,6 +35,7 @@ import type {
 	StrictPartial,
 	StrictRequired,
 } from '../../utils/internals';
+import type { Locale } from '../common';
 import type { RESTPutAPIChannelPermissionJSONBody } from './channel';
 
 export interface RESTAPIGuildCreateOverwrite extends RESTPutAPIChannelPermissionJSONBody {
@@ -315,7 +316,7 @@ export interface RESTPatchAPIGuildJSONBody {
 	 *
 	 * @default "en-US" (if the value is set to `null`)
 	 */
-	preferred_locale?: string | null | undefined;
+	preferred_locale?: Locale | null | undefined;
 	/**
 	 * Enabled guild features
 	 *

--- a/rest/v9/guild.ts
+++ b/rest/v9/guild.ts
@@ -35,6 +35,7 @@ import type {
 	StrictPartial,
 	StrictRequired,
 } from '../../utils/internals';
+import type { Locale } from '../common';
 import type { RESTPutAPIChannelPermissionJSONBody } from './channel';
 
 export interface RESTAPIGuildCreateOverwrite extends RESTPutAPIChannelPermissionJSONBody {
@@ -315,7 +316,7 @@ export interface RESTPatchAPIGuildJSONBody {
 	 *
 	 * @default "en-US" (if the value is set to `null`)
 	 */
-	preferred_locale?: string | null | undefined;
+	preferred_locale?: Locale | null | undefined;
 	/**
 	 * Enabled guild features
 	 *


### PR DESCRIPTION
Deprecates `LocaleString` (to use `Locale` instead).