### PR TITLE
refactor(APIThreadMetadata): `locked` is always present

### DIFF
--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -1064,7 +1064,7 @@ export interface APIThreadMetadata {
 	/**
 	 * Whether the thread is locked; when a thread is locked, only users with `MANAGE_THREADS` can unarchive it
 	 */
-	locked?: boolean;
+	locked: boolean;
 	/**
 	 * Whether non-moderators can add other non-moderators to the thread; only available on private threads
 	 */

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -1027,7 +1027,7 @@ export interface APIThreadMetadata {
 	/**
 	 * Whether the thread is locked; when a thread is locked, only users with `MANAGE_THREADS` can unarchive it
 	 */
-	locked?: boolean;
+	locked: boolean;
 	/**
 	 * Whether non-moderators can add other non-moderators to the thread; only available on private threads
 	 */

--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -1064,7 +1064,7 @@ export interface APIThreadMetadata {
 	/**
 	 * Whether the thread is locked; when a thread is locked, only users with `MANAGE_THREADS` can unarchive it
 	 */
-	locked?: boolean;
+	locked: boolean;
 	/**
 	 * Whether non-moderators can add other non-moderators to the thread; only available on private threads
 	 */

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -1027,7 +1027,7 @@ export interface APIThreadMetadata {
 	/**
 	 * Whether the thread is locked; when a thread is locked, only users with `MANAGE_THREADS` can unarchive it
 	 */
-	locked?: boolean;
+	locked: boolean;
 	/**
 	 * Whether non-moderators can add other non-moderators to the thread; only available on private threads
 	 */


### PR DESCRIPTION
- https://github.com/discord/discord-api-docs/pull/3404