### PR TITLE
fix(MessageEmbed): remove deprecation for EmbedType

### DIFF
--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -1229,7 +1229,7 @@ export interface APIEmbed {
 }
 
 /**
- * https://discord.com/developers/docs/resources/message#embed-object-embed-types
+ * https://discord.com/developers/docs/resources/channel#embed-object-embed-types
  */
 export enum EmbedType {
 	/**

--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -1162,10 +1162,6 @@ export interface APIEmbed {
 	title?: string;
 	/**
 	 * Type of embed (always "rich" for webhook embeds)
-	 *
-	 * @deprecated *Embed types should be considered deprecated and might be removed in a future API version*
-	 *
-	 * See https://discord.com/developers/docs/resources/channel#embed-object-embed-types
 	 */
 	type?: EmbedType;
 	/**
@@ -1233,9 +1229,7 @@ export interface APIEmbed {
 }
 
 /**
- * https://discord.com/developers/docs/resources/channel#embed-object-embed-types
- *
- * @deprecated *Embed types should be considered deprecated and might be removed in a future API version*
+ * https://discord.com/developers/docs/resources/message#embed-object-embed-types
  */
 export enum EmbedType {
 	/**

--- a/deno/payloads/v6/channel.ts
+++ b/deno/payloads/v6/channel.ts
@@ -219,9 +219,6 @@ export enum OverwriteType {
  */
 export interface APIEmbed {
 	title?: string;
-	/**
-	 * @deprecated *Embed types should be considered deprecated and might be removed in a future API version*
-	 */
 	type?: EmbedType;
 	description?: string;
 	url?: string;
@@ -239,7 +236,6 @@ export interface APIEmbed {
 /**
  * https://discord.com/developers/docs/resources/channel#embed-object-embed-types
  *
- * @deprecated *Embed types should be considered deprecated and might be removed in a future API version*
  * @deprecated API and Gateway v6 are deprecated and the types will not receive further updates, please update to v8.
  */
 export enum EmbedType {

--- a/deno/payloads/v8/channel.ts
+++ b/deno/payloads/v8/channel.ts
@@ -693,10 +693,6 @@ export interface APIEmbed {
 	title?: string;
 	/**
 	 * Type of embed (always "rich" for webhook embeds)
-	 *
-	 * @deprecated *Embed types should be considered deprecated and might be removed in a future API version*
-	 *
-	 * See https://discord.com/developers/docs/resources/channel#embed-object-embed-types
 	 */
 	type?: EmbedType;
 	/**
@@ -766,7 +762,6 @@ export interface APIEmbed {
 /**
  * https://discord.com/developers/docs/resources/channel#embed-object-embed-types
  *
- * @deprecated *Embed types should be considered deprecated and might be removed in a future API version*
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
 export enum EmbedType {

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -1129,10 +1129,6 @@ export interface APIEmbed {
 	title?: string;
 	/**
 	 * Type of embed (always "rich" for webhook embeds)
-	 *
-	 * @deprecated *Embed types should be considered deprecated and might be removed in a future API version*
-	 *
-	 * See https://discord.com/developers/docs/resources/channel#embed-object-embed-types
 	 */
 	type?: EmbedType;
 	/**
@@ -1201,8 +1197,6 @@ export interface APIEmbed {
 
 /**
  * https://discord.com/developers/docs/resources/channel#embed-object-embed-types
- *
- * @deprecated *Embed types should be considered deprecated and might be removed in a future API version*
  */
 export enum EmbedType {
 	/**

--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -1162,10 +1162,6 @@ export interface APIEmbed {
 	title?: string;
 	/**
 	 * Type of embed (always "rich" for webhook embeds)
-	 *
-	 * @deprecated *Embed types should be considered deprecated and might be removed in a future API version*
-	 *
-	 * See https://discord.com/developers/docs/resources/channel#embed-object-embed-types
 	 */
 	type?: EmbedType;
 	/**
@@ -1234,8 +1230,6 @@ export interface APIEmbed {
 
 /**
  * https://discord.com/developers/docs/resources/channel#embed-object-embed-types
- *
- * @deprecated *Embed types should be considered deprecated and might be removed in a future API version*
  */
 export enum EmbedType {
 	/**

--- a/payloads/v6/channel.ts
+++ b/payloads/v6/channel.ts
@@ -219,9 +219,6 @@ export enum OverwriteType {
  */
 export interface APIEmbed {
 	title?: string;
-	/**
-	 * @deprecated *Embed types should be considered deprecated and might be removed in a future API version*
-	 */
 	type?: EmbedType;
 	description?: string;
 	url?: string;
@@ -239,7 +236,6 @@ export interface APIEmbed {
 /**
  * https://discord.com/developers/docs/resources/channel#embed-object-embed-types
  *
- * @deprecated *Embed types should be considered deprecated and might be removed in a future API version*
  * @deprecated API and Gateway v6 are deprecated and the types will not receive further updates, please update to v8.
  */
 export enum EmbedType {

--- a/payloads/v8/channel.ts
+++ b/payloads/v8/channel.ts
@@ -693,10 +693,6 @@ export interface APIEmbed {
 	title?: string;
 	/**
 	 * Type of embed (always "rich" for webhook embeds)
-	 *
-	 * @deprecated *Embed types should be considered deprecated and might be removed in a future API version*
-	 *
-	 * See https://discord.com/developers/docs/resources/channel#embed-object-embed-types
 	 */
 	type?: EmbedType;
 	/**
@@ -766,7 +762,6 @@ export interface APIEmbed {
 /**
  * https://discord.com/developers/docs/resources/channel#embed-object-embed-types
  *
- * @deprecated *Embed types should be considered deprecated and might be removed in a future API version*
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
 export enum EmbedType {

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -1129,10 +1129,6 @@ export interface APIEmbed {
 	title?: string;
 	/**
 	 * Type of embed (always "rich" for webhook embeds)
-	 *
-	 * @deprecated *Embed types should be considered deprecated and might be removed in a future API version*
-	 *
-	 * See https://discord.com/developers/docs/resources/channel#embed-object-embed-types
 	 */
 	type?: EmbedType;
 	/**
@@ -1201,8 +1197,6 @@ export interface APIEmbed {
 
 /**
  * https://discord.com/developers/docs/resources/channel#embed-object-embed-types
- *
- * @deprecated *Embed types should be considered deprecated and might be removed in a future API version*
  */
 export enum EmbedType {
 	/**


### PR DESCRIPTION
close #1186

Discord API documentation removed the deprecation message for EmbedType at [discord/discord-api-docs#7050](https://github.com/discord/discord-api-docs/pull/7050). This PR undeprecates the associated property and enum.