### PR TITLE
docs: Update privilege intents link

### DIFF
--- a/deno/payloads/v10/application.ts
+++ b/deno/payloads/v10/application.ts
@@ -227,11 +227,11 @@ export enum ApplicationFlags {
 	 */
 	Embedded = 1 << 17,
 	/**
-	 * Intent required for bots in 100 or more servers to receive {@link https://support-dev.discord.com/hc/en-us/articles/4404772028055 | message content}
+	 * Intent required for bots in 100 or more servers to receive {@link https://support-dev.discord.com/hc/articles/6207308062871 | message content}
 	 */
 	GatewayMessageContent = 1 << 18,
 	/**
-	 * Intent required for bots in under 100 servers to receive {@link https://support-dev.discord.com/hc/en-us/articles/4404772028055 | message content},
+	 * Intent required for bots in under 100 servers to receive {@link https://support-dev.discord.com/hc/articles/6207308062871 | message content},
 	 * found in Bot Settings
 	 */
 	GatewayMessageContentLimited = 1 << 19,

--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -522,7 +522,7 @@ export interface APIMessage {
 	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot \> Privileged Gateway Intents**.
 	 * You also need to specify the intent bit value (`1 << 15`) if you are connecting to the gateway
 	 *
-	 * @see {@link https://support-dev.discord.com/hc/articles/4404772028055}
+	 * @see {@link https://support-dev.discord.com/hc/articles/6207308062871}
 	 */
 	content: string;
 	/**
@@ -578,7 +578,7 @@ export interface APIMessage {
 	 *
 	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot \> Privileged Gateway Intents**.
 	 * You also need to specify the intent bit value (`1 << 15`) if you are connecting to the gateway
-	 * @see {@link https://support-dev.discord.com/hc/articles/4404772028055}
+	 * @see {@link https://support-dev.discord.com/hc/articles/6207308062871}
 	 */
 	attachments: APIAttachment[];
 	/**
@@ -590,7 +590,7 @@ export interface APIMessage {
 	 *
 	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot \> Privileged Gateway Intents**.
 	 * You also need to specify the intent bit value (`1 << 15`) if you are connecting to the gateway
-	 * @see {@link https://support-dev.discord.com/hc/articles/4404772028055}
+	 * @see {@link https://support-dev.discord.com/hc/articles/6207308062871}
 	 */
 	embeds: APIEmbed[];
 	/**
@@ -685,7 +685,7 @@ export interface APIMessage {
 	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot \> Privileged Gateway Intents**.
 	 * You also need to specify the intent bit value (`1 << 15`) if you are connecting to the gateway
 	 *
-	 * @see {@link https://support-dev.discord.com/hc/articles/4404772028055}
+	 * @see {@link https://support-dev.discord.com/hc/articles/6207308062871}
 	 */
 	components?: APIMessageTopLevelComponent[];
 	/**
@@ -725,7 +725,7 @@ export interface APIMessage {
 	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot \> Privileged Gateway Intents**.
 	 * You also need to specify the intent bit value (`1 << 15`) if you are connecting to the gateway
 	 *
-	 * @see {@link https://support-dev.discord.com/hc/articles/4404772028055}
+	 * @see {@link https://support-dev.discord.com/hc/articles/6207308062871}
 	 */
 	poll?: APIPoll;
 	/**

--- a/deno/payloads/v9/application.ts
+++ b/deno/payloads/v9/application.ts
@@ -227,11 +227,11 @@ export enum ApplicationFlags {
 	 */
 	Embedded = 1 << 17,
 	/**
-	 * Intent required for bots in 100 or more servers to receive {@link https://support-dev.discord.com/hc/en-us/articles/4404772028055 | message content}
+	 * Intent required for bots in 100 or more servers to receive {@link https://support-dev.discord.com/hc/articles/6207308062871 | message content}
 	 */
 	GatewayMessageContent = 1 << 18,
 	/**
-	 * Intent required for bots in under 100 servers to receive {@link https://support-dev.discord.com/hc/en-us/articles/4404772028055 | message content},
+	 * Intent required for bots in under 100 servers to receive {@link https://support-dev.discord.com/hc/articles/6207308062871 | message content},
 	 * found in Bot Settings
 	 */
 	GatewayMessageContentLimited = 1 << 19,

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -521,7 +521,7 @@ export interface APIMessage {
 	 *
 	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot \> Privileged Gateway Intents**
 	 *
-	 * @see {@link https://support-dev.discord.com/hc/articles/4404772028055}
+	 * @see {@link https://support-dev.discord.com/hc/articles/6207308062871}
 	 */
 	content: string;
 	/**
@@ -576,7 +576,7 @@ export interface APIMessage {
 	 * The `MESSAGE_CONTENT` privileged gateway intent is required for verified applications to receive a non-empty value from this field
 	 *
 	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot \> Privileged Gateway Intents**
-	 * @see {@link https://support-dev.discord.com/hc/articles/4404772028055}
+	 * @see {@link https://support-dev.discord.com/hc/articles/6207308062871}
 	 */
 	attachments: APIAttachment[];
 	/**
@@ -587,7 +587,7 @@ export interface APIMessage {
 	 * The `MESSAGE_CONTENT` privileged gateway intent is required for verified applications to receive a non-empty value from this field
 	 *
 	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot \> Privileged Gateway Intents**
-	 * @see {@link https://support-dev.discord.com/hc/articles/4404772028055}
+	 * @see {@link https://support-dev.discord.com/hc/articles/6207308062871}
 	 */
 	embeds: APIEmbed[];
 	/**
@@ -681,7 +681,7 @@ export interface APIMessage {
 	 *
 	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot \> Privileged Gateway Intents**
 	 *
-	 * @see {@link https://support-dev.discord.com/hc/articles/4404772028055}
+	 * @see {@link https://support-dev.discord.com/hc/articles/6207308062871}
 	 */
 	components?: APIMessageTopLevelComponent[];
 	/**
@@ -720,7 +720,7 @@ export interface APIMessage {
 	 *
 	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot \> Privileged Gateway Intents**.
 	 *
-	 * @see {@link https://support-dev.discord.com/hc/articles/4404772028055}
+	 * @see {@link https://support-dev.discord.com/hc/articles/6207308062871}
 	 */
 	poll?: APIPoll;
 	/**

--- a/payloads/v10/application.ts
+++ b/payloads/v10/application.ts
@@ -227,11 +227,11 @@ export enum ApplicationFlags {
 	 */
 	Embedded = 1 << 17,
 	/**
-	 * Intent required for bots in 100 or more servers to receive {@link https://support-dev.discord.com/hc/en-us/articles/4404772028055 | message content}
+	 * Intent required for bots in 100 or more servers to receive {@link https://support-dev.discord.com/hc/articles/6207308062871 | message content}
 	 */
 	GatewayMessageContent = 1 << 18,
 	/**
-	 * Intent required for bots in under 100 servers to receive {@link https://support-dev.discord.com/hc/en-us/articles/4404772028055 | message content},
+	 * Intent required for bots in under 100 servers to receive {@link https://support-dev.discord.com/hc/articles/6207308062871 | message content},
 	 * found in Bot Settings
 	 */
 	GatewayMessageContentLimited = 1 << 19,

--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -522,7 +522,7 @@ export interface APIMessage {
 	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot \> Privileged Gateway Intents**.
 	 * You also need to specify the intent bit value (`1 << 15`) if you are connecting to the gateway
 	 *
-	 * @see {@link https://support-dev.discord.com/hc/articles/4404772028055}
+	 * @see {@link https://support-dev.discord.com/hc/articles/6207308062871}
 	 */
 	content: string;
 	/**
@@ -578,7 +578,7 @@ export interface APIMessage {
 	 *
 	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot \> Privileged Gateway Intents**.
 	 * You also need to specify the intent bit value (`1 << 15`) if you are connecting to the gateway
-	 * @see {@link https://support-dev.discord.com/hc/articles/4404772028055}
+	 * @see {@link https://support-dev.discord.com/hc/articles/6207308062871}
 	 */
 	attachments: APIAttachment[];
 	/**
@@ -590,7 +590,7 @@ export interface APIMessage {
 	 *
 	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot \> Privileged Gateway Intents**.
 	 * You also need to specify the intent bit value (`1 << 15`) if you are connecting to the gateway
-	 * @see {@link https://support-dev.discord.com/hc/articles/4404772028055}
+	 * @see {@link https://support-dev.discord.com/hc/articles/6207308062871}
 	 */
 	embeds: APIEmbed[];
 	/**
@@ -685,7 +685,7 @@ export interface APIMessage {
 	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot \> Privileged Gateway Intents**.
 	 * You also need to specify the intent bit value (`1 << 15`) if you are connecting to the gateway
 	 *
-	 * @see {@link https://support-dev.discord.com/hc/articles/4404772028055}
+	 * @see {@link https://support-dev.discord.com/hc/articles/6207308062871}
 	 */
 	components?: APIMessageTopLevelComponent[];
 	/**
@@ -725,7 +725,7 @@ export interface APIMessage {
 	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot \> Privileged Gateway Intents**.
 	 * You also need to specify the intent bit value (`1 << 15`) if you are connecting to the gateway
 	 *
-	 * @see {@link https://support-dev.discord.com/hc/articles/4404772028055}
+	 * @see {@link https://support-dev.discord.com/hc/articles/6207308062871}
 	 */
 	poll?: APIPoll;
 	/**

--- a/payloads/v9/application.ts
+++ b/payloads/v9/application.ts
@@ -227,11 +227,11 @@ export enum ApplicationFlags {
 	 */
 	Embedded = 1 << 17,
 	/**
-	 * Intent required for bots in 100 or more servers to receive {@link https://support-dev.discord.com/hc/en-us/articles/4404772028055 | message content}
+	 * Intent required for bots in 100 or more servers to receive {@link https://support-dev.discord.com/hc/articles/6207308062871 | message content}
 	 */
 	GatewayMessageContent = 1 << 18,
 	/**
-	 * Intent required for bots in under 100 servers to receive {@link https://support-dev.discord.com/hc/en-us/articles/4404772028055 | message content},
+	 * Intent required for bots in under 100 servers to receive {@link https://support-dev.discord.com/hc/articles/6207308062871 | message content},
 	 * found in Bot Settings
 	 */
 	GatewayMessageContentLimited = 1 << 19,

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -521,7 +521,7 @@ export interface APIMessage {
 	 *
 	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot \> Privileged Gateway Intents**
 	 *
-	 * @see {@link https://support-dev.discord.com/hc/articles/4404772028055}
+	 * @see {@link https://support-dev.discord.com/hc/articles/6207308062871}
 	 */
 	content: string;
 	/**
@@ -576,7 +576,7 @@ export interface APIMessage {
 	 * The `MESSAGE_CONTENT` privileged gateway intent is required for verified applications to receive a non-empty value from this field
 	 *
 	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot \> Privileged Gateway Intents**
-	 * @see {@link https://support-dev.discord.com/hc/articles/4404772028055}
+	 * @see {@link https://support-dev.discord.com/hc/articles/6207308062871}
 	 */
 	attachments: APIAttachment[];
 	/**
@@ -587,7 +587,7 @@ export interface APIMessage {
 	 * The `MESSAGE_CONTENT` privileged gateway intent is required for verified applications to receive a non-empty value from this field
 	 *
 	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot \> Privileged Gateway Intents**
-	 * @see {@link https://support-dev.discord.com/hc/articles/4404772028055}
+	 * @see {@link https://support-dev.discord.com/hc/articles/6207308062871}
 	 */
 	embeds: APIEmbed[];
 	/**
@@ -681,7 +681,7 @@ export interface APIMessage {
 	 *
 	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot \> Privileged Gateway Intents**
 	 *
-	 * @see {@link https://support-dev.discord.com/hc/articles/4404772028055}
+	 * @see {@link https://support-dev.discord.com/hc/articles/6207308062871}
 	 */
 	components?: APIMessageTopLevelComponent[];
 	/**
@@ -720,7 +720,7 @@ export interface APIMessage {
 	 *
 	 * In the Discord Developers Portal, you need to enable the toggle of this intent of your application in **Bot \> Privileged Gateway Intents**.
 	 *
-	 * @see {@link https://support-dev.discord.com/hc/articles/4404772028055}
+	 * @see {@link https://support-dev.discord.com/hc/articles/6207308062871}
 	 */
 	poll?: APIPoll;
 	/**


### PR DESCRIPTION
https://support-dev.discord.com/hc/articles/4404772028055 is no longer available. https://support-dev.discord.com/hc/articles/6207308062871 seems to be a suitable replacement.