### PR TITLE
feat(_interactions): Support partial guild objects

### DIFF
--- a/deno/payloads/v10/_interactions/base.ts
+++ b/deno/payloads/v10/_interactions/base.ts
@@ -9,7 +9,7 @@ import type {
 	ChannelType,
 	ThreadChannelType,
 } from '../channel.ts';
-import type { APIGuildMember } from '../guild.ts';
+import type { APIGuildMember, APIPartialInteractionGuild } from '../guild.ts';
 import type { APIEntitlement } from '../monetization.ts';
 import type { APIUser } from '../user.ts';
 import type { InteractionType } from './responses.ts';
@@ -118,7 +118,11 @@ export interface APIBaseInteraction<Type extends InteractionType, Data> {
 	 */
 	data?: Data;
 	/**
-	 * The guild it was sent from
+	 * Guild that the interaction was sent from
+	 */
+	guild?: APIPartialInteractionGuild;
+	/**
+	 * Guild that the interaction was sent from
 	 */
 	guild_id?: Snowflake;
 	/**

--- a/deno/payloads/v10/guild.ts
+++ b/deno/payloads/v10/guild.ts
@@ -290,7 +290,7 @@ export interface APIPartialInteractionGuild extends Pick<APIGuild, 'features' | 
 	/**
 	 * The preferred locale of a Community guild; used in guild discovery and notices from Discord; defaults to "en-US"
 	 *
-	 * @remarks This field may change in the future due to https://github.com/discord/discord-api-docs/issues/6938.
+	 * @unstable https://github.com/discord/discord-api-docs/issues/6938
 	 * @default "en-US"
 	 */
 	locale: Locale;

--- a/deno/payloads/v10/guild.ts
+++ b/deno/payloads/v10/guild.ts
@@ -284,6 +284,19 @@ export interface APIGuild extends APIPartialGuild {
 }
 
 /**
+ * https://discord.com/developers/docs/resources/guild#guild-object-guild-structure
+ */
+export interface APIPartialInteractionGuild extends Pick<APIGuild, 'features' | 'id'> {
+	/**
+	 * The preferred locale of a Community guild; used in guild discovery and notices from Discord; defaults to "en-US"
+	 *
+	 * @remarks This field may change in the future due to https://github.com/discord/discord-api-docs/issues/6938.
+	 * @default "en-US"
+	 */
+	locale: Locale;
+}
+
+/**
  * https://discord.com/developers/docs/resources/guild#guild-object-default-message-notification-level
  */
 export enum GuildDefaultMessageNotifications {

--- a/deno/payloads/v9/_interactions/base.ts
+++ b/deno/payloads/v9/_interactions/base.ts
@@ -9,7 +9,7 @@ import type {
 	ChannelType,
 	ThreadChannelType,
 } from '../channel.ts';
-import type { APIGuildMember } from '../guild.ts';
+import type { APIGuildMember, APIPartialInteractionGuild } from '../guild.ts';
 import type { APIEntitlement } from '../monetization.ts';
 import type { APIUser } from '../user.ts';
 import type { InteractionType } from './responses.ts';
@@ -118,7 +118,11 @@ export interface APIBaseInteraction<Type extends InteractionType, Data> {
 	 */
 	data?: Data;
 	/**
-	 * The guild it was sent from
+	 * Guild that the interaction was sent from
+	 */
+	guild?: APIPartialInteractionGuild;
+	/**
+	 * Guild that the interaction was sent from
 	 */
 	guild_id?: Snowflake;
 	/**

--- a/deno/payloads/v9/guild.ts
+++ b/deno/payloads/v9/guild.ts
@@ -290,7 +290,7 @@ export interface APIPartialInteractionGuild extends Pick<APIGuild, 'features' | 
 	/**
 	 * The preferred locale of a Community guild; used in guild discovery and notices from Discord; defaults to "en-US"
 	 *
-	 * @remarks This field may change in the future due to https://github.com/discord/discord-api-docs/issues/6938.
+	 * @unstable https://github.com/discord/discord-api-docs/issues/6938
 	 * @default "en-US"
 	 */
 	locale: Locale;

--- a/deno/payloads/v9/guild.ts
+++ b/deno/payloads/v9/guild.ts
@@ -284,6 +284,19 @@ export interface APIGuild extends APIPartialGuild {
 }
 
 /**
+ * https://discord.com/developers/docs/resources/guild#guild-object-guild-structure
+ */
+export interface APIPartialInteractionGuild extends Pick<APIGuild, 'features' | 'id'> {
+	/**
+	 * The preferred locale of a Community guild; used in guild discovery and notices from Discord; defaults to "en-US"
+	 *
+	 * @remarks This field may change in the future due to https://github.com/discord/discord-api-docs/issues/6938.
+	 * @default "en-US"
+	 */
+	locale: Locale;
+}
+
+/**
  * https://discord.com/developers/docs/resources/guild#guild-object-default-message-notification-level
  */
 export enum GuildDefaultMessageNotifications {

--- a/payloads/v10/_interactions/base.ts
+++ b/payloads/v10/_interactions/base.ts
@@ -9,7 +9,7 @@ import type {
 	ChannelType,
 	ThreadChannelType,
 } from '../channel';
-import type { APIGuildMember } from '../guild';
+import type { APIGuildMember, APIPartialInteractionGuild } from '../guild';
 import type { APIEntitlement } from '../monetization';
 import type { APIUser } from '../user';
 import type { InteractionType } from './responses';
@@ -118,7 +118,11 @@ export interface APIBaseInteraction<Type extends InteractionType, Data> {
 	 */
 	data?: Data;
 	/**
-	 * The guild it was sent from
+	 * Guild that the interaction was sent from
+	 */
+	guild?: APIPartialInteractionGuild;
+	/**
+	 * Guild that the interaction was sent from
 	 */
 	guild_id?: Snowflake;
 	/**

--- a/payloads/v10/guild.ts
+++ b/payloads/v10/guild.ts
@@ -290,7 +290,7 @@ export interface APIPartialInteractionGuild extends Pick<APIGuild, 'features' | 
 	/**
 	 * The preferred locale of a Community guild; used in guild discovery and notices from Discord; defaults to "en-US"
 	 *
-	 * @remarks This field may change in the future due to https://github.com/discord/discord-api-docs/issues/6938.
+	 * @unstable https://github.com/discord/discord-api-docs/issues/6938
 	 * @default "en-US"
 	 */
 	locale: Locale;

--- a/payloads/v10/guild.ts
+++ b/payloads/v10/guild.ts
@@ -284,6 +284,19 @@ export interface APIGuild extends APIPartialGuild {
 }
 
 /**
+ * https://discord.com/developers/docs/resources/guild#guild-object-guild-structure
+ */
+export interface APIPartialInteractionGuild extends Pick<APIGuild, 'features' | 'id'> {
+	/**
+	 * The preferred locale of a Community guild; used in guild discovery and notices from Discord; defaults to "en-US"
+	 *
+	 * @remarks This field may change in the future due to https://github.com/discord/discord-api-docs/issues/6938.
+	 * @default "en-US"
+	 */
+	locale: Locale;
+}
+
+/**
  * https://discord.com/developers/docs/resources/guild#guild-object-default-message-notification-level
  */
 export enum GuildDefaultMessageNotifications {

--- a/payloads/v9/_interactions/base.ts
+++ b/payloads/v9/_interactions/base.ts
@@ -9,7 +9,7 @@ import type {
 	ChannelType,
 	ThreadChannelType,
 } from '../channel';
-import type { APIGuildMember } from '../guild';
+import type { APIGuildMember, APIPartialInteractionGuild } from '../guild';
 import type { APIEntitlement } from '../monetization';
 import type { APIUser } from '../user';
 import type { InteractionType } from './responses';
@@ -118,7 +118,11 @@ export interface APIBaseInteraction<Type extends InteractionType, Data> {
 	 */
 	data?: Data;
 	/**
-	 * The guild it was sent from
+	 * Guild that the interaction was sent from
+	 */
+	guild?: APIPartialInteractionGuild;
+	/**
+	 * Guild that the interaction was sent from
 	 */
 	guild_id?: Snowflake;
 	/**

--- a/payloads/v9/guild.ts
+++ b/payloads/v9/guild.ts
@@ -290,7 +290,7 @@ export interface APIPartialInteractionGuild extends Pick<APIGuild, 'features' | 
 	/**
 	 * The preferred locale of a Community guild; used in guild discovery and notices from Discord; defaults to "en-US"
 	 *
-	 * @remarks This field may change in the future due to https://github.com/discord/discord-api-docs/issues/6938.
+	 * @unstable https://github.com/discord/discord-api-docs/issues/6938
 	 * @default "en-US"
 	 */
 	locale: Locale;

--- a/payloads/v9/guild.ts
+++ b/payloads/v9/guild.ts
@@ -284,6 +284,19 @@ export interface APIGuild extends APIPartialGuild {
 }
 
 /**
+ * https://discord.com/developers/docs/resources/guild#guild-object-guild-structure
+ */
+export interface APIPartialInteractionGuild extends Pick<APIGuild, 'features' | 'id'> {
+	/**
+	 * The preferred locale of a Community guild; used in guild discovery and notices from Discord; defaults to "en-US"
+	 *
+	 * @remarks This field may change in the future due to https://github.com/discord/discord-api-docs/issues/6938.
+	 * @default "en-US"
+	 */
+	locale: Locale;
+}
+
+/**
  * https://discord.com/developers/docs/resources/guild#guild-object-default-message-notification-level
  */
 export enum GuildDefaultMessageNotifications {


### PR DESCRIPTION
Resolves #1133.

The partial guild object returns `locale` instead of `preferred_locale`. There is an open issue about this: https://github.com/discord/discord-api-docs/issues/6938. I wasn't sure whether to mark this as `@unstable`, so I've left it as a `@remark`.

Upstream:
- https://github.com/discord/discord-api-docs/pull/6870
