### PR TITLE
refactor(APIInteractionResponseCallbackData): Remove `flags` override

### DIFF
--- a/deno/payloads/v10/_interactions/responses.ts
+++ b/deno/payloads/v10/_interactions/responses.ts
@@ -1,6 +1,5 @@
 import type { RESTPostAPIWebhookWithTokenJSONBody } from '../../../v10.ts';
 import type { APIActionRowComponent, APIModalActionRowComponent } from '../channel.ts';
-import type { MessageFlags } from '../mod.ts';
 import type { APIApplicationCommandOptionChoice } from './applicationCommands.ts';
 
 /**
@@ -120,10 +119,7 @@ export enum InteractionResponseType {
 /**
  * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object-interaction-callback-data-structure
  */
-export type APIInteractionResponseCallbackData = Omit<
-	RESTPostAPIWebhookWithTokenJSONBody,
-	'avatar_url' | 'username'
-> & { flags?: MessageFlags };
+export type APIInteractionResponseCallbackData = Omit<RESTPostAPIWebhookWithTokenJSONBody, 'avatar_url' | 'username'>;
 
 export interface APICommandAutocompleteInteractionResponseCallbackData {
 	choices?: APIApplicationCommandOptionChoice[];

--- a/deno/payloads/v9/_interactions/responses.ts
+++ b/deno/payloads/v9/_interactions/responses.ts
@@ -1,6 +1,5 @@
 import type { RESTPostAPIWebhookWithTokenJSONBody } from '../../../v9.ts';
 import type { APIActionRowComponent, APIModalActionRowComponent } from '../channel.ts';
-import type { MessageFlags } from '../mod.ts';
 import type { APIApplicationCommandOptionChoice } from './applicationCommands.ts';
 
 /**
@@ -120,10 +119,7 @@ export enum InteractionResponseType {
 /**
  * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object-interaction-callback-data-structure
  */
-export type APIInteractionResponseCallbackData = Omit<
-	RESTPostAPIWebhookWithTokenJSONBody,
-	'avatar_url' | 'username'
-> & { flags?: MessageFlags };
+export type APIInteractionResponseCallbackData = Omit<RESTPostAPIWebhookWithTokenJSONBody, 'avatar_url' | 'username'>;
 
 export interface APICommandAutocompleteInteractionResponseCallbackData {
 	choices?: APIApplicationCommandOptionChoice[];

--- a/payloads/v10/_interactions/responses.ts
+++ b/payloads/v10/_interactions/responses.ts
@@ -1,6 +1,5 @@
 import type { RESTPostAPIWebhookWithTokenJSONBody } from '../../../v10';
 import type { APIActionRowComponent, APIModalActionRowComponent } from '../channel';
-import type { MessageFlags } from '../index';
 import type { APIApplicationCommandOptionChoice } from './applicationCommands';
 
 /**
@@ -120,10 +119,7 @@ export enum InteractionResponseType {
 /**
  * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object-interaction-callback-data-structure
  */
-export type APIInteractionResponseCallbackData = Omit<
-	RESTPostAPIWebhookWithTokenJSONBody,
-	'avatar_url' | 'username'
-> & { flags?: MessageFlags };
+export type APIInteractionResponseCallbackData = Omit<RESTPostAPIWebhookWithTokenJSONBody, 'avatar_url' | 'username'>;
 
 export interface APICommandAutocompleteInteractionResponseCallbackData {
 	choices?: APIApplicationCommandOptionChoice[];

--- a/payloads/v9/_interactions/responses.ts
+++ b/payloads/v9/_interactions/responses.ts
@@ -1,6 +1,5 @@
 import type { RESTPostAPIWebhookWithTokenJSONBody } from '../../../v9';
 import type { APIActionRowComponent, APIModalActionRowComponent } from '../channel';
-import type { MessageFlags } from '../index';
 import type { APIApplicationCommandOptionChoice } from './applicationCommands';
 
 /**
@@ -120,10 +119,7 @@ export enum InteractionResponseType {
 /**
  * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object-interaction-callback-data-structure
  */
-export type APIInteractionResponseCallbackData = Omit<
-	RESTPostAPIWebhookWithTokenJSONBody,
-	'avatar_url' | 'username'
-> & { flags?: MessageFlags };
+export type APIInteractionResponseCallbackData = Omit<RESTPostAPIWebhookWithTokenJSONBody, 'avatar_url' | 'username'>;
 
 export interface APICommandAutocompleteInteractionResponseCallbackData {
 	choices?: APIApplicationCommandOptionChoice[];


### PR DESCRIPTION
Removes the override of `flags`. This was harmful with `exactOptionalPropertyTypes` enabled.