### PR TITLE
fix: Ensure autocomplete option values resolve to string for numerical types

### DIFF
--- a/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/integer.ts
+++ b/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/integer.ts
@@ -1,3 +1,4 @@
+import type { InteractionType } from '../../responses.ts';
 import type {
 	APIApplicationCommandOptionBase,
 	APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper,
@@ -22,7 +23,10 @@ export type APIApplicationCommandIntegerOption = APIApplicationCommandOptionWith
 	APIApplicationCommandOptionChoice<number>
 >;
 
-export interface APIApplicationCommandInteractionDataIntegerOption
-	extends APIInteractionDataOptionBase<ApplicationCommandOptionType.Integer, number> {
+export interface APIApplicationCommandInteractionDataIntegerOption<Type extends InteractionType>
+	extends APIInteractionDataOptionBase<
+		ApplicationCommandOptionType.Integer,
+		Type extends InteractionType.ApplicationCommandAutocomplete ? string : number
+	> {
 	focused?: boolean;
 }

--- a/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/integer.ts
+++ b/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/integer.ts
@@ -23,7 +23,7 @@ export type APIApplicationCommandIntegerOption = APIApplicationCommandOptionWith
 	APIApplicationCommandOptionChoice<number>
 >;
 
-export interface APIApplicationCommandInteractionDataIntegerOption<Type extends InteractionType>
+export interface APIApplicationCommandInteractionDataIntegerOption<Type extends InteractionType = InteractionType>
 	extends APIInteractionDataOptionBase<
 		ApplicationCommandOptionType.Integer,
 		Type extends InteractionType.ApplicationCommandAutocomplete ? string : number

--- a/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/number.ts
+++ b/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/number.ts
@@ -23,7 +23,7 @@ export type APIApplicationCommandNumberOption = APIApplicationCommandOptionWithA
 	APIApplicationCommandOptionChoice<number>
 >;
 
-export interface APIApplicationCommandInteractionDataNumberOption<Type extends InteractionType>
+export interface APIApplicationCommandInteractionDataNumberOption<Type extends InteractionType = InteractionType>
 	extends APIInteractionDataOptionBase<
 		ApplicationCommandOptionType.Number,
 		Type extends InteractionType.ApplicationCommandAutocomplete ? string : number

--- a/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/number.ts
+++ b/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/number.ts
@@ -1,3 +1,4 @@
+import type { InteractionType } from '../../responses.ts';
 import type {
 	APIApplicationCommandOptionBase,
 	APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper,
@@ -22,7 +23,10 @@ export type APIApplicationCommandNumberOption = APIApplicationCommandOptionWithA
 	APIApplicationCommandOptionChoice<number>
 >;
 
-export interface APIApplicationCommandInteractionDataNumberOption
-	extends APIInteractionDataOptionBase<ApplicationCommandOptionType.Number, number> {
+export interface APIApplicationCommandInteractionDataNumberOption<Type extends InteractionType>
+	extends APIInteractionDataOptionBase<
+		ApplicationCommandOptionType.Number,
+		Type extends InteractionType.ApplicationCommandAutocomplete ? string : number
+	> {
 	focused?: boolean;
 }

--- a/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/subcommand.ts
+++ b/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/subcommand.ts
@@ -8,7 +8,7 @@ export interface APIApplicationCommandSubcommandOption
 	options?: APIApplicationCommandBasicOption[];
 }
 
-export interface APIApplicationCommandInteractionDataSubcommandOption<Type extends InteractionType> {
+export interface APIApplicationCommandInteractionDataSubcommandOption<Type extends InteractionType = InteractionType> {
 	name: string;
 	type: ApplicationCommandOptionType.Subcommand;
 	options?: APIApplicationCommandInteractionDataBasicOption<Type>[];

--- a/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/subcommand.ts
+++ b/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/subcommand.ts
@@ -1,3 +1,4 @@
+import type { InteractionType } from '../../responses.ts';
 import type { APIApplicationCommandBasicOption, APIApplicationCommandInteractionDataBasicOption } from '../chatInput.ts';
 import type { APIApplicationCommandOptionBase } from './base.ts';
 import type { ApplicationCommandOptionType } from './shared.ts';
@@ -7,8 +8,8 @@ export interface APIApplicationCommandSubcommandOption
 	options?: APIApplicationCommandBasicOption[];
 }
 
-export interface APIApplicationCommandInteractionDataSubcommandOption {
+export interface APIApplicationCommandInteractionDataSubcommandOption<Type extends InteractionType> {
 	name: string;
 	type: ApplicationCommandOptionType.Subcommand;
-	options?: APIApplicationCommandInteractionDataBasicOption[];
+	options?: APIApplicationCommandInteractionDataBasicOption<Type>[];
 }

--- a/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/subcommandGroup.ts
+++ b/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/subcommandGroup.ts
@@ -11,7 +11,9 @@ export interface APIApplicationCommandSubcommandGroupOption
 	options?: APIApplicationCommandSubcommandOption[];
 }
 
-export interface APIApplicationCommandInteractionDataSubcommandGroupOption<Type extends InteractionType> {
+export interface APIApplicationCommandInteractionDataSubcommandGroupOption<
+	Type extends InteractionType = InteractionType,
+> {
 	name: string;
 	type: ApplicationCommandOptionType.SubcommandGroup;
 	options: APIApplicationCommandInteractionDataSubcommandOption<Type>[];

--- a/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/subcommandGroup.ts
+++ b/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/subcommandGroup.ts
@@ -1,3 +1,4 @@
+import type { InteractionType } from '../../responses.ts';
 import type { APIApplicationCommandOptionBase } from './base.ts';
 import type { ApplicationCommandOptionType } from './shared.ts';
 import type {
@@ -10,8 +11,8 @@ export interface APIApplicationCommandSubcommandGroupOption
 	options?: APIApplicationCommandSubcommandOption[];
 }
 
-export interface APIApplicationCommandInteractionDataSubcommandGroupOption {
+export interface APIApplicationCommandInteractionDataSubcommandGroupOption<Type extends InteractionType> {
 	name: string;
 	type: ApplicationCommandOptionType.SubcommandGroup;
-	options: APIApplicationCommandInteractionDataSubcommandOption[];
+	options: APIApplicationCommandInteractionDataSubcommandOption<Type>[];
 }

--- a/deno/payloads/v10/_interactions/_applicationCommands/chatInput.ts
+++ b/deno/payloads/v10/_interactions/_applicationCommands/chatInput.ts
@@ -86,12 +86,12 @@ export type APIApplicationCommandOption =
 /**
  * https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-interaction-data-option-structure
  */
-export type APIApplicationCommandInteractionDataOption<Type extends InteractionType> =
+export type APIApplicationCommandInteractionDataOption<Type extends InteractionType = InteractionType> =
 	| APIApplicationCommandInteractionDataBasicOption<Type>
 	| APIApplicationCommandInteractionDataSubcommandGroupOption<Type>
 	| APIApplicationCommandInteractionDataSubcommandOption<Type>;
 
-export type APIApplicationCommandInteractionDataBasicOption<Type extends InteractionType> =
+export type APIApplicationCommandInteractionDataBasicOption<Type extends InteractionType = InteractionType> =
 	| APIApplicationCommandInteractionDataAttachmentOption
 	| APIApplicationCommandInteractionDataBooleanOption
 	| APIApplicationCommandInteractionDataChannelOption

--- a/deno/payloads/v10/_interactions/_applicationCommands/chatInput.ts
+++ b/deno/payloads/v10/_interactions/_applicationCommands/chatInput.ts
@@ -1,4 +1,4 @@
-import type { APIInteractionDataResolved } from '../../mod.ts';
+import type { APIInteractionDataResolved, InteractionType } from '../../mod.ts';
 import type { APIApplicationCommandInteractionWrapper, ApplicationCommandType } from '../applicationCommands.ts';
 import type { APIDMInteractionWrapper, APIGuildInteractionWrapper } from '../base.ts';
 import type {
@@ -86,18 +86,18 @@ export type APIApplicationCommandOption =
 /**
  * https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-interaction-data-option-structure
  */
-export type APIApplicationCommandInteractionDataOption =
-	| APIApplicationCommandInteractionDataBasicOption
-	| APIApplicationCommandInteractionDataSubcommandGroupOption
-	| APIApplicationCommandInteractionDataSubcommandOption;
+export type APIApplicationCommandInteractionDataOption<Type extends InteractionType> =
+	| APIApplicationCommandInteractionDataBasicOption<Type>
+	| APIApplicationCommandInteractionDataSubcommandGroupOption<Type>
+	| APIApplicationCommandInteractionDataSubcommandOption<Type>;
 
-export type APIApplicationCommandInteractionDataBasicOption =
+export type APIApplicationCommandInteractionDataBasicOption<Type extends InteractionType> =
 	| APIApplicationCommandInteractionDataAttachmentOption
 	| APIApplicationCommandInteractionDataBooleanOption
 	| APIApplicationCommandInteractionDataChannelOption
-	| APIApplicationCommandInteractionDataIntegerOption
+	| APIApplicationCommandInteractionDataIntegerOption<Type>
 	| APIApplicationCommandInteractionDataMentionableOption
-	| APIApplicationCommandInteractionDataNumberOption
+	| APIApplicationCommandInteractionDataNumberOption<Type>
 	| APIApplicationCommandInteractionDataRoleOption
 	| APIApplicationCommandInteractionDataStringOption
 	| APIApplicationCommandInteractionDataUserOption;
@@ -107,7 +107,16 @@ export type APIApplicationCommandInteractionDataBasicOption =
  */
 export interface APIChatInputApplicationCommandInteractionData
 	extends APIBaseApplicationCommandInteractionData<ApplicationCommandType.ChatInput> {
-	options?: APIApplicationCommandInteractionDataOption[];
+	options?: APIApplicationCommandInteractionDataOption<InteractionType.ApplicationCommand>[];
+	resolved?: APIInteractionDataResolved;
+}
+
+/**
+ * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data
+ */
+export interface APIAutocompleteApplicationCommandInteractionData
+	extends APIBaseApplicationCommandInteractionData<ApplicationCommandType.ChatInput> {
+	options?: APIApplicationCommandInteractionDataOption<InteractionType.ApplicationCommandAutocomplete>[];
 	resolved?: APIInteractionDataResolved;
 }
 

--- a/deno/payloads/v10/_interactions/autocomplete.ts
+++ b/deno/payloads/v10/_interactions/autocomplete.ts
@@ -1,6 +1,6 @@
 import type {
 	APIBaseInteraction,
-	APIChatInputApplicationCommandInteractionData,
+	APIAutocompleteApplicationCommandInteractionData,
 	APIDMInteractionWrapper,
 	APIGuildInteractionWrapper,
 	InteractionType,
@@ -8,13 +8,13 @@ import type {
 
 export type APIApplicationCommandAutocompleteInteraction = APIBaseInteraction<
 	InteractionType.ApplicationCommandAutocomplete,
-	APIChatInputApplicationCommandInteractionData
+	APIAutocompleteApplicationCommandInteractionData
 > &
 	Required<
 		Pick<
 			APIBaseInteraction<
 				InteractionType.ApplicationCommandAutocomplete,
-				Required<Pick<APIChatInputApplicationCommandInteractionData, 'options'>>
+				Required<Pick<APIAutocompleteApplicationCommandInteractionData, 'options'>>
 			>,
 			'data'
 		>

--- a/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/integer.ts
+++ b/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/integer.ts
@@ -1,3 +1,4 @@
+import type { InteractionType } from '../../responses.ts';
 import type {
 	APIApplicationCommandOptionBase,
 	APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper,
@@ -22,7 +23,10 @@ export type APIApplicationCommandIntegerOption = APIApplicationCommandOptionWith
 	APIApplicationCommandOptionChoice<number>
 >;
 
-export interface APIApplicationCommandInteractionDataIntegerOption
-	extends APIInteractionDataOptionBase<ApplicationCommandOptionType.Integer, number> {
+export interface APIApplicationCommandInteractionDataIntegerOption<Type extends InteractionType>
+	extends APIInteractionDataOptionBase<
+		ApplicationCommandOptionType.Integer,
+		Type extends InteractionType.ApplicationCommandAutocomplete ? string : number
+	> {
 	focused?: boolean;
 }

--- a/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/integer.ts
+++ b/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/integer.ts
@@ -23,7 +23,7 @@ export type APIApplicationCommandIntegerOption = APIApplicationCommandOptionWith
 	APIApplicationCommandOptionChoice<number>
 >;
 
-export interface APIApplicationCommandInteractionDataIntegerOption<Type extends InteractionType>
+export interface APIApplicationCommandInteractionDataIntegerOption<Type extends InteractionType = InteractionType>
 	extends APIInteractionDataOptionBase<
 		ApplicationCommandOptionType.Integer,
 		Type extends InteractionType.ApplicationCommandAutocomplete ? string : number

--- a/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/number.ts
+++ b/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/number.ts
@@ -23,7 +23,7 @@ export type APIApplicationCommandNumberOption = APIApplicationCommandOptionWithA
 	APIApplicationCommandOptionChoice<number>
 >;
 
-export interface APIApplicationCommandInteractionDataNumberOption<Type extends InteractionType>
+export interface APIApplicationCommandInteractionDataNumberOption<Type extends InteractionType = InteractionType>
 	extends APIInteractionDataOptionBase<
 		ApplicationCommandOptionType.Number,
 		Type extends InteractionType.ApplicationCommandAutocomplete ? string : number

--- a/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/number.ts
+++ b/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/number.ts
@@ -1,3 +1,4 @@
+import type { InteractionType } from '../../responses.ts';
 import type {
 	APIApplicationCommandOptionBase,
 	APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper,
@@ -22,7 +23,10 @@ export type APIApplicationCommandNumberOption = APIApplicationCommandOptionWithA
 	APIApplicationCommandOptionChoice<number>
 >;
 
-export interface APIApplicationCommandInteractionDataNumberOption
-	extends APIInteractionDataOptionBase<ApplicationCommandOptionType.Number, number> {
+export interface APIApplicationCommandInteractionDataNumberOption<Type extends InteractionType>
+	extends APIInteractionDataOptionBase<
+		ApplicationCommandOptionType.Number,
+		Type extends InteractionType.ApplicationCommandAutocomplete ? string : number
+	> {
 	focused?: boolean;
 }

--- a/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/subcommand.ts
+++ b/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/subcommand.ts
@@ -8,7 +8,7 @@ export interface APIApplicationCommandSubcommandOption
 	options?: APIApplicationCommandBasicOption[];
 }
 
-export interface APIApplicationCommandInteractionDataSubcommandOption<Type extends InteractionType> {
+export interface APIApplicationCommandInteractionDataSubcommandOption<Type extends InteractionType = InteractionType> {
 	name: string;
 	type: ApplicationCommandOptionType.Subcommand;
 	options?: APIApplicationCommandInteractionDataBasicOption<Type>[];

--- a/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/subcommand.ts
+++ b/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/subcommand.ts
@@ -1,3 +1,4 @@
+import type { InteractionType } from '../../responses.ts';
 import type { APIApplicationCommandBasicOption, APIApplicationCommandInteractionDataBasicOption } from '../chatInput.ts';
 import type { APIApplicationCommandOptionBase } from './base.ts';
 import type { ApplicationCommandOptionType } from './shared.ts';
@@ -7,8 +8,8 @@ export interface APIApplicationCommandSubcommandOption
 	options?: APIApplicationCommandBasicOption[];
 }
 
-export interface APIApplicationCommandInteractionDataSubcommandOption {
+export interface APIApplicationCommandInteractionDataSubcommandOption<Type extends InteractionType> {
 	name: string;
 	type: ApplicationCommandOptionType.Subcommand;
-	options?: APIApplicationCommandInteractionDataBasicOption[];
+	options?: APIApplicationCommandInteractionDataBasicOption<Type>[];
 }

--- a/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/subcommandGroup.ts
+++ b/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/subcommandGroup.ts
@@ -11,7 +11,9 @@ export interface APIApplicationCommandSubcommandGroupOption
 	options?: APIApplicationCommandSubcommandOption[];
 }
 
-export interface APIApplicationCommandInteractionDataSubcommandGroupOption<Type extends InteractionType> {
+export interface APIApplicationCommandInteractionDataSubcommandGroupOption<
+	Type extends InteractionType = InteractionType,
+> {
 	name: string;
 	type: ApplicationCommandOptionType.SubcommandGroup;
 	options: APIApplicationCommandInteractionDataSubcommandOption<Type>[];

--- a/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/subcommandGroup.ts
+++ b/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/subcommandGroup.ts
@@ -1,3 +1,4 @@
+import type { InteractionType } from '../../responses.ts';
 import type { APIApplicationCommandOptionBase } from './base.ts';
 import type { ApplicationCommandOptionType } from './shared.ts';
 import type {
@@ -10,8 +11,8 @@ export interface APIApplicationCommandSubcommandGroupOption
 	options?: APIApplicationCommandSubcommandOption[];
 }
 
-export interface APIApplicationCommandInteractionDataSubcommandGroupOption {
+export interface APIApplicationCommandInteractionDataSubcommandGroupOption<Type extends InteractionType> {
 	name: string;
 	type: ApplicationCommandOptionType.SubcommandGroup;
-	options: APIApplicationCommandInteractionDataSubcommandOption[];
+	options: APIApplicationCommandInteractionDataSubcommandOption<Type>[];
 }

--- a/deno/payloads/v9/_interactions/_applicationCommands/chatInput.ts
+++ b/deno/payloads/v9/_interactions/_applicationCommands/chatInput.ts
@@ -86,12 +86,12 @@ export type APIApplicationCommandOption =
 /**
  * https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-interaction-data-option-structure
  */
-export type APIApplicationCommandInteractionDataOption<Type extends InteractionType> =
+export type APIApplicationCommandInteractionDataOption<Type extends InteractionType = InteractionType> =
 	| APIApplicationCommandInteractionDataBasicOption<Type>
 	| APIApplicationCommandInteractionDataSubcommandGroupOption<Type>
 	| APIApplicationCommandInteractionDataSubcommandOption<Type>;
 
-export type APIApplicationCommandInteractionDataBasicOption<Type extends InteractionType> =
+export type APIApplicationCommandInteractionDataBasicOption<Type extends InteractionType = InteractionType> =
 	| APIApplicationCommandInteractionDataAttachmentOption
 	| APIApplicationCommandInteractionDataBooleanOption
 	| APIApplicationCommandInteractionDataChannelOption

--- a/deno/payloads/v9/_interactions/_applicationCommands/chatInput.ts
+++ b/deno/payloads/v9/_interactions/_applicationCommands/chatInput.ts
@@ -1,4 +1,4 @@
-import type { APIInteractionDataResolved } from '../../mod.ts';
+import type { APIInteractionDataResolved, InteractionType } from '../../mod.ts';
 import type { APIApplicationCommandInteractionWrapper, ApplicationCommandType } from '../applicationCommands.ts';
 import type { APIDMInteractionWrapper, APIGuildInteractionWrapper } from '../base.ts';
 import type {
@@ -86,18 +86,18 @@ export type APIApplicationCommandOption =
 /**
  * https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-interaction-data-option-structure
  */
-export type APIApplicationCommandInteractionDataOption =
-	| APIApplicationCommandInteractionDataBasicOption
-	| APIApplicationCommandInteractionDataSubcommandGroupOption
-	| APIApplicationCommandInteractionDataSubcommandOption;
+export type APIApplicationCommandInteractionDataOption<Type extends InteractionType> =
+	| APIApplicationCommandInteractionDataBasicOption<Type>
+	| APIApplicationCommandInteractionDataSubcommandGroupOption<Type>
+	| APIApplicationCommandInteractionDataSubcommandOption<Type>;
 
-export type APIApplicationCommandInteractionDataBasicOption =
+export type APIApplicationCommandInteractionDataBasicOption<Type extends InteractionType> =
 	| APIApplicationCommandInteractionDataAttachmentOption
 	| APIApplicationCommandInteractionDataBooleanOption
 	| APIApplicationCommandInteractionDataChannelOption
-	| APIApplicationCommandInteractionDataIntegerOption
+	| APIApplicationCommandInteractionDataIntegerOption<Type>
 	| APIApplicationCommandInteractionDataMentionableOption
-	| APIApplicationCommandInteractionDataNumberOption
+	| APIApplicationCommandInteractionDataNumberOption<Type>
 	| APIApplicationCommandInteractionDataRoleOption
 	| APIApplicationCommandInteractionDataStringOption
 	| APIApplicationCommandInteractionDataUserOption;
@@ -107,7 +107,16 @@ export type APIApplicationCommandInteractionDataBasicOption =
  */
 export interface APIChatInputApplicationCommandInteractionData
 	extends APIBaseApplicationCommandInteractionData<ApplicationCommandType.ChatInput> {
-	options?: APIApplicationCommandInteractionDataOption[];
+	options?: APIApplicationCommandInteractionDataOption<InteractionType.ApplicationCommand>[];
+	resolved?: APIInteractionDataResolved;
+}
+
+/**
+ * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data
+ */
+export interface APIAutocompleteApplicationCommandInteractionData
+	extends APIBaseApplicationCommandInteractionData<ApplicationCommandType.ChatInput> {
+	options?: APIApplicationCommandInteractionDataOption<InteractionType.ApplicationCommandAutocomplete>[];
 	resolved?: APIInteractionDataResolved;
 }
 

--- a/deno/payloads/v9/_interactions/autocomplete.ts
+++ b/deno/payloads/v9/_interactions/autocomplete.ts
@@ -1,6 +1,6 @@
 import type {
 	APIBaseInteraction,
-	APIChatInputApplicationCommandInteractionData,
+	APIAutocompleteApplicationCommandInteractionData,
 	APIDMInteractionWrapper,
 	APIGuildInteractionWrapper,
 	InteractionType,
@@ -8,13 +8,13 @@ import type {
 
 export type APIApplicationCommandAutocompleteInteraction = APIBaseInteraction<
 	InteractionType.ApplicationCommandAutocomplete,
-	APIChatInputApplicationCommandInteractionData
+	APIAutocompleteApplicationCommandInteractionData
 > &
 	Required<
 		Pick<
 			APIBaseInteraction<
 				InteractionType.ApplicationCommandAutocomplete,
-				Required<Pick<APIChatInputApplicationCommandInteractionData, 'options'>>
+				Required<Pick<APIAutocompleteApplicationCommandInteractionData, 'options'>>
 			>,
 			'data'
 		>

--- a/payloads/v10/_interactions/_applicationCommands/_chatInput/integer.ts
+++ b/payloads/v10/_interactions/_applicationCommands/_chatInput/integer.ts
@@ -1,3 +1,4 @@
+import type { InteractionType } from '../../responses';
 import type {
 	APIApplicationCommandOptionBase,
 	APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper,
@@ -22,7 +23,10 @@ export type APIApplicationCommandIntegerOption = APIApplicationCommandOptionWith
 	APIApplicationCommandOptionChoice<number>
 >;
 
-export interface APIApplicationCommandInteractionDataIntegerOption
-	extends APIInteractionDataOptionBase<ApplicationCommandOptionType.Integer, number> {
+export interface APIApplicationCommandInteractionDataIntegerOption<Type extends InteractionType>
+	extends APIInteractionDataOptionBase<
+		ApplicationCommandOptionType.Integer,
+		Type extends InteractionType.ApplicationCommandAutocomplete ? string : number
+	> {
 	focused?: boolean;
 }

--- a/payloads/v10/_interactions/_applicationCommands/_chatInput/integer.ts
+++ b/payloads/v10/_interactions/_applicationCommands/_chatInput/integer.ts
@@ -23,7 +23,7 @@ export type APIApplicationCommandIntegerOption = APIApplicationCommandOptionWith
 	APIApplicationCommandOptionChoice<number>
 >;
 
-export interface APIApplicationCommandInteractionDataIntegerOption<Type extends InteractionType>
+export interface APIApplicationCommandInteractionDataIntegerOption<Type extends InteractionType = InteractionType>
 	extends APIInteractionDataOptionBase<
 		ApplicationCommandOptionType.Integer,
 		Type extends InteractionType.ApplicationCommandAutocomplete ? string : number

--- a/payloads/v10/_interactions/_applicationCommands/_chatInput/number.ts
+++ b/payloads/v10/_interactions/_applicationCommands/_chatInput/number.ts
@@ -1,3 +1,4 @@
+import type { InteractionType } from '../../responses';
 import type {
 	APIApplicationCommandOptionBase,
 	APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper,
@@ -22,7 +23,10 @@ export type APIApplicationCommandNumberOption = APIApplicationCommandOptionWithA
 	APIApplicationCommandOptionChoice<number>
 >;
 
-export interface APIApplicationCommandInteractionDataNumberOption
-	extends APIInteractionDataOptionBase<ApplicationCommandOptionType.Number, number> {
+export interface APIApplicationCommandInteractionDataNumberOption<Type extends InteractionType>
+	extends APIInteractionDataOptionBase<
+		ApplicationCommandOptionType.Number,
+		Type extends InteractionType.ApplicationCommandAutocomplete ? string : number
+	> {
 	focused?: boolean;
 }

--- a/payloads/v10/_interactions/_applicationCommands/_chatInput/number.ts
+++ b/payloads/v10/_interactions/_applicationCommands/_chatInput/number.ts
@@ -23,7 +23,7 @@ export type APIApplicationCommandNumberOption = APIApplicationCommandOptionWithA
 	APIApplicationCommandOptionChoice<number>
 >;
 
-export interface APIApplicationCommandInteractionDataNumberOption<Type extends InteractionType>
+export interface APIApplicationCommandInteractionDataNumberOption<Type extends InteractionType = InteractionType>
 	extends APIInteractionDataOptionBase<
 		ApplicationCommandOptionType.Number,
 		Type extends InteractionType.ApplicationCommandAutocomplete ? string : number

--- a/payloads/v10/_interactions/_applicationCommands/_chatInput/subcommand.ts
+++ b/payloads/v10/_interactions/_applicationCommands/_chatInput/subcommand.ts
@@ -8,7 +8,7 @@ export interface APIApplicationCommandSubcommandOption
 	options?: APIApplicationCommandBasicOption[];
 }
 
-export interface APIApplicationCommandInteractionDataSubcommandOption<Type extends InteractionType> {
+export interface APIApplicationCommandInteractionDataSubcommandOption<Type extends InteractionType = InteractionType> {
 	name: string;
 	type: ApplicationCommandOptionType.Subcommand;
 	options?: APIApplicationCommandInteractionDataBasicOption<Type>[];

--- a/payloads/v10/_interactions/_applicationCommands/_chatInput/subcommand.ts
+++ b/payloads/v10/_interactions/_applicationCommands/_chatInput/subcommand.ts
@@ -1,3 +1,4 @@
+import type { InteractionType } from '../../responses';
 import type { APIApplicationCommandBasicOption, APIApplicationCommandInteractionDataBasicOption } from '../chatInput';
 import type { APIApplicationCommandOptionBase } from './base';
 import type { ApplicationCommandOptionType } from './shared';
@@ -7,8 +8,8 @@ export interface APIApplicationCommandSubcommandOption
 	options?: APIApplicationCommandBasicOption[];
 }
 
-export interface APIApplicationCommandInteractionDataSubcommandOption {
+export interface APIApplicationCommandInteractionDataSubcommandOption<Type extends InteractionType> {
 	name: string;
 	type: ApplicationCommandOptionType.Subcommand;
-	options?: APIApplicationCommandInteractionDataBasicOption[];
+	options?: APIApplicationCommandInteractionDataBasicOption<Type>[];
 }

--- a/payloads/v10/_interactions/_applicationCommands/_chatInput/subcommandGroup.ts
+++ b/payloads/v10/_interactions/_applicationCommands/_chatInput/subcommandGroup.ts
@@ -1,3 +1,4 @@
+import type { InteractionType } from '../../responses';
 import type { APIApplicationCommandOptionBase } from './base';
 import type { ApplicationCommandOptionType } from './shared';
 import type {
@@ -10,8 +11,8 @@ export interface APIApplicationCommandSubcommandGroupOption
 	options?: APIApplicationCommandSubcommandOption[];
 }
 
-export interface APIApplicationCommandInteractionDataSubcommandGroupOption {
+export interface APIApplicationCommandInteractionDataSubcommandGroupOption<Type extends InteractionType> {
 	name: string;
 	type: ApplicationCommandOptionType.SubcommandGroup;
-	options: APIApplicationCommandInteractionDataSubcommandOption[];
+	options: APIApplicationCommandInteractionDataSubcommandOption<Type>[];
 }

--- a/payloads/v10/_interactions/_applicationCommands/_chatInput/subcommandGroup.ts
+++ b/payloads/v10/_interactions/_applicationCommands/_chatInput/subcommandGroup.ts
@@ -11,7 +11,9 @@ export interface APIApplicationCommandSubcommandGroupOption
 	options?: APIApplicationCommandSubcommandOption[];
 }
 
-export interface APIApplicationCommandInteractionDataSubcommandGroupOption<Type extends InteractionType> {
+export interface APIApplicationCommandInteractionDataSubcommandGroupOption<
+	Type extends InteractionType = InteractionType,
+> {
 	name: string;
 	type: ApplicationCommandOptionType.SubcommandGroup;
 	options: APIApplicationCommandInteractionDataSubcommandOption<Type>[];

--- a/payloads/v10/_interactions/_applicationCommands/chatInput.ts
+++ b/payloads/v10/_interactions/_applicationCommands/chatInput.ts
@@ -1,4 +1,4 @@
-import type { APIInteractionDataResolved } from '../../index';
+import type { APIInteractionDataResolved, InteractionType } from '../../index';
 import type { APIApplicationCommandInteractionWrapper, ApplicationCommandType } from '../applicationCommands';
 import type { APIDMInteractionWrapper, APIGuildInteractionWrapper } from '../base';
 import type {
@@ -86,18 +86,18 @@ export type APIApplicationCommandOption =
 /**
  * https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-interaction-data-option-structure
  */
-export type APIApplicationCommandInteractionDataOption =
-	| APIApplicationCommandInteractionDataBasicOption
-	| APIApplicationCommandInteractionDataSubcommandGroupOption
-	| APIApplicationCommandInteractionDataSubcommandOption;
+export type APIApplicationCommandInteractionDataOption<Type extends InteractionType> =
+	| APIApplicationCommandInteractionDataBasicOption<Type>
+	| APIApplicationCommandInteractionDataSubcommandGroupOption<Type>
+	| APIApplicationCommandInteractionDataSubcommandOption<Type>;
 
-export type APIApplicationCommandInteractionDataBasicOption =
+export type APIApplicationCommandInteractionDataBasicOption<Type extends InteractionType> =
 	| APIApplicationCommandInteractionDataAttachmentOption
 	| APIApplicationCommandInteractionDataBooleanOption
 	| APIApplicationCommandInteractionDataChannelOption
-	| APIApplicationCommandInteractionDataIntegerOption
+	| APIApplicationCommandInteractionDataIntegerOption<Type>
 	| APIApplicationCommandInteractionDataMentionableOption
-	| APIApplicationCommandInteractionDataNumberOption
+	| APIApplicationCommandInteractionDataNumberOption<Type>
 	| APIApplicationCommandInteractionDataRoleOption
 	| APIApplicationCommandInteractionDataStringOption
 	| APIApplicationCommandInteractionDataUserOption;
@@ -107,7 +107,16 @@ export type APIApplicationCommandInteractionDataBasicOption =
  */
 export interface APIChatInputApplicationCommandInteractionData
 	extends APIBaseApplicationCommandInteractionData<ApplicationCommandType.ChatInput> {
-	options?: APIApplicationCommandInteractionDataOption[];
+	options?: APIApplicationCommandInteractionDataOption<InteractionType.ApplicationCommand>[];
+	resolved?: APIInteractionDataResolved;
+}
+
+/**
+ * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data
+ */
+export interface APIAutocompleteApplicationCommandInteractionData
+	extends APIBaseApplicationCommandInteractionData<ApplicationCommandType.ChatInput> {
+	options?: APIApplicationCommandInteractionDataOption<InteractionType.ApplicationCommandAutocomplete>[];
 	resolved?: APIInteractionDataResolved;
 }
 

--- a/payloads/v10/_interactions/_applicationCommands/chatInput.ts
+++ b/payloads/v10/_interactions/_applicationCommands/chatInput.ts
@@ -86,12 +86,12 @@ export type APIApplicationCommandOption =
 /**
  * https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-interaction-data-option-structure
  */
-export type APIApplicationCommandInteractionDataOption<Type extends InteractionType> =
+export type APIApplicationCommandInteractionDataOption<Type extends InteractionType = InteractionType> =
 	| APIApplicationCommandInteractionDataBasicOption<Type>
 	| APIApplicationCommandInteractionDataSubcommandGroupOption<Type>
 	| APIApplicationCommandInteractionDataSubcommandOption<Type>;
 
-export type APIApplicationCommandInteractionDataBasicOption<Type extends InteractionType> =
+export type APIApplicationCommandInteractionDataBasicOption<Type extends InteractionType = InteractionType> =
 	| APIApplicationCommandInteractionDataAttachmentOption
 	| APIApplicationCommandInteractionDataBooleanOption
 	| APIApplicationCommandInteractionDataChannelOption

--- a/payloads/v10/_interactions/autocomplete.ts
+++ b/payloads/v10/_interactions/autocomplete.ts
@@ -1,6 +1,6 @@
 import type {
 	APIBaseInteraction,
-	APIChatInputApplicationCommandInteractionData,
+	APIAutocompleteApplicationCommandInteractionData,
 	APIDMInteractionWrapper,
 	APIGuildInteractionWrapper,
 	InteractionType,
@@ -8,13 +8,13 @@ import type {
 
 export type APIApplicationCommandAutocompleteInteraction = APIBaseInteraction<
 	InteractionType.ApplicationCommandAutocomplete,
-	APIChatInputApplicationCommandInteractionData
+	APIAutocompleteApplicationCommandInteractionData
 > &
 	Required<
 		Pick<
 			APIBaseInteraction<
 				InteractionType.ApplicationCommandAutocomplete,
-				Required<Pick<APIChatInputApplicationCommandInteractionData, 'options'>>
+				Required<Pick<APIAutocompleteApplicationCommandInteractionData, 'options'>>
 			>,
 			'data'
 		>

--- a/payloads/v9/_interactions/_applicationCommands/_chatInput/integer.ts
+++ b/payloads/v9/_interactions/_applicationCommands/_chatInput/integer.ts
@@ -1,3 +1,4 @@
+import type { InteractionType } from '../../responses';
 import type {
 	APIApplicationCommandOptionBase,
 	APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper,
@@ -22,7 +23,10 @@ export type APIApplicationCommandIntegerOption = APIApplicationCommandOptionWith
 	APIApplicationCommandOptionChoice<number>
 >;
 
-export interface APIApplicationCommandInteractionDataIntegerOption
-	extends APIInteractionDataOptionBase<ApplicationCommandOptionType.Integer, number> {
+export interface APIApplicationCommandInteractionDataIntegerOption<Type extends InteractionType>
+	extends APIInteractionDataOptionBase<
+		ApplicationCommandOptionType.Integer,
+		Type extends InteractionType.ApplicationCommandAutocomplete ? string : number
+	> {
 	focused?: boolean;
 }

--- a/payloads/v9/_interactions/_applicationCommands/_chatInput/integer.ts
+++ b/payloads/v9/_interactions/_applicationCommands/_chatInput/integer.ts
@@ -23,7 +23,7 @@ export type APIApplicationCommandIntegerOption = APIApplicationCommandOptionWith
 	APIApplicationCommandOptionChoice<number>
 >;
 
-export interface APIApplicationCommandInteractionDataIntegerOption<Type extends InteractionType>
+export interface APIApplicationCommandInteractionDataIntegerOption<Type extends InteractionType = InteractionType>
 	extends APIInteractionDataOptionBase<
 		ApplicationCommandOptionType.Integer,
 		Type extends InteractionType.ApplicationCommandAutocomplete ? string : number

--- a/payloads/v9/_interactions/_applicationCommands/_chatInput/number.ts
+++ b/payloads/v9/_interactions/_applicationCommands/_chatInput/number.ts
@@ -1,3 +1,4 @@
+import type { InteractionType } from '../../responses';
 import type {
 	APIApplicationCommandOptionBase,
 	APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper,
@@ -22,7 +23,10 @@ export type APIApplicationCommandNumberOption = APIApplicationCommandOptionWithA
 	APIApplicationCommandOptionChoice<number>
 >;
 
-export interface APIApplicationCommandInteractionDataNumberOption
-	extends APIInteractionDataOptionBase<ApplicationCommandOptionType.Number, number> {
+export interface APIApplicationCommandInteractionDataNumberOption<Type extends InteractionType>
+	extends APIInteractionDataOptionBase<
+		ApplicationCommandOptionType.Number,
+		Type extends InteractionType.ApplicationCommandAutocomplete ? string : number
+	> {
 	focused?: boolean;
 }

--- a/payloads/v9/_interactions/_applicationCommands/_chatInput/number.ts
+++ b/payloads/v9/_interactions/_applicationCommands/_chatInput/number.ts
@@ -23,7 +23,7 @@ export type APIApplicationCommandNumberOption = APIApplicationCommandOptionWithA
 	APIApplicationCommandOptionChoice<number>
 >;
 
-export interface APIApplicationCommandInteractionDataNumberOption<Type extends InteractionType>
+export interface APIApplicationCommandInteractionDataNumberOption<Type extends InteractionType = InteractionType>
 	extends APIInteractionDataOptionBase<
 		ApplicationCommandOptionType.Number,
 		Type extends InteractionType.ApplicationCommandAutocomplete ? string : number

--- a/payloads/v9/_interactions/_applicationCommands/_chatInput/subcommand.ts
+++ b/payloads/v9/_interactions/_applicationCommands/_chatInput/subcommand.ts
@@ -8,7 +8,7 @@ export interface APIApplicationCommandSubcommandOption
 	options?: APIApplicationCommandBasicOption[];
 }
 
-export interface APIApplicationCommandInteractionDataSubcommandOption<Type extends InteractionType> {
+export interface APIApplicationCommandInteractionDataSubcommandOption<Type extends InteractionType = InteractionType> {
 	name: string;
 	type: ApplicationCommandOptionType.Subcommand;
 	options?: APIApplicationCommandInteractionDataBasicOption<Type>[];

--- a/payloads/v9/_interactions/_applicationCommands/_chatInput/subcommand.ts
+++ b/payloads/v9/_interactions/_applicationCommands/_chatInput/subcommand.ts
@@ -1,3 +1,4 @@
+import type { InteractionType } from '../../responses';
 import type { APIApplicationCommandBasicOption, APIApplicationCommandInteractionDataBasicOption } from '../chatInput';
 import type { APIApplicationCommandOptionBase } from './base';
 import type { ApplicationCommandOptionType } from './shared';
@@ -7,8 +8,8 @@ export interface APIApplicationCommandSubcommandOption
 	options?: APIApplicationCommandBasicOption[];
 }
 
-export interface APIApplicationCommandInteractionDataSubcommandOption {
+export interface APIApplicationCommandInteractionDataSubcommandOption<Type extends InteractionType> {
 	name: string;
 	type: ApplicationCommandOptionType.Subcommand;
-	options?: APIApplicationCommandInteractionDataBasicOption[];
+	options?: APIApplicationCommandInteractionDataBasicOption<Type>[];
 }

--- a/payloads/v9/_interactions/_applicationCommands/_chatInput/subcommandGroup.ts
+++ b/payloads/v9/_interactions/_applicationCommands/_chatInput/subcommandGroup.ts
@@ -1,3 +1,4 @@
+import type { InteractionType } from '../../responses';
 import type { APIApplicationCommandOptionBase } from './base';
 import type { ApplicationCommandOptionType } from './shared';
 import type {
@@ -10,8 +11,8 @@ export interface APIApplicationCommandSubcommandGroupOption
 	options?: APIApplicationCommandSubcommandOption[];
 }
 
-export interface APIApplicationCommandInteractionDataSubcommandGroupOption {
+export interface APIApplicationCommandInteractionDataSubcommandGroupOption<Type extends InteractionType> {
 	name: string;
 	type: ApplicationCommandOptionType.SubcommandGroup;
-	options: APIApplicationCommandInteractionDataSubcommandOption[];
+	options: APIApplicationCommandInteractionDataSubcommandOption<Type>[];
 }

--- a/payloads/v9/_interactions/_applicationCommands/_chatInput/subcommandGroup.ts
+++ b/payloads/v9/_interactions/_applicationCommands/_chatInput/subcommandGroup.ts
@@ -11,7 +11,9 @@ export interface APIApplicationCommandSubcommandGroupOption
 	options?: APIApplicationCommandSubcommandOption[];
 }
 
-export interface APIApplicationCommandInteractionDataSubcommandGroupOption<Type extends InteractionType> {
+export interface APIApplicationCommandInteractionDataSubcommandGroupOption<
+	Type extends InteractionType = InteractionType,
+> {
 	name: string;
 	type: ApplicationCommandOptionType.SubcommandGroup;
 	options: APIApplicationCommandInteractionDataSubcommandOption<Type>[];

--- a/payloads/v9/_interactions/_applicationCommands/chatInput.ts
+++ b/payloads/v9/_interactions/_applicationCommands/chatInput.ts
@@ -1,4 +1,4 @@
-import type { APIInteractionDataResolved } from '../../index';
+import type { APIInteractionDataResolved, InteractionType } from '../../index';
 import type { APIApplicationCommandInteractionWrapper, ApplicationCommandType } from '../applicationCommands';
 import type { APIDMInteractionWrapper, APIGuildInteractionWrapper } from '../base';
 import type {
@@ -86,18 +86,18 @@ export type APIApplicationCommandOption =
 /**
  * https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-interaction-data-option-structure
  */
-export type APIApplicationCommandInteractionDataOption =
-	| APIApplicationCommandInteractionDataBasicOption
-	| APIApplicationCommandInteractionDataSubcommandGroupOption
-	| APIApplicationCommandInteractionDataSubcommandOption;
+export type APIApplicationCommandInteractionDataOption<Type extends InteractionType> =
+	| APIApplicationCommandInteractionDataBasicOption<Type>
+	| APIApplicationCommandInteractionDataSubcommandGroupOption<Type>
+	| APIApplicationCommandInteractionDataSubcommandOption<Type>;
 
-export type APIApplicationCommandInteractionDataBasicOption =
+export type APIApplicationCommandInteractionDataBasicOption<Type extends InteractionType> =
 	| APIApplicationCommandInteractionDataAttachmentOption
 	| APIApplicationCommandInteractionDataBooleanOption
 	| APIApplicationCommandInteractionDataChannelOption
-	| APIApplicationCommandInteractionDataIntegerOption
+	| APIApplicationCommandInteractionDataIntegerOption<Type>
 	| APIApplicationCommandInteractionDataMentionableOption
-	| APIApplicationCommandInteractionDataNumberOption
+	| APIApplicationCommandInteractionDataNumberOption<Type>
 	| APIApplicationCommandInteractionDataRoleOption
 	| APIApplicationCommandInteractionDataStringOption
 	| APIApplicationCommandInteractionDataUserOption;
@@ -107,7 +107,16 @@ export type APIApplicationCommandInteractionDataBasicOption =
  */
 export interface APIChatInputApplicationCommandInteractionData
 	extends APIBaseApplicationCommandInteractionData<ApplicationCommandType.ChatInput> {
-	options?: APIApplicationCommandInteractionDataOption[];
+	options?: APIApplicationCommandInteractionDataOption<InteractionType.ApplicationCommand>[];
+	resolved?: APIInteractionDataResolved;
+}
+
+/**
+ * https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data
+ */
+export interface APIAutocompleteApplicationCommandInteractionData
+	extends APIBaseApplicationCommandInteractionData<ApplicationCommandType.ChatInput> {
+	options?: APIApplicationCommandInteractionDataOption<InteractionType.ApplicationCommandAutocomplete>[];
 	resolved?: APIInteractionDataResolved;
 }
 

--- a/payloads/v9/_interactions/_applicationCommands/chatInput.ts
+++ b/payloads/v9/_interactions/_applicationCommands/chatInput.ts
@@ -86,12 +86,12 @@ export type APIApplicationCommandOption =
 /**
  * https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-interaction-data-option-structure
  */
-export type APIApplicationCommandInteractionDataOption<Type extends InteractionType> =
+export type APIApplicationCommandInteractionDataOption<Type extends InteractionType = InteractionType> =
 	| APIApplicationCommandInteractionDataBasicOption<Type>
 	| APIApplicationCommandInteractionDataSubcommandGroupOption<Type>
 	| APIApplicationCommandInteractionDataSubcommandOption<Type>;
 
-export type APIApplicationCommandInteractionDataBasicOption<Type extends InteractionType> =
+export type APIApplicationCommandInteractionDataBasicOption<Type extends InteractionType = InteractionType> =
 	| APIApplicationCommandInteractionDataAttachmentOption
 	| APIApplicationCommandInteractionDataBooleanOption
 	| APIApplicationCommandInteractionDataChannelOption

--- a/payloads/v9/_interactions/autocomplete.ts
+++ b/payloads/v9/_interactions/autocomplete.ts
@@ -1,6 +1,6 @@
 import type {
 	APIBaseInteraction,
-	APIChatInputApplicationCommandInteractionData,
+	APIAutocompleteApplicationCommandInteractionData,
 	APIDMInteractionWrapper,
 	APIGuildInteractionWrapper,
 	InteractionType,
@@ -8,13 +8,13 @@ import type {
 
 export type APIApplicationCommandAutocompleteInteraction = APIBaseInteraction<
 	InteractionType.ApplicationCommandAutocomplete,
-	APIChatInputApplicationCommandInteractionData
+	APIAutocompleteApplicationCommandInteractionData
 > &
 	Required<
 		Pick<
 			APIBaseInteraction<
 				InteractionType.ApplicationCommandAutocomplete,
-				Required<Pick<APIChatInputApplicationCommandInteractionData, 'options'>>
+				Required<Pick<APIAutocompleteApplicationCommandInteractionData, 'options'>>
 			>,
 			'data'
 		>

--- a/tests/v10/interactions.ts
+++ b/tests/v10/interactions.ts
@@ -13,7 +13,7 @@ import type {
 	APIModalSubmission,
 	APIUser,
 } from '../../v10';
-import { ComponentType, InteractionType } from '../../v10';
+import { ApplicationCommandOptionType, ApplicationCommandType, ComponentType, InteractionType } from '../../v10';
 import { expectAssignable } from '../__utils__/type-assertions';
 
 declare const interaction: APIInteraction;
@@ -24,6 +24,20 @@ if (interaction.type === InteractionType.ApplicationCommand) {
 	const { data } = interaction;
 	expectAssignable<APIApplicationCommandInteractionData>(data);
 	expectAssignable<Snowflake | undefined>(data.guild_id);
+
+	if (data.type === ApplicationCommandType.ChatInput) {
+		if (data.options?.[0]?.type === ApplicationCommandOptionType.String) {
+			expectAssignable<string>(data.options[0].value);
+		}
+
+		if (data.options?.[0]?.type === ApplicationCommandOptionType.Integer) {
+			expectAssignable<number>(data.options[0].value);
+		}
+
+		if (data.options?.[0]?.type === ApplicationCommandOptionType.Number) {
+			expectAssignable<number>(data.options[0].value);
+		}
+	}
 }
 
 if (interaction.type === InteractionType.MessageComponent) {
@@ -42,6 +56,18 @@ if (interaction.type === InteractionType.MessageComponent) {
 
 if (interaction.type === InteractionType.ApplicationCommandAutocomplete) {
 	expectAssignable<APIApplicationCommandAutocompleteInteraction['data']>(interaction.data);
+
+	if (interaction.data.options[0]?.type === ApplicationCommandOptionType.String) {
+		expectAssignable<string>(interaction.data.options[0].value);
+	}
+
+	if (interaction.data.options[0]?.type === ApplicationCommandOptionType.Integer) {
+		expectAssignable<string>(interaction.data.options[0].value);
+	}
+
+	if (interaction.data.options[0]?.type === ApplicationCommandOptionType.Number) {
+		expectAssignable<string>(interaction.data.options[0].value);
+	}
 }
 
 if (interaction.type === InteractionType.ModalSubmit) {


### PR DESCRIPTION
Resolves #1175.

A type argument of the interaction type is passed to the integer and number options to know whether to return a string if it came from an autocomplete interaction.