### PR TITLE
docs: remove duplication in descriptions

### DIFF
--- a/deno/payloads/v10/_interactions/applicationCommands.ts
+++ b/deno/payloads/v10/_interactions/applicationCommands.ts
@@ -95,15 +95,21 @@ export interface APIApplicationCommand {
 	 */
 	default_permission?: boolean;
 	/**
-	 * Indicates whether the command is age-restricted, defaults to `false`
+	 * Indicates whether the command is age-restricted
+	 *
+	 * @defaultValue `false`
 	 */
 	nsfw?: boolean;
 	/**
-	 * Installation context(s) where the command is available, only for globally-scoped commands. Defaults to `GUILD_INSTALL ([0])`
+	 * Installation context(s) where the command is available, only for globally-scoped commands
+	 *
+	 * @defaultValue `[ApplicationIntegrationType.GuildInstall]`
 	 */
 	integration_types?: ApplicationIntegrationType[];
 	/**
-	 * Interaction context(s) where the command can be used, only for globally-scoped commands. By default, all interaction context types included for new commands `[0,1,2]`.
+	 * Interaction context(s) where the command can be used, only for globally-scoped commands
+	 *
+	 * @defaultValue `[InteractionContextType.Guild, InteractionContextType.BotDM, InteractionContextType.PrivateChannel]`
 	 */
 	contexts?: InteractionContextType[] | null;
 	/**

--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -363,7 +363,9 @@ export interface APIThreadOnlyChannel<T extends ChannelType.GuildForum | Channel
 
 export interface APIGuildForumChannel extends APIThreadOnlyChannel<ChannelType.GuildForum> {
 	/**
-	 * The default layout type used to display posts in a forum channel. Defaults to `0`, which indicates a layout view has not been set by a channel admin
+	 * The default layout type used to display posts in a forum channel
+	 *
+	 * @defaultValue `ForumLayoutType.NotSet` which indicates a layout view has not been set by a channel admin
 	 */
 	default_forum_layout: ForumLayoutType;
 }
@@ -1548,7 +1550,7 @@ export interface APIAllowedMentions {
 	 */
 	users?: Snowflake[];
 	/**
-	 * 	For replies, whether to mention the author of the message being replied to (default false)
+	 * For replies, whether to mention the author of the message being replied to
 	 *
 	 * @defaultValue `false`
 	 */

--- a/deno/payloads/v10/guild.ts
+++ b/deno/payloads/v10/guild.ts
@@ -223,7 +223,7 @@ export interface APIGuild extends APIPartialGuild {
 	 */
 	premium_subscription_count?: number;
 	/**
-	 * The preferred locale of a Community guild; used in guild discovery and notices from Discord; defaults to "en-US"
+	 * The preferred locale of a Community guild; used in guild discovery and notices from Discord
 	 *
 	 * @defaultValue `"en-US"`
 	 */
@@ -291,7 +291,7 @@ export interface APIGuild extends APIPartialGuild {
  */
 export interface APIPartialInteractionGuild extends Pick<APIGuild, 'features' | 'id'> {
 	/**
-	 * The preferred locale of a Community guild; used in guild discovery and notices from Discord; defaults to "en-US"
+	 * The preferred locale of a Community guild; used in guild discovery and notices from Discord
 	 *
 	 * @unstable https://github.com/discord/discord-api-docs/issues/6938
 	 * @defaultValue `"en-US"`
@@ -682,7 +682,9 @@ export interface APIGuildMember {
 	 */
 	mute: boolean;
 	/**
-	 * Guild member flags represented as a bit set, defaults to `0`
+	 * Guild member flags represented as a bit set
+	 *
+	 * @defaultValue `0`
 	 */
 	flags: GuildMemberFlags;
 	/**

--- a/deno/payloads/v9/_interactions/applicationCommands.ts
+++ b/deno/payloads/v9/_interactions/applicationCommands.ts
@@ -95,15 +95,19 @@ export interface APIApplicationCommand {
 	 */
 	default_permission?: boolean;
 	/**
-	 * Indicates whether the command is age-restricted, defaults to `false`
+	 * Indicates whether the command is age-restricted
 	 */
 	nsfw?: boolean;
 	/**
-	 * Installation context(s) where the command is available, only for globally-scoped commands. Defaults to `GUILD_INSTALL ([0])`
+	 * Installation context(s) where the command is available, only for globally-scoped commands
+	 *
+	 * @defaultValue `[ApplicationIntegrationType.GuildInstall]`
 	 */
 	integration_types?: ApplicationIntegrationType[];
 	/**
-	 * Interaction context(s) where the command can be used, only for globally-scoped commands. By default, all interaction context types included for new commands `[0,1,2]`.
+	 * Interaction context(s) where the command can be used, only for globally-scoped commands
+	 *
+	 * @defaultValue `[InteractionContextType.Guild, InteractionContextType.BotDM, InteractionContextType.PrivateChannel]`
 	 */
 	contexts?: InteractionContextType[] | null;
 	/**

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -363,7 +363,9 @@ export interface APIThreadOnlyChannel<T extends ChannelType.GuildForum | Channel
 
 export interface APIGuildForumChannel extends APIThreadOnlyChannel<ChannelType.GuildForum> {
 	/**
-	 * The default layout type used to display posts in a forum channel. Defaults to `0`, which indicates a layout view has not been set by a channel admin
+	 * The default layout type used to display posts in a forum channel
+	 *
+	 * @defaultValue `ForumLayoutType.NotSet` which indicates a layout view has not been set by a channel admin
 	 */
 	default_forum_layout: ForumLayoutType;
 }
@@ -1547,7 +1549,7 @@ export interface APIAllowedMentions {
 	 */
 	users?: Snowflake[];
 	/**
-	 * 	For replies, whether to mention the author of the message being replied to (default false)
+	 * For replies, whether to mention the author of the message being replied to
 	 *
 	 * @defaultValue `false`
 	 */

--- a/deno/payloads/v9/guild.ts
+++ b/deno/payloads/v9/guild.ts
@@ -223,7 +223,7 @@ export interface APIGuild extends APIPartialGuild {
 	 */
 	premium_subscription_count?: number;
 	/**
-	 * The preferred locale of a Community guild; used in guild discovery and notices from Discord; defaults to "en-US"
+	 * The preferred locale of a Community guild; used in guild discovery and notices from Discord
 	 *
 	 * @defaultValue `"en-US"`
 	 */
@@ -291,7 +291,7 @@ export interface APIGuild extends APIPartialGuild {
  */
 export interface APIPartialInteractionGuild extends Pick<APIGuild, 'features' | 'id'> {
 	/**
-	 * The preferred locale of a Community guild; used in guild discovery and notices from Discord; defaults to "en-US"
+	 * The preferred locale of a Community guild; used in guild discovery and notices from Discord
 	 *
 	 * @unstable https://github.com/discord/discord-api-docs/issues/6938
 	 * @defaultValue `"en-US"`
@@ -674,7 +674,9 @@ export interface APIGuildMember {
 	 */
 	mute: boolean;
 	/**
-	 * Guild member flags represented as a bit set, defaults to `0`
+	 * Guild member flags represented as a bit set
+	 *
+	 * @defaultValue `0`
 	 */
 	flags: GuildMemberFlags;
 	/**

--- a/deno/rest/v10/channel.ts
+++ b/deno/rest/v10/channel.ts
@@ -709,11 +709,9 @@ export interface RESTPostAPIChannelThreadsJSONBody extends RESTPostAPIChannelMes
 	/**
 	 * The type of thread to create
 	 *
-	 * In API v9 and v10, `type` defaults to `PRIVATE_THREAD`.
-	 * In a future API version this will be changed to be a required field, with no default.
-	 *
 	 * @see {@link https://discord.com/developers/docs/resources/channel#channel-object-channel-types}
-	 * @defaultValue `ChannelType.PrivateThread`
+	 * @defaultValue `ChannelType.PrivateThread` in API v9 and v10.
+	 * In a future API version this will be changed to be a required field, with no default.
 	 */
 	type?: ThreadChannelType | undefined;
 	/**
@@ -765,7 +763,9 @@ export interface RESTGetAPIChannelThreadMembersQuery {
 	 */
 	after?: Snowflake;
 	/**
-	 * Max number of thread members to return (1-100). Defaults to 100
+	 * Max number of thread members to return (1-100)
+	 *
+	 * @defaultValue `100`
 	 */
 	limit?: number;
 }

--- a/deno/rest/v10/guild.ts
+++ b/deno/rest/v10/guild.ts
@@ -310,7 +310,7 @@ export interface RESTPatchAPIGuildJSONBody {
 	 */
 	public_updates_channel_id?: Snowflake | null | undefined;
 	/**
-	 * The preferred locale of a Community guild used in server discovery and notices from Discord; defaults to "en-US"
+	 * The preferred locale of a Community guild used in server discovery and notices from Discord
 	 *
 	 * @defaultValue `"en-US"` (if the value is set to `null`)
 	 */

--- a/deno/rest/v10/monetization.ts
+++ b/deno/rest/v10/monetization.ts
@@ -33,11 +33,15 @@ export interface RESTGetAPIEntitlementsQuery {
 	 */
 	guild_id?: Snowflake | undefined;
 	/**
-	 * Whether ended entitlements should be omitted. Defaults to `false`, ended entitlements are included by default
+	 * Whether ended entitlements should be omitted
+	 *
+	 * @defaultValue `false` ended entitlements are included by default
 	 */
 	exclude_ended?: boolean | undefined;
 	/**
-	 * Whether deleted entitlements should be omitted. Defaults to `true`, deleted entitlements are not included by default
+	 * Whether deleted entitlements should be omitted
+	 *
+	 * @defaultValue `true` deleted entitlements are not included by default
 	 */
 	exclude_deleted?: boolean | undefined;
 }

--- a/deno/rest/v10/webhook.ts
+++ b/deno/rest/v10/webhook.ts
@@ -178,7 +178,7 @@ export type RESTPostAPIWebhookWithTokenFormDataBody =
 export interface RESTPostAPIWebhookWithTokenQuery {
 	/**
 	 * Waits for server confirmation of message send before response, and returns the created message body
-	 * (defaults to `false`; when `false` a message that is not saved does not return an error)
+	 * (when `false` a message that is not saved does not return an error)
 	 *
 	 * @defaultValue `false`
 	 */
@@ -191,7 +191,7 @@ export interface RESTPostAPIWebhookWithTokenQuery {
 	thread_id?: Snowflake;
 	/**
 	 * Whether to allow sending (non-interactive) components for non-application-owned webhooks
-	 * (defaults to `false`; ignored for application-owned webhooks)
+	 * (ignored for application-owned webhooks)
 	 *
 	 * @defaultValue `false`
 	 */

--- a/deno/rest/v9/channel.ts
+++ b/deno/rest/v9/channel.ts
@@ -723,11 +723,9 @@ export interface RESTPostAPIChannelThreadsJSONBody extends RESTPostAPIChannelMes
 	/**
 	 * The type of thread to create
 	 *
-	 * In API v9, `type` defaults to `PRIVATE_THREAD`.
-	 * In a future API version this will be changed to be a required field, with no default.
-	 *
 	 * @see {@link https://discord.com/developers/docs/resources/channel#channel-object-channel-types}
-	 * @defaultValue `ChannelType.PrivateThread`
+	 * @defaultValue `ChannelType.PrivateThread` in API v9.
+	 * In a future API version this will be changed to be a required field, with no default.
 	 */
 	type?: ThreadChannelType | undefined;
 	/**
@@ -779,7 +777,9 @@ export interface RESTGetAPIChannelThreadMembersQuery {
 	 */
 	after?: Snowflake;
 	/**
-	 * Max number of thread members to return (1-100). Defaults to 100
+	 * Max number of thread members to return (1-100)
+	 *
+	 * @defaultValue `100`
 	 */
 	limit?: number;
 }

--- a/deno/rest/v9/guild.ts
+++ b/deno/rest/v9/guild.ts
@@ -310,7 +310,7 @@ export interface RESTPatchAPIGuildJSONBody {
 	 */
 	public_updates_channel_id?: Snowflake | null | undefined;
 	/**
-	 * The preferred locale of a Community guild used in server discovery and notices from Discord; defaults to "en-US"
+	 * The preferred locale of a Community guild used in server discovery and notices from Discord
 	 *
 	 * @defaultValue `"en-US"` (if the value is set to `null`)
 	 */

--- a/deno/rest/v9/monetization.ts
+++ b/deno/rest/v9/monetization.ts
@@ -33,11 +33,15 @@ export interface RESTGetAPIEntitlementsQuery {
 	 */
 	guild_id?: Snowflake | undefined;
 	/**
-	 * Whether ended entitlements should be omitted. Defaults to `false`, ended entitlements are included by default
+	 * Whether ended entitlements should be omitted
+	 *
+	 * @defaultValue `false` ended entitlements are included by default
 	 */
 	exclude_ended?: boolean | undefined;
 	/**
-	 * Whether deleted entitlements should be omitted. Defaults to `true`, deleted entitlements are not included by default
+	 * Whether deleted entitlements should be omitted
+	 *
+	 * @defaultValue `true` deleted entitlements are not included by default
 	 */
 	exclude_deleted?: boolean | undefined;
 }

--- a/deno/rest/v9/webhook.ts
+++ b/deno/rest/v9/webhook.ts
@@ -178,7 +178,7 @@ export type RESTPostAPIWebhookWithTokenFormDataBody =
 export interface RESTPostAPIWebhookWithTokenQuery {
 	/**
 	 * Waits for server confirmation of message send before response, and returns the created message body
-	 * (defaults to `false`; when `false` a message that is not saved does not return an error)
+	 * (when `false` a message that is not saved does not return an error)
 	 *
 	 * @defaultValue `false`
 	 */
@@ -191,7 +191,7 @@ export interface RESTPostAPIWebhookWithTokenQuery {
 	thread_id?: Snowflake;
 	/**
 	 * Whether to allow sending (non-interactive) components for non-application-owned webhooks
-	 * (defaults to `false`; ignored for application-owned webhooks)
+	 * (ignored for application-owned webhooks)
 	 *
 	 * @defaultValue `false`
 	 */

--- a/deno/rpc/v10.ts
+++ b/deno/rpc/v10.ts
@@ -435,7 +435,9 @@ export interface RPCSetUserVoiceSettingsArgs {
 	 */
 	pan?: RPCVoicePan;
 	/**
-	 * Set the volume of user (defaults to 100, min 0, max 200)
+	 * Set the volume of user (min 0, max 200)
+	 *
+	 * @defaultValue `100`
 	 */
 	volume?: number;
 	/**

--- a/payloads/v10/_interactions/applicationCommands.ts
+++ b/payloads/v10/_interactions/applicationCommands.ts
@@ -95,15 +95,21 @@ export interface APIApplicationCommand {
 	 */
 	default_permission?: boolean;
 	/**
-	 * Indicates whether the command is age-restricted, defaults to `false`
+	 * Indicates whether the command is age-restricted
+	 *
+	 * @defaultValue `false`
 	 */
 	nsfw?: boolean;
 	/**
-	 * Installation context(s) where the command is available, only for globally-scoped commands. Defaults to `GUILD_INSTALL ([0])`
+	 * Installation context(s) where the command is available, only for globally-scoped commands
+	 *
+	 * @defaultValue `[ApplicationIntegrationType.GuildInstall]`
 	 */
 	integration_types?: ApplicationIntegrationType[];
 	/**
-	 * Interaction context(s) where the command can be used, only for globally-scoped commands. By default, all interaction context types included for new commands `[0,1,2]`.
+	 * Interaction context(s) where the command can be used, only for globally-scoped commands
+	 *
+	 * @defaultValue `[InteractionContextType.Guild, InteractionContextType.BotDM, InteractionContextType.PrivateChannel]`
 	 */
 	contexts?: InteractionContextType[] | null;
 	/**

--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -363,7 +363,9 @@ export interface APIThreadOnlyChannel<T extends ChannelType.GuildForum | Channel
 
 export interface APIGuildForumChannel extends APIThreadOnlyChannel<ChannelType.GuildForum> {
 	/**
-	 * The default layout type used to display posts in a forum channel. Defaults to `0`, which indicates a layout view has not been set by a channel admin
+	 * The default layout type used to display posts in a forum channel
+	 *
+	 * @defaultValue `ForumLayoutType.NotSet` which indicates a layout view has not been set by a channel admin
 	 */
 	default_forum_layout: ForumLayoutType;
 }
@@ -1548,7 +1550,7 @@ export interface APIAllowedMentions {
 	 */
 	users?: Snowflake[];
 	/**
-	 * 	For replies, whether to mention the author of the message being replied to (default false)
+	 * For replies, whether to mention the author of the message being replied to
 	 *
 	 * @defaultValue `false`
 	 */

--- a/payloads/v10/guild.ts
+++ b/payloads/v10/guild.ts
@@ -223,7 +223,7 @@ export interface APIGuild extends APIPartialGuild {
 	 */
 	premium_subscription_count?: number;
 	/**
-	 * The preferred locale of a Community guild; used in guild discovery and notices from Discord; defaults to "en-US"
+	 * The preferred locale of a Community guild; used in guild discovery and notices from Discord
 	 *
 	 * @defaultValue `"en-US"`
 	 */
@@ -291,7 +291,7 @@ export interface APIGuild extends APIPartialGuild {
  */
 export interface APIPartialInteractionGuild extends Pick<APIGuild, 'features' | 'id'> {
 	/**
-	 * The preferred locale of a Community guild; used in guild discovery and notices from Discord; defaults to "en-US"
+	 * The preferred locale of a Community guild; used in guild discovery and notices from Discord
 	 *
 	 * @unstable https://github.com/discord/discord-api-docs/issues/6938
 	 * @defaultValue `"en-US"`
@@ -682,7 +682,9 @@ export interface APIGuildMember {
 	 */
 	mute: boolean;
 	/**
-	 * Guild member flags represented as a bit set, defaults to `0`
+	 * Guild member flags represented as a bit set
+	 *
+	 * @defaultValue `0`
 	 */
 	flags: GuildMemberFlags;
 	/**

--- a/payloads/v9/_interactions/applicationCommands.ts
+++ b/payloads/v9/_interactions/applicationCommands.ts
@@ -95,15 +95,19 @@ export interface APIApplicationCommand {
 	 */
 	default_permission?: boolean;
 	/**
-	 * Indicates whether the command is age-restricted, defaults to `false`
+	 * Indicates whether the command is age-restricted
 	 */
 	nsfw?: boolean;
 	/**
-	 * Installation context(s) where the command is available, only for globally-scoped commands. Defaults to `GUILD_INSTALL ([0])`
+	 * Installation context(s) where the command is available, only for globally-scoped commands
+	 *
+	 * @defaultValue `[ApplicationIntegrationType.GuildInstall]`
 	 */
 	integration_types?: ApplicationIntegrationType[];
 	/**
-	 * Interaction context(s) where the command can be used, only for globally-scoped commands. By default, all interaction context types included for new commands `[0,1,2]`.
+	 * Interaction context(s) where the command can be used, only for globally-scoped commands
+	 *
+	 * @defaultValue `[InteractionContextType.Guild, InteractionContextType.BotDM, InteractionContextType.PrivateChannel]`
 	 */
 	contexts?: InteractionContextType[] | null;
 	/**

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -363,7 +363,9 @@ export interface APIThreadOnlyChannel<T extends ChannelType.GuildForum | Channel
 
 export interface APIGuildForumChannel extends APIThreadOnlyChannel<ChannelType.GuildForum> {
 	/**
-	 * The default layout type used to display posts in a forum channel. Defaults to `0`, which indicates a layout view has not been set by a channel admin
+	 * The default layout type used to display posts in a forum channel
+	 *
+	 * @defaultValue `ForumLayoutType.NotSet` which indicates a layout view has not been set by a channel admin
 	 */
 	default_forum_layout: ForumLayoutType;
 }
@@ -1547,7 +1549,7 @@ export interface APIAllowedMentions {
 	 */
 	users?: Snowflake[];
 	/**
-	 * 	For replies, whether to mention the author of the message being replied to (default false)
+	 * For replies, whether to mention the author of the message being replied to
 	 *
 	 * @defaultValue `false`
 	 */

--- a/payloads/v9/guild.ts
+++ b/payloads/v9/guild.ts
@@ -223,7 +223,7 @@ export interface APIGuild extends APIPartialGuild {
 	 */
 	premium_subscription_count?: number;
 	/**
-	 * The preferred locale of a Community guild; used in guild discovery and notices from Discord; defaults to "en-US"
+	 * The preferred locale of a Community guild; used in guild discovery and notices from Discord
 	 *
 	 * @defaultValue `"en-US"`
 	 */
@@ -291,7 +291,7 @@ export interface APIGuild extends APIPartialGuild {
  */
 export interface APIPartialInteractionGuild extends Pick<APIGuild, 'features' | 'id'> {
 	/**
-	 * The preferred locale of a Community guild; used in guild discovery and notices from Discord; defaults to "en-US"
+	 * The preferred locale of a Community guild; used in guild discovery and notices from Discord
 	 *
 	 * @unstable https://github.com/discord/discord-api-docs/issues/6938
 	 * @defaultValue `"en-US"`
@@ -674,7 +674,9 @@ export interface APIGuildMember {
 	 */
 	mute: boolean;
 	/**
-	 * Guild member flags represented as a bit set, defaults to `0`
+	 * Guild member flags represented as a bit set
+	 *
+	 * @defaultValue `0`
 	 */
 	flags: GuildMemberFlags;
 	/**

--- a/rest/v10/channel.ts
+++ b/rest/v10/channel.ts
@@ -709,11 +709,9 @@ export interface RESTPostAPIChannelThreadsJSONBody extends RESTPostAPIChannelMes
 	/**
 	 * The type of thread to create
 	 *
-	 * In API v9 and v10, `type` defaults to `PRIVATE_THREAD`.
-	 * In a future API version this will be changed to be a required field, with no default.
-	 *
 	 * @see {@link https://discord.com/developers/docs/resources/channel#channel-object-channel-types}
-	 * @defaultValue `ChannelType.PrivateThread`
+	 * @defaultValue `ChannelType.PrivateThread` in API v9 and v10.
+	 * In a future API version this will be changed to be a required field, with no default.
 	 */
 	type?: ThreadChannelType | undefined;
 	/**
@@ -765,7 +763,9 @@ export interface RESTGetAPIChannelThreadMembersQuery {
 	 */
 	after?: Snowflake;
 	/**
-	 * Max number of thread members to return (1-100). Defaults to 100
+	 * Max number of thread members to return (1-100)
+	 *
+	 * @defaultValue `100`
 	 */
 	limit?: number;
 }

--- a/rest/v10/guild.ts
+++ b/rest/v10/guild.ts
@@ -310,7 +310,7 @@ export interface RESTPatchAPIGuildJSONBody {
 	 */
 	public_updates_channel_id?: Snowflake | null | undefined;
 	/**
-	 * The preferred locale of a Community guild used in server discovery and notices from Discord; defaults to "en-US"
+	 * The preferred locale of a Community guild used in server discovery and notices from Discord
 	 *
 	 * @defaultValue `"en-US"` (if the value is set to `null`)
 	 */

--- a/rest/v10/monetization.ts
+++ b/rest/v10/monetization.ts
@@ -33,11 +33,15 @@ export interface RESTGetAPIEntitlementsQuery {
 	 */
 	guild_id?: Snowflake | undefined;
 	/**
-	 * Whether ended entitlements should be omitted. Defaults to `false`, ended entitlements are included by default
+	 * Whether ended entitlements should be omitted
+	 *
+	 * @defaultValue `false` ended entitlements are included by default
 	 */
 	exclude_ended?: boolean | undefined;
 	/**
-	 * Whether deleted entitlements should be omitted. Defaults to `true`, deleted entitlements are not included by default
+	 * Whether deleted entitlements should be omitted
+	 *
+	 * @defaultValue `true` deleted entitlements are not included by default
 	 */
 	exclude_deleted?: boolean | undefined;
 }

--- a/rest/v10/webhook.ts
+++ b/rest/v10/webhook.ts
@@ -178,7 +178,7 @@ export type RESTPostAPIWebhookWithTokenFormDataBody =
 export interface RESTPostAPIWebhookWithTokenQuery {
 	/**
 	 * Waits for server confirmation of message send before response, and returns the created message body
-	 * (defaults to `false`; when `false` a message that is not saved does not return an error)
+	 * (when `false` a message that is not saved does not return an error)
 	 *
 	 * @defaultValue `false`
 	 */
@@ -191,7 +191,7 @@ export interface RESTPostAPIWebhookWithTokenQuery {
 	thread_id?: Snowflake;
 	/**
 	 * Whether to allow sending (non-interactive) components for non-application-owned webhooks
-	 * (defaults to `false`; ignored for application-owned webhooks)
+	 * (ignored for application-owned webhooks)
 	 *
 	 * @defaultValue `false`
 	 */

--- a/rest/v9/channel.ts
+++ b/rest/v9/channel.ts
@@ -723,11 +723,9 @@ export interface RESTPostAPIChannelThreadsJSONBody extends RESTPostAPIChannelMes
 	/**
 	 * The type of thread to create
 	 *
-	 * In API v9, `type` defaults to `PRIVATE_THREAD`.
-	 * In a future API version this will be changed to be a required field, with no default.
-	 *
 	 * @see {@link https://discord.com/developers/docs/resources/channel#channel-object-channel-types}
-	 * @defaultValue `ChannelType.PrivateThread`
+	 * @defaultValue `ChannelType.PrivateThread` in API v9.
+	 * In a future API version this will be changed to be a required field, with no default.
 	 */
 	type?: ThreadChannelType | undefined;
 	/**
@@ -779,7 +777,9 @@ export interface RESTGetAPIChannelThreadMembersQuery {
 	 */
 	after?: Snowflake;
 	/**
-	 * Max number of thread members to return (1-100). Defaults to 100
+	 * Max number of thread members to return (1-100)
+	 *
+	 * @defaultValue `100`
 	 */
 	limit?: number;
 }

--- a/rest/v9/guild.ts
+++ b/rest/v9/guild.ts
@@ -310,7 +310,7 @@ export interface RESTPatchAPIGuildJSONBody {
 	 */
 	public_updates_channel_id?: Snowflake | null | undefined;
 	/**
-	 * The preferred locale of a Community guild used in server discovery and notices from Discord; defaults to "en-US"
+	 * The preferred locale of a Community guild used in server discovery and notices from Discord
 	 *
 	 * @defaultValue `"en-US"` (if the value is set to `null`)
 	 */

--- a/rest/v9/monetization.ts
+++ b/rest/v9/monetization.ts
@@ -33,11 +33,15 @@ export interface RESTGetAPIEntitlementsQuery {
 	 */
 	guild_id?: Snowflake | undefined;
 	/**
-	 * Whether ended entitlements should be omitted. Defaults to `false`, ended entitlements are included by default
+	 * Whether ended entitlements should be omitted
+	 *
+	 * @defaultValue `false` ended entitlements are included by default
 	 */
 	exclude_ended?: boolean | undefined;
 	/**
-	 * Whether deleted entitlements should be omitted. Defaults to `true`, deleted entitlements are not included by default
+	 * Whether deleted entitlements should be omitted
+	 *
+	 * @defaultValue `true` deleted entitlements are not included by default
 	 */
 	exclude_deleted?: boolean | undefined;
 }

--- a/rest/v9/webhook.ts
+++ b/rest/v9/webhook.ts
@@ -178,7 +178,7 @@ export type RESTPostAPIWebhookWithTokenFormDataBody =
 export interface RESTPostAPIWebhookWithTokenQuery {
 	/**
 	 * Waits for server confirmation of message send before response, and returns the created message body
-	 * (defaults to `false`; when `false` a message that is not saved does not return an error)
+	 * (when `false` a message that is not saved does not return an error)
 	 *
 	 * @defaultValue `false`
 	 */
@@ -191,7 +191,7 @@ export interface RESTPostAPIWebhookWithTokenQuery {
 	thread_id?: Snowflake;
 	/**
 	 * Whether to allow sending (non-interactive) components for non-application-owned webhooks
-	 * (defaults to `false`; ignored for application-owned webhooks)
+	 * (ignored for application-owned webhooks)
 	 *
 	 * @defaultValue `false`
 	 */

--- a/rpc/v10.ts
+++ b/rpc/v10.ts
@@ -435,7 +435,9 @@ export interface RPCSetUserVoiceSettingsArgs {
 	 */
 	pan?: RPCVoicePan;
 	/**
-	 * Set the volume of user (defaults to 100, min 0, max 200)
+	 * Set the volume of user (min 0, max 200)
+	 *
+	 * @defaultValue `100`
 	 */
 	volume?: number;
 	/**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Removes duplication in descriptions and uses `@defaultValue` instead, pointed out [here](https://github.com/discordjs/discord-api-types/pull/1224#discussion_r2055780708), internal discussion [here](https://canary.discord.com/channels/222078108977594368/999796393810067607/1364556416228134943)

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
