### PR TITLE
refactor(APIEntitlement): update `ends_at` and `starts_at` to be nullable

### DIFF
--- a/deno/payloads/v10/monetization.ts
+++ b/deno/payloads/v10/monetization.ts
@@ -33,13 +33,13 @@ export interface APIEntitlement {
 	 */
 	deleted: boolean;
 	/**
-	 * Start date at which the entitlement is valid. Not present when using test entitlements.
+	 * Start date at which the entitlement is valid.
 	 */
-	starts_at?: string;
+	starts_at: string | null;
 	/**
-	 * Date at which the entitlement is no longer valid. Not present when using test entitlements.
+	 * Date at which the entitlement is no longer valid.
 	 */
-	ends_at?: string;
+	ends_at: string | null;
 	/**
 	 * For consumable items, whether or not the entitlement has been consumed
 	 */

--- a/deno/payloads/v9/monetization.ts
+++ b/deno/payloads/v9/monetization.ts
@@ -33,13 +33,13 @@ export interface APIEntitlement {
 	 */
 	deleted: boolean;
 	/**
-	 * Start date at which the entitlement is valid. Not present when using test entitlements.
+	 * Start date at which the entitlement is valid.
 	 */
-	starts_at?: string;
+	starts_at: string | null;
 	/**
-	 * Date at which the entitlement is no longer valid. Not present when using test entitlements.
+	 * Date at which the entitlement is no longer valid.
 	 */
-	ends_at?: string;
+	ends_at: string | null;
 	/**
 	 * For consumable items, whether or not the entitlement has been consumed
 	 */

--- a/payloads/v10/monetization.ts
+++ b/payloads/v10/monetization.ts
@@ -33,13 +33,13 @@ export interface APIEntitlement {
 	 */
 	deleted: boolean;
 	/**
-	 * Start date at which the entitlement is valid. Not present when using test entitlements.
+	 * Start date at which the entitlement is valid.
 	 */
-	starts_at?: string;
+	starts_at: string | null;
 	/**
-	 * Date at which the entitlement is no longer valid. Not present when using test entitlements.
+	 * Date at which the entitlement is no longer valid.
 	 */
-	ends_at?: string;
+	ends_at: string | null;
 	/**
 	 * For consumable items, whether or not the entitlement has been consumed
 	 */

--- a/payloads/v9/monetization.ts
+++ b/payloads/v9/monetization.ts
@@ -33,13 +33,13 @@ export interface APIEntitlement {
 	 */
 	deleted: boolean;
 	/**
-	 * Start date at which the entitlement is valid. Not present when using test entitlements.
+	 * Start date at which the entitlement is valid.
 	 */
-	starts_at?: string;
+	starts_at: string | null;
 	/**
-	 * Date at which the entitlement is no longer valid. Not present when using test entitlements.
+	 * Date at which the entitlement is no longer valid.
 	 */
-	ends_at?: string;
+	ends_at: string | null;
 	/**
 	 * For consumable items, whether or not the entitlement has been consumed
 	 */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
- https://github.com/discord/discord-api-docs/pull/7288