### PR TITLE
feat(Message): add more attachment flags and fields

### DIFF
--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -1309,6 +1309,14 @@ export interface APIEmbedThumbnail {
 	 * Width of thumbnail
 	 */
 	width?: number;
+	/**
+	 * Embed media flags combined as a bitfield
+	 *
+	 * See https://discord.com/developers/docs/resources/message#embed-object-embed-media-flags
+	 *
+	 * See https://en.wikipedia.org/wiki/Bit_field
+	 */
+	flags?: EmbedMediaFlags;
 }
 
 /**

--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -1226,6 +1226,14 @@ export interface APIEmbed {
 	 * See https://discord.com/developers/docs/resources/channel#embed-object-embed-field-structure
 	 */
 	fields?: APIEmbedField[];
+	/**
+	 * Embed flags combined as a bitfield
+	 *
+	 * See https://discord.com/developers/docs/resources/message#embed-object-embed-flags
+	 *
+	 * See https://en.wikipedia.org/wiki/Bit_field
+	 */
+	flags?: EmbedFlags;
 }
 
 /**
@@ -1266,6 +1274,19 @@ export enum EmbedType {
 	 * Poll result embed
 	 */
 	PollResult = 'poll_result',
+}
+
+export enum EmbedFlags {
+	/**
+	 * This embed was flagged as sensitive content
+	 *
+	 * See https://support.discord.com/hc/en-us/articles/18210995019671
+	 */
+	ContainsExplicitMedia = 1 << 4,
+	/**
+	 * This embed is a reply to an activity card and is no longer displayed
+	 */
+	IsContentInventoryEntry = 1 << 5,
 }
 
 /**
@@ -1332,6 +1353,21 @@ export interface APIEmbedImage {
 	 * Width of image
 	 */
 	width?: number;
+	/**
+	 * Embed media flags combined as a bitfield
+	 *
+	 * See https://discord.com/developers/docs/resources/message#embed-object-embed-media-flags
+	 *
+	 * See https://en.wikipedia.org/wiki/Bit_field
+	 */
+	flags?: EmbedMediaFlags;
+}
+
+export enum EmbedMediaFlags {
+	/**
+	 * This image is animated
+	 */
+	IsAnimated = 1 << 5,
 }
 
 /**
@@ -1476,6 +1512,18 @@ export interface APIAttachment {
 	 * Attachment flags combined as a bitfield
 	 */
 	flags?: AttachmentFlags;
+	/**
+	 * For Clips, array of users who were in the stream
+	 */
+	clip_participants?: APIUser[];
+	/**
+	 * For Clips, when the clip was created
+	 */
+	clip_created_at?: string;
+	/**
+	 * For Clips, the application in the stream, if recognized
+	 */
+	application?: APIApplication | null;
 }
 
 /**
@@ -1483,9 +1531,33 @@ export interface APIAttachment {
  */
 export enum AttachmentFlags {
 	/**
+	 * This attachment is a Clip from a stream
+	 *
+	 * See https://support.discord.com/hc/en-us/articles/16861982215703
+	 */
+	IsClip = 1 << 0,
+	/**
+	 * This attachment is the thumbnail of a thread in a media channel, displayed in the grid but not on the message
+	 */
+	IsThumbnail = 1 << 1,
+	/**
 	 * This attachment has been edited using the remix feature on mobile
 	 */
 	IsRemix = 1 << 2,
+	/**
+	 * This attachment was marked as a spoiler and is blurred until clicked
+	 */
+	IsSpoiler = 1 << 3,
+	/**
+	 * This attachment was flagged as sensitive content
+	 *
+	 * See https://support.discord.com/hc/en-us/articles/18210995019671
+	 */
+	ContainsExplicitMedia = 1 << 4,
+	/**
+	 * This attachment is an animated image
+	 */
+	IsAnimated = 1 << 5,
 }
 
 /**

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -1276,6 +1276,14 @@ export interface APIEmbedThumbnail {
 	 * Width of thumbnail
 	 */
 	width?: number;
+	/**
+	 * Embed media flags combined as a bitfield
+	 *
+	 * See https://discord.com/developers/docs/resources/message#embed-object-embed-media-flags
+	 *
+	 * See https://en.wikipedia.org/wiki/Bit_field
+	 */
+	flags?: EmbedMediaFlags;
 }
 
 /**

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -1193,6 +1193,14 @@ export interface APIEmbed {
 	 * See https://discord.com/developers/docs/resources/channel#embed-object-embed-field-structure
 	 */
 	fields?: APIEmbedField[];
+	/**
+	 * Embed flags combined as a bitfield
+	 *
+	 * See https://discord.com/developers/docs/resources/message#embed-object-embed-flags
+	 *
+	 * See https://en.wikipedia.org/wiki/Bit_field
+	 */
+	flags?: EmbedFlags;
 }
 
 /**
@@ -1233,6 +1241,19 @@ export enum EmbedType {
 	 * Poll result embed
 	 */
 	PollResult = 'poll_result',
+}
+
+export enum EmbedFlags {
+	/**
+	 * This embed was flagged as sensitive content
+	 *
+	 * See https://support.discord.com/hc/en-us/articles/18210995019671
+	 */
+	ContainsExplicitMedia = 1 << 4,
+	/**
+	 * This embed is a reply to an activity card and is no longer displayed
+	 */
+	IsContentInventoryEntry = 1 << 5,
 }
 
 /**
@@ -1299,6 +1320,21 @@ export interface APIEmbedImage {
 	 * Width of image
 	 */
 	width?: number;
+	/**
+	 * Embed media flags combined as a bitfield
+	 *
+	 * See https://discord.com/developers/docs/resources/message#embed-object-embed-media-flags
+	 *
+	 * See https://en.wikipedia.org/wiki/Bit_field
+	 */
+	flags?: EmbedMediaFlags;
+}
+
+export enum EmbedMediaFlags {
+	/**
+	 * This image is animated
+	 */
+	IsAnimated = 1 << 5,
 }
 
 /**
@@ -1443,6 +1479,18 @@ export interface APIAttachment {
 	 * Attachment flags combined as a bitfield
 	 */
 	flags?: AttachmentFlags;
+	/**
+	 * For Clips, array of users who were in the stream
+	 */
+	clip_participants?: APIUser[];
+	/**
+	 * For Clips, when the clip was created
+	 */
+	clip_created_at?: string;
+	/**
+	 * For Clips, the application in the stream, if recognized
+	 */
+	application?: APIApplication | null;
 }
 
 /**
@@ -1450,9 +1498,33 @@ export interface APIAttachment {
  */
 export enum AttachmentFlags {
 	/**
+	 * This attachment is a Clip from a stream
+	 *
+	 * See https://support.discord.com/hc/en-us/articles/16861982215703
+	 */
+	IsClip = 1 << 0,
+	/**
+	 * This attachment is the thumbnail of a thread in a media channel, displayed in the grid but not on the message
+	 */
+	IsThumbnail = 1 << 1,
+	/**
 	 * This attachment has been edited using the remix feature on mobile
 	 */
 	IsRemix = 1 << 2,
+	/**
+	 * This attachment was marked as a spoiler and is blurred until clicked
+	 */
+	IsSpoiler = 1 << 3,
+	/**
+	 * This attachment was flagged as sensitive content
+	 *
+	 * See https://support.discord.com/hc/en-us/articles/18210995019671
+	 */
+	ContainsExplicitMedia = 1 << 4,
+	/**
+	 * This attachment is an animated image
+	 */
+	IsAnimated = 1 << 5,
 }
 
 /**

--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -1309,6 +1309,14 @@ export interface APIEmbedThumbnail {
 	 * Width of thumbnail
 	 */
 	width?: number;
+	/**
+	 * Embed media flags combined as a bitfield
+	 *
+	 * See https://discord.com/developers/docs/resources/message#embed-object-embed-media-flags
+	 *
+	 * See https://en.wikipedia.org/wiki/Bit_field
+	 */
+	flags?: EmbedMediaFlags;
 }
 
 /**

--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -1226,6 +1226,14 @@ export interface APIEmbed {
 	 * See https://discord.com/developers/docs/resources/channel#embed-object-embed-field-structure
 	 */
 	fields?: APIEmbedField[];
+	/**
+	 * Embed flags combined as a bitfield
+	 *
+	 * See https://discord.com/developers/docs/resources/message#embed-object-embed-flags
+	 *
+	 * See https://en.wikipedia.org/wiki/Bit_field
+	 */
+	flags?: EmbedFlags;
 }
 
 /**
@@ -1266,6 +1274,19 @@ export enum EmbedType {
 	 * Poll result embed
 	 */
 	PollResult = 'poll_result',
+}
+
+export enum EmbedFlags {
+	/**
+	 * This embed was flagged as sensitive content
+	 *
+	 * See https://support.discord.com/hc/en-us/articles/18210995019671
+	 */
+	ContainsExplicitMedia = 1 << 4,
+	/**
+	 * This embed is a reply to an activity card and is no longer displayed
+	 */
+	IsContentInventoryEntry = 1 << 5,
 }
 
 /**
@@ -1332,6 +1353,21 @@ export interface APIEmbedImage {
 	 * Width of image
 	 */
 	width?: number;
+	/**
+	 * Embed media flags combined as a bitfield
+	 *
+	 * See https://discord.com/developers/docs/resources/message#embed-object-embed-media-flags
+	 *
+	 * See https://en.wikipedia.org/wiki/Bit_field
+	 */
+	flags?: EmbedMediaFlags;
+}
+
+export enum EmbedMediaFlags {
+	/**
+	 * This image is animated
+	 */
+	IsAnimated = 1 << 5,
 }
 
 /**
@@ -1476,6 +1512,18 @@ export interface APIAttachment {
 	 * Attachment flags combined as a bitfield
 	 */
 	flags?: AttachmentFlags;
+	/**
+	 * For Clips, array of users who were in the stream
+	 */
+	clip_participants?: APIUser[];
+	/**
+	 * For Clips, when the clip was created
+	 */
+	clip_created_at?: string;
+	/**
+	 * For Clips, the application in the stream, if recognized
+	 */
+	application?: APIApplication | null;
 }
 
 /**
@@ -1483,9 +1531,33 @@ export interface APIAttachment {
  */
 export enum AttachmentFlags {
 	/**
+	 * This attachment is a Clip from a stream
+	 *
+	 * See https://support.discord.com/hc/en-us/articles/16861982215703
+	 */
+	IsClip = 1 << 0,
+	/**
+	 * This attachment is the thumbnail of a thread in a media channel, displayed in the grid but not on the message
+	 */
+	IsThumbnail = 1 << 1,
+	/**
 	 * This attachment has been edited using the remix feature on mobile
 	 */
 	IsRemix = 1 << 2,
+	/**
+	 * This attachment was marked as a spoiler and is blurred until clicked
+	 */
+	IsSpoiler = 1 << 3,
+	/**
+	 * This attachment was flagged as sensitive content
+	 *
+	 * See https://support.discord.com/hc/en-us/articles/18210995019671
+	 */
+	ContainsExplicitMedia = 1 << 4,
+	/**
+	 * This attachment is an animated image
+	 */
+	IsAnimated = 1 << 5,
 }
 
 /**

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -1276,6 +1276,14 @@ export interface APIEmbedThumbnail {
 	 * Width of thumbnail
 	 */
 	width?: number;
+	/**
+	 * Embed media flags combined as a bitfield
+	 *
+	 * See https://discord.com/developers/docs/resources/message#embed-object-embed-media-flags
+	 *
+	 * See https://en.wikipedia.org/wiki/Bit_field
+	 */
+	flags?: EmbedMediaFlags;
 }
 
 /**

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -1193,6 +1193,14 @@ export interface APIEmbed {
 	 * See https://discord.com/developers/docs/resources/channel#embed-object-embed-field-structure
 	 */
 	fields?: APIEmbedField[];
+	/**
+	 * Embed flags combined as a bitfield
+	 *
+	 * See https://discord.com/developers/docs/resources/message#embed-object-embed-flags
+	 *
+	 * See https://en.wikipedia.org/wiki/Bit_field
+	 */
+	flags?: EmbedFlags;
 }
 
 /**
@@ -1233,6 +1241,19 @@ export enum EmbedType {
 	 * Poll result embed
 	 */
 	PollResult = 'poll_result',
+}
+
+export enum EmbedFlags {
+	/**
+	 * This embed was flagged as sensitive content
+	 *
+	 * See https://support.discord.com/hc/en-us/articles/18210995019671
+	 */
+	ContainsExplicitMedia = 1 << 4,
+	/**
+	 * This embed is a reply to an activity card and is no longer displayed
+	 */
+	IsContentInventoryEntry = 1 << 5,
 }
 
 /**
@@ -1299,6 +1320,21 @@ export interface APIEmbedImage {
 	 * Width of image
 	 */
 	width?: number;
+	/**
+	 * Embed media flags combined as a bitfield
+	 *
+	 * See https://discord.com/developers/docs/resources/message#embed-object-embed-media-flags
+	 *
+	 * See https://en.wikipedia.org/wiki/Bit_field
+	 */
+	flags?: EmbedMediaFlags;
+}
+
+export enum EmbedMediaFlags {
+	/**
+	 * This image is animated
+	 */
+	IsAnimated = 1 << 5,
 }
 
 /**
@@ -1443,6 +1479,18 @@ export interface APIAttachment {
 	 * Attachment flags combined as a bitfield
 	 */
 	flags?: AttachmentFlags;
+	/**
+	 * For Clips, array of users who were in the stream
+	 */
+	clip_participants?: APIUser[];
+	/**
+	 * For Clips, when the clip was created
+	 */
+	clip_created_at?: string;
+	/**
+	 * For Clips, the application in the stream, if recognized
+	 */
+	application?: APIApplication | null;
 }
 
 /**
@@ -1450,9 +1498,33 @@ export interface APIAttachment {
  */
 export enum AttachmentFlags {
 	/**
+	 * This attachment is a Clip from a stream
+	 *
+	 * See https://support.discord.com/hc/en-us/articles/16861982215703
+	 */
+	IsClip = 1 << 0,
+	/**
+	 * This attachment is the thumbnail of a thread in a media channel, displayed in the grid but not on the message
+	 */
+	IsThumbnail = 1 << 1,
+	/**
 	 * This attachment has been edited using the remix feature on mobile
 	 */
 	IsRemix = 1 << 2,
+	/**
+	 * This attachment was marked as a spoiler and is blurred until clicked
+	 */
+	IsSpoiler = 1 << 3,
+	/**
+	 * This attachment was flagged as sensitive content
+	 *
+	 * See https://support.discord.com/hc/en-us/articles/18210995019671
+	 */
+	ContainsExplicitMedia = 1 << 4,
+	/**
+	 * This attachment is an animated image
+	 */
+	IsAnimated = 1 << 5,
 }
 
 /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

* completes attachment flags enum
* adds embed flags and embed media flags
* adds attachment clip fields

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
* https://github.com/discord/discord-api-docs/pull/7353