### PR TITLE
docs(RESTPostAPIChannelMessageJSONBody): Make message reference generic

### DIFF
--- a/deno/rest/v10/channel.ts
+++ b/deno/rest/v10/channel.ts
@@ -301,7 +301,7 @@ export interface RESTPostAPIChannelMessageJSONBody {
 	 */
 	allowed_mentions?: APIAllowedMentions | undefined;
 	/**
-	 * Include to make your message a reply
+	 * Include to reference another message (reply, forward, etc.)
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#message-reference-object-message-reference-structure
 	 */

--- a/deno/rest/v10/channel.ts
+++ b/deno/rest/v10/channel.ts
@@ -301,7 +301,7 @@ export interface RESTPostAPIChannelMessageJSONBody {
 	 */
 	allowed_mentions?: APIAllowedMentions | undefined;
 	/**
-	 * Include to reference another message (reply, forward, etc.)
+	 * Include to make your message a reply or a forward
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#message-reference-object-message-reference-structure
 	 */

--- a/deno/rest/v9/channel.ts
+++ b/deno/rest/v9/channel.ts
@@ -309,7 +309,7 @@ export interface RESTPostAPIChannelMessageJSONBody {
 	 */
 	allowed_mentions?: APIAllowedMentions | undefined;
 	/**
-	 * Include to reference another message (reply, forward, etc.)
+	 * Include to make your message a reply or a forward
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#message-reference-object-message-reference-structure
 	 */

--- a/deno/rest/v9/channel.ts
+++ b/deno/rest/v9/channel.ts
@@ -309,7 +309,7 @@ export interface RESTPostAPIChannelMessageJSONBody {
 	 */
 	allowed_mentions?: APIAllowedMentions | undefined;
 	/**
-	 * Include to make your message a reply
+	 * Include to reference another message (reply, forward, etc.)
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#message-reference-object-message-reference-structure
 	 */

--- a/rest/v10/channel.ts
+++ b/rest/v10/channel.ts
@@ -301,7 +301,7 @@ export interface RESTPostAPIChannelMessageJSONBody {
 	 */
 	allowed_mentions?: APIAllowedMentions | undefined;
 	/**
-	 * Include to make your message a reply
+	 * Include to reference another message (reply, forward, etc.)
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#message-reference-object-message-reference-structure
 	 */

--- a/rest/v10/channel.ts
+++ b/rest/v10/channel.ts
@@ -301,7 +301,7 @@ export interface RESTPostAPIChannelMessageJSONBody {
 	 */
 	allowed_mentions?: APIAllowedMentions | undefined;
 	/**
-	 * Include to reference another message (reply, forward, etc.)
+	 * Include to make your message a reply or a forward
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#message-reference-object-message-reference-structure
 	 */

--- a/rest/v9/channel.ts
+++ b/rest/v9/channel.ts
@@ -309,7 +309,7 @@ export interface RESTPostAPIChannelMessageJSONBody {
 	 */
 	allowed_mentions?: APIAllowedMentions | undefined;
 	/**
-	 * Include to reference another message (reply, forward, etc.)
+	 * Include to make your message a reply or a forward
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#message-reference-object-message-reference-structure
 	 */

--- a/rest/v9/channel.ts
+++ b/rest/v9/channel.ts
@@ -309,7 +309,7 @@ export interface RESTPostAPIChannelMessageJSONBody {
 	 */
 	allowed_mentions?: APIAllowedMentions | undefined;
 	/**
-	 * Include to make your message a reply
+	 * Include to reference another message (reply, forward, etc.)
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#message-reference-object-message-reference-structure
 	 */


### PR DESCRIPTION
Made this more generic as this is not for only replying any more (since #971).