### PR TITLE
refactor(GatewayGuildCreateDispatchData): Narrow `channels` and `threads` types

### DIFF
--- a/deno/gateway/v10.ts
+++ b/deno/gateway/v10.ts
@@ -37,6 +37,8 @@ import type {
 	ChannelType,
 	APISubscription,
 	APISoundboardSound,
+	GuildChannelType,
+	ThreadChannelType,
 } from '../payloads/v10/mod.ts';
 import type { ReactionType } from '../rest/v10/mod.ts';
 import type { Nullable } from '../utils/internals.ts';
@@ -879,7 +881,7 @@ export interface GatewayGuildCreateDispatchData extends APIGuild {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#channel-object
 	 */
-	channels: (APIChannel & { type: Exclude<ChannelType, ChannelType.DM | ChannelType.GroupDM> })[];
+	channels: (APIChannel & { type: Exclude<GuildChannelType, ThreadChannelType> })[];
 	/**
 	 * Threads in the guild
 	 *
@@ -887,9 +889,7 @@ export interface GatewayGuildCreateDispatchData extends APIGuild {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#channel-object
 	 */
-	threads: (APIChannel & {
-		type: ChannelType.AnnouncementThread | ChannelType.PrivateThread | ChannelType.PublicThread;
-	})[];
+	threads: (APIChannel & { type: ThreadChannelType })[];
 	/**
 	 * Presences of the members in the guild, will only include non-offline members if the size is greater than `large_threshold`
 	 *

--- a/deno/gateway/v10.ts
+++ b/deno/gateway/v10.ts
@@ -879,7 +879,7 @@ export interface GatewayGuildCreateDispatchData extends APIGuild {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#channel-object
 	 */
-	channels: APIChannel[];
+	channels: (APIChannel & { type: Exclude<ChannelType, ChannelType.DM | ChannelType.GroupDM> })[];
 	/**
 	 * Threads in the guild
 	 *
@@ -887,7 +887,9 @@ export interface GatewayGuildCreateDispatchData extends APIGuild {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#channel-object
 	 */
-	threads: APIChannel[];
+	threads: (APIChannel & {
+		type: ChannelType.AnnouncementThread | ChannelType.PrivateThread | ChannelType.PublicThread;
+	})[];
 	/**
 	 * Presences of the members in the guild, will only include non-offline members if the size is greater than `large_threshold`
 	 *

--- a/deno/gateway/v9.ts
+++ b/deno/gateway/v9.ts
@@ -878,7 +878,7 @@ export interface GatewayGuildCreateDispatchData extends APIGuild {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#channel-object
 	 */
-	channels: APIChannel[];
+	channels: (APIChannel & { type: Exclude<ChannelType, ChannelType.DM | ChannelType.GroupDM> })[];
 	/**
 	 * Threads in the guild
 	 *
@@ -886,7 +886,9 @@ export interface GatewayGuildCreateDispatchData extends APIGuild {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#channel-object
 	 */
-	threads: APIChannel[];
+	threads: (APIChannel & {
+		type: ChannelType.AnnouncementThread | ChannelType.PrivateThread | ChannelType.PublicThread;
+	})[];
 	/**
 	 * Presences of the members in the guild, will only include non-offline members if the size is greater than `large_threshold`
 	 *

--- a/deno/gateway/v9.ts
+++ b/deno/gateway/v9.ts
@@ -36,6 +36,8 @@ import type {
 	ChannelType,
 	APISubscription,
 	APISoundboardSound,
+	GuildChannelType,
+	ThreadChannelType,
 } from '../payloads/v9/mod.ts';
 import type { ReactionType } from '../rest/v9/mod.ts';
 import type { Nullable } from '../utils/internals.ts';
@@ -878,7 +880,7 @@ export interface GatewayGuildCreateDispatchData extends APIGuild {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#channel-object
 	 */
-	channels: (APIChannel & { type: Exclude<ChannelType, ChannelType.DM | ChannelType.GroupDM> })[];
+	channels: (APIChannel & { type: Exclude<GuildChannelType, ThreadChannelType> })[];
 	/**
 	 * Threads in the guild
 	 *
@@ -886,9 +888,7 @@ export interface GatewayGuildCreateDispatchData extends APIGuild {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#channel-object
 	 */
-	threads: (APIChannel & {
-		type: ChannelType.AnnouncementThread | ChannelType.PrivateThread | ChannelType.PublicThread;
-	})[];
+	threads: (APIChannel & { type: ThreadChannelType })[];
 	/**
 	 * Presences of the members in the guild, will only include non-offline members if the size is greater than `large_threshold`
 	 *

--- a/gateway/v10.ts
+++ b/gateway/v10.ts
@@ -879,7 +879,7 @@ export interface GatewayGuildCreateDispatchData extends APIGuild {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#channel-object
 	 */
-	channels: APIChannel[];
+	channels: (APIChannel & { type: Exclude<ChannelType, ChannelType.DM | ChannelType.GroupDM> })[];
 	/**
 	 * Threads in the guild
 	 *
@@ -887,7 +887,9 @@ export interface GatewayGuildCreateDispatchData extends APIGuild {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#channel-object
 	 */
-	threads: APIChannel[];
+	threads: (APIChannel & {
+		type: ChannelType.AnnouncementThread | ChannelType.PrivateThread | ChannelType.PublicThread;
+	})[];
 	/**
 	 * Presences of the members in the guild, will only include non-offline members if the size is greater than `large_threshold`
 	 *

--- a/gateway/v10.ts
+++ b/gateway/v10.ts
@@ -37,6 +37,8 @@ import type {
 	ChannelType,
 	APISubscription,
 	APISoundboardSound,
+	GuildChannelType,
+	ThreadChannelType,
 } from '../payloads/v10/index';
 import type { ReactionType } from '../rest/v10/index';
 import type { Nullable } from '../utils/internals';
@@ -879,7 +881,7 @@ export interface GatewayGuildCreateDispatchData extends APIGuild {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#channel-object
 	 */
-	channels: (APIChannel & { type: Exclude<ChannelType, ChannelType.DM | ChannelType.GroupDM> })[];
+	channels: (APIChannel & { type: Exclude<GuildChannelType, ThreadChannelType> })[];
 	/**
 	 * Threads in the guild
 	 *
@@ -887,9 +889,7 @@ export interface GatewayGuildCreateDispatchData extends APIGuild {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#channel-object
 	 */
-	threads: (APIChannel & {
-		type: ChannelType.AnnouncementThread | ChannelType.PrivateThread | ChannelType.PublicThread;
-	})[];
+	threads: (APIChannel & { type: ThreadChannelType })[];
 	/**
 	 * Presences of the members in the guild, will only include non-offline members if the size is greater than `large_threshold`
 	 *

--- a/gateway/v9.ts
+++ b/gateway/v9.ts
@@ -878,7 +878,7 @@ export interface GatewayGuildCreateDispatchData extends APIGuild {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#channel-object
 	 */
-	channels: APIChannel[];
+	channels: (APIChannel & { type: Exclude<ChannelType, ChannelType.DM | ChannelType.GroupDM> })[];
 	/**
 	 * Threads in the guild
 	 *
@@ -886,7 +886,9 @@ export interface GatewayGuildCreateDispatchData extends APIGuild {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#channel-object
 	 */
-	threads: APIChannel[];
+	threads: (APIChannel & {
+		type: ChannelType.AnnouncementThread | ChannelType.PrivateThread | ChannelType.PublicThread;
+	})[];
 	/**
 	 * Presences of the members in the guild, will only include non-offline members if the size is greater than `large_threshold`
 	 *

--- a/gateway/v9.ts
+++ b/gateway/v9.ts
@@ -36,6 +36,8 @@ import type {
 	ChannelType,
 	APISubscription,
 	APISoundboardSound,
+	GuildChannelType,
+	ThreadChannelType,
 } from '../payloads/v9/index';
 import type { ReactionType } from '../rest/v9/index';
 import type { Nullable } from '../utils/internals';
@@ -878,7 +880,7 @@ export interface GatewayGuildCreateDispatchData extends APIGuild {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#channel-object
 	 */
-	channels: (APIChannel & { type: Exclude<ChannelType, ChannelType.DM | ChannelType.GroupDM> })[];
+	channels: (APIChannel & { type: Exclude<GuildChannelType, ThreadChannelType> })[];
 	/**
 	 * Threads in the guild
 	 *
@@ -886,9 +888,7 @@ export interface GatewayGuildCreateDispatchData extends APIGuild {
 	 *
 	 * See https://discord.com/developers/docs/resources/channel#channel-object
 	 */
-	threads: (APIChannel & {
-		type: ChannelType.AnnouncementThread | ChannelType.PrivateThread | ChannelType.PublicThread;
-	})[];
+	threads: (APIChannel & { type: ThreadChannelType })[];
 	/**
 	 * Presences of the members in the guild, will only include non-offline members if the size is greater than `large_threshold`
 	 *


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
- `channels` will not contain direct message channels or group direct message channels. These are channels attached to a guild.
- `threads` are, well, threads. This cannot contain category channels, for example.

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
N/A