### PR TITLE
refactor: Narrow channel gateway events types

### DIFF
--- a/deno/gateway/v10.ts
+++ b/deno/gateway/v10.ts
@@ -707,7 +707,10 @@ export type GatewayChannelModifyDispatch = DataPayload<
  * https://discord.com/developers/docs/topics/gateway-events#channel-update
  * https://discord.com/developers/docs/topics/gateway-events#channel-delete
  */
-export type GatewayChannelModifyDispatchData = APIChannel;
+export type GatewayChannelModifyDispatchData = APIChannel & {
+	type: Exclude<GuildChannelType, ThreadChannelType>;
+	guild_id: Snowflake;
+};
 
 /**
  * https://discord.com/developers/docs/topics/gateway-events#channel-create
@@ -1838,7 +1841,7 @@ export type GatewayThreadMemberUpdateDispatchData = APIThreadMember & { guild_id
  */
 export type GatewayThreadModifyDispatch = DataPayload<
 	GatewayDispatchEvents.ThreadCreate | GatewayDispatchEvents.ThreadDelete | GatewayDispatchEvents.ThreadUpdate,
-	GatewayChannelModifyDispatchData
+	APIThreadChannel
 >;
 
 /**

--- a/deno/gateway/v9.ts
+++ b/deno/gateway/v9.ts
@@ -706,7 +706,10 @@ export type GatewayChannelModifyDispatch = DataPayload<
  * https://discord.com/developers/docs/topics/gateway-events#channel-update
  * https://discord.com/developers/docs/topics/gateway-events#channel-delete
  */
-export type GatewayChannelModifyDispatchData = APIChannel;
+export type GatewayChannelModifyDispatchData = APIChannel & {
+	type: Exclude<GuildChannelType, ThreadChannelType>;
+	guild_id: Snowflake;
+};
 
 /**
  * https://discord.com/developers/docs/topics/gateway-events#channel-create
@@ -1837,7 +1840,7 @@ export type GatewayThreadMemberUpdateDispatchData = APIThreadMember & { guild_id
  */
 export type GatewayThreadModifyDispatch = DataPayload<
 	GatewayDispatchEvents.ThreadCreate | GatewayDispatchEvents.ThreadDelete | GatewayDispatchEvents.ThreadUpdate,
-	GatewayChannelModifyDispatchData
+	APIThreadChannel
 >;
 
 /**

--- a/gateway/v10.ts
+++ b/gateway/v10.ts
@@ -707,7 +707,10 @@ export type GatewayChannelModifyDispatch = DataPayload<
  * https://discord.com/developers/docs/topics/gateway-events#channel-update
  * https://discord.com/developers/docs/topics/gateway-events#channel-delete
  */
-export type GatewayChannelModifyDispatchData = APIChannel;
+export type GatewayChannelModifyDispatchData = APIChannel & {
+	type: Exclude<GuildChannelType, ThreadChannelType>;
+	guild_id: Snowflake;
+};
 
 /**
  * https://discord.com/developers/docs/topics/gateway-events#channel-create
@@ -1838,7 +1841,7 @@ export type GatewayThreadMemberUpdateDispatchData = APIThreadMember & { guild_id
  */
 export type GatewayThreadModifyDispatch = DataPayload<
 	GatewayDispatchEvents.ThreadCreate | GatewayDispatchEvents.ThreadDelete | GatewayDispatchEvents.ThreadUpdate,
-	GatewayChannelModifyDispatchData
+	APIThreadChannel
 >;
 
 /**

--- a/gateway/v9.ts
+++ b/gateway/v9.ts
@@ -706,7 +706,10 @@ export type GatewayChannelModifyDispatch = DataPayload<
  * https://discord.com/developers/docs/topics/gateway-events#channel-update
  * https://discord.com/developers/docs/topics/gateway-events#channel-delete
  */
-export type GatewayChannelModifyDispatchData = APIChannel;
+export type GatewayChannelModifyDispatchData = APIChannel & {
+	type: Exclude<GuildChannelType, ThreadChannelType>;
+	guild_id: Snowflake;
+};
 
 /**
  * https://discord.com/developers/docs/topics/gateway-events#channel-create
@@ -1837,7 +1840,7 @@ export type GatewayThreadMemberUpdateDispatchData = APIThreadMember & { guild_id
  */
 export type GatewayThreadModifyDispatch = DataPayload<
 	GatewayDispatchEvents.ThreadCreate | GatewayDispatchEvents.ThreadDelete | GatewayDispatchEvents.ThreadUpdate,
-	GatewayChannelModifyDispatchData
+	APIThreadChannel
 >;
 
 /**


### PR DESCRIPTION
Narrowed the `CHANNEL_CREATE`, `CHANNEL_DELETE`, and `CHANNEL_UPDATE` gateway events types.

It is [documented](https://discord.com/developers/docs/events/gateway-events#channel-create) that channel creations are guild channels. This excludes threads, which have their own gateway events. Does not seem like direct message channels trigger update or delete either.

Made `guild_id` present. [It's only missing on guild dispatches](https://discord.com/developers/docs/resources/channel#channel-object-channel-structure).

I had to touch the deprecated `GatewayThreadModifyDispatch` type as the payload would have been wrong.