### PR TITLE
chore: Use feature request label for feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature request
 description: Request a feature for the discord-api-types library (we accept documented features of the official Discord developer API only!)
-labels: [discussion]
+labels: [feature request]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
The "discussion" label does not exist. Using an existing one.