### PR TITLE
refactor(GatewayThreadListSync): Narrow `threads`

### DIFF
--- a/deno/payloads/v10/gateway.ts
+++ b/deno/payloads/v10/gateway.ts
@@ -5,7 +5,7 @@
  */
 
 import type { Snowflake } from '../../globals.ts';
-import type { APIChannel, APIThreadMember } from './channel.ts';
+import type { APIThreadChannel, APIThreadMember } from './channel.ts';
 import type { APIEmoji } from './emoji.ts';
 import type { APIUser } from './user.ts';
 
@@ -361,7 +361,7 @@ export interface GatewayThreadListSync {
 	/**
 	 * Array of the synced threads
 	 */
-	threads: APIChannel[];
+	threads: APIThreadChannel[];
 	/**
 	 * The member objects for the client user in each joined thread that was synced
 	 */

--- a/deno/payloads/v9/gateway.ts
+++ b/deno/payloads/v9/gateway.ts
@@ -5,7 +5,7 @@
  */
 
 import type { Snowflake } from '../../globals.ts';
-import type { APIChannel, APIThreadMember } from './channel.ts';
+import type { APIThreadChannel, APIThreadMember } from './channel.ts';
 import type { APIEmoji } from './emoji.ts';
 import type { APIUser } from './user.ts';
 
@@ -349,7 +349,7 @@ export interface GatewayThreadListSync {
 	/**
 	 * Array of the synced threads
 	 */
-	threads: APIChannel[];
+	threads: APIThreadChannel[];
 	/**
 	 * The member objects for the client user in each joined thread that was synced
 	 */

--- a/payloads/v10/gateway.ts
+++ b/payloads/v10/gateway.ts
@@ -5,7 +5,7 @@
  */
 
 import type { Snowflake } from '../../globals';
-import type { APIChannel, APIThreadMember } from './channel';
+import type { APIThreadChannel, APIThreadMember } from './channel';
 import type { APIEmoji } from './emoji';
 import type { APIUser } from './user';
 
@@ -361,7 +361,7 @@ export interface GatewayThreadListSync {
 	/**
 	 * Array of the synced threads
 	 */
-	threads: APIChannel[];
+	threads: APIThreadChannel[];
 	/**
 	 * The member objects for the client user in each joined thread that was synced
 	 */

--- a/payloads/v9/gateway.ts
+++ b/payloads/v9/gateway.ts
@@ -5,7 +5,7 @@
  */
 
 import type { Snowflake } from '../../globals';
-import type { APIChannel, APIThreadMember } from './channel';
+import type { APIThreadChannel, APIThreadMember } from './channel';
 import type { APIEmoji } from './emoji';
 import type { APIUser } from './user';
 
@@ -349,7 +349,7 @@ export interface GatewayThreadListSync {
 	/**
 	 * Array of the synced threads
 	 */
-	threads: APIChannel[];
+	threads: APIThreadChannel[];
 	/**
 	 * The member objects for the client user in each joined thread that was synced
 	 */


### PR DESCRIPTION
Narrowed the `threads` property to only contain threads.