### PR TITLE
refactor(ImageSize): allow other sizes

### DIFF
--- a/deno/rest/v10/mod.ts
+++ b/deno/rest/v10/mod.ts
@@ -1087,7 +1087,7 @@ Object.freeze(Routes);
 
 export const StickerPackApplicationId = '710982414301790216';
 
-export type ImageSize = 1_024 | 2_048 | 4_096 | 16 | 32 | 64 | 128 | 256 | 512;
+export type ImageSize = 1_024 | 2_048 | 4_096 | 16 | 32 | 64 | 128 | 256 | 512 | (number & {});
 
 export enum ImageFormat {
 	JPEG = 'jpeg',

--- a/deno/rest/v9/mod.ts
+++ b/deno/rest/v9/mod.ts
@@ -1096,7 +1096,7 @@ Object.freeze(Routes);
 
 export const StickerPackApplicationId = '710982414301790216';
 
-export type ImageSize = 1_024 | 2_048 | 4_096 | 16 | 32 | 64 | 128 | 256 | 512;
+export type ImageSize = 1_024 | 2_048 | 4_096 | 16 | 32 | 64 | 128 | 256 | 512 | (number & {});
 
 export enum ImageFormat {
 	JPEG = 'jpeg',

--- a/rest/v10/index.ts
+++ b/rest/v10/index.ts
@@ -1087,7 +1087,7 @@ Object.freeze(Routes);
 
 export const StickerPackApplicationId = '710982414301790216';
 
-export type ImageSize = 1_024 | 2_048 | 4_096 | 16 | 32 | 64 | 128 | 256 | 512;
+export type ImageSize = 1_024 | 2_048 | 4_096 | 16 | 32 | 64 | 128 | 256 | 512 | (number & {});
 
 export enum ImageFormat {
 	JPEG = 'jpeg',

--- a/rest/v9/index.ts
+++ b/rest/v9/index.ts
@@ -1096,7 +1096,7 @@ Object.freeze(Routes);
 
 export const StickerPackApplicationId = '710982414301790216';
 
-export type ImageSize = 1_024 | 2_048 | 4_096 | 16 | 32 | 64 | 128 | 256 | 512;
+export type ImageSize = 1_024 | 2_048 | 4_096 | 16 | 32 | 64 | 128 | 256 | 512 | (number & {});
 
 export enum ImageFormat {
 	JPEG = 'jpeg',


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Allow other sizes for `ImageSize`, as many others can also be used. Internal discussion [here](https://canary.discord.com/channels/222078108977594368/999796393810067607/1364005073432346797)

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
