### PR TITLE
feat(GatewayMessageUpdateDispatchData): Use full message object

### DIFF
--- a/deno/gateway/v10.ts
+++ b/deno/gateway/v10.ts
@@ -1597,17 +1597,7 @@ export type GatewayMessageUpdateDispatch = DataPayload<
 /**
  * https://discord.com/developers/docs/topics/gateway-events#message-update
  */
-export type GatewayMessageUpdateDispatchData = GatewayMessageEventExtraFields &
-	Omit<Partial<APIMessage>, 'mentions'> & {
-		/**
-		 * ID of the message
-		 */
-		id: Snowflake;
-		/**
-		 * ID of the channel the message was sent in
-		 */
-		channel_id: Snowflake;
-	};
+export type GatewayMessageUpdateDispatchData = GatewayMessageEventExtraFields & Omit<APIMessage, 'mentions'>;
 
 /**
  * https://discord.com/developers/docs/topics/gateway-events#message-create-message-create-extra-fields

--- a/deno/gateway/v9.ts
+++ b/deno/gateway/v9.ts
@@ -1596,17 +1596,7 @@ export type GatewayMessageUpdateDispatch = DataPayload<
 /**
  * https://discord.com/developers/docs/topics/gateway-events#message-update
  */
-export type GatewayMessageUpdateDispatchData = GatewayMessageEventExtraFields &
-	Omit<Partial<APIMessage>, 'mentions'> & {
-		/**
-		 * ID of the message
-		 */
-		id: Snowflake;
-		/**
-		 * ID of the channel the message was sent in
-		 */
-		channel_id: Snowflake;
-	};
+export type GatewayMessageUpdateDispatchData = GatewayMessageEventExtraFields & Omit<APIMessage, 'mentions'>;
 
 /**
  * https://discord.com/developers/docs/topics/gateway-events#message-create-message-create-extra-fields

--- a/gateway/v10.ts
+++ b/gateway/v10.ts
@@ -1597,17 +1597,7 @@ export type GatewayMessageUpdateDispatch = DataPayload<
 /**
  * https://discord.com/developers/docs/topics/gateway-events#message-update
  */
-export type GatewayMessageUpdateDispatchData = GatewayMessageEventExtraFields &
-	Omit<Partial<APIMessage>, 'mentions'> & {
-		/**
-		 * ID of the message
-		 */
-		id: Snowflake;
-		/**
-		 * ID of the channel the message was sent in
-		 */
-		channel_id: Snowflake;
-	};
+export type GatewayMessageUpdateDispatchData = GatewayMessageEventExtraFields & Omit<APIMessage, 'mentions'>;
 
 /**
  * https://discord.com/developers/docs/topics/gateway-events#message-create-message-create-extra-fields

--- a/gateway/v9.ts
+++ b/gateway/v9.ts
@@ -1596,17 +1596,7 @@ export type GatewayMessageUpdateDispatch = DataPayload<
 /**
  * https://discord.com/developers/docs/topics/gateway-events#message-update
  */
-export type GatewayMessageUpdateDispatchData = GatewayMessageEventExtraFields &
-	Omit<Partial<APIMessage>, 'mentions'> & {
-		/**
-		 * ID of the message
-		 */
-		id: Snowflake;
-		/**
-		 * ID of the channel the message was sent in
-		 */
-		channel_id: Snowflake;
-	};
+export type GatewayMessageUpdateDispatchData = GatewayMessageEventExtraFields & Omit<APIMessage, 'mentions'>;
 
 /**
  * https://discord.com/developers/docs/topics/gateway-events#message-create-message-create-extra-fields


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Message updates now contain full message object.

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**

- https://github.com/discord/discord-api-docs/pull/7017