### PR TITLE
feat: `APIInviteChannel`

### DIFF
--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -33,6 +33,22 @@ export interface APIPartialChannel {
 }
 
 /**
+ * A channel obtained from fetching an invite.
+ */
+export interface APIInviteChannel extends Required<APIPartialChannel> {
+	/**
+	 * Icon hash.
+	 */
+	icon?: string | undefined;
+	/**
+	 * The invite channel's recipients.
+	 *
+	 * @remarks Only includes usernames of users.
+	 */
+	recipients?: Pick<APIUser, 'username'>[] | undefined;
+}
+
+/**
  * This interface is used to allow easy extension for other channel types. While
  * also allowing `APIPartialChannel` to be used without breaking.
  */

--- a/deno/payloads/v10/invite.ts
+++ b/deno/payloads/v10/invite.ts
@@ -3,7 +3,7 @@
  */
 
 import type { APIApplication } from './application.ts';
-import type { APIPartialChannel } from './channel.ts';
+import type { APIInviteChannel } from './channel.ts';
 import type { APIGuild } from './guild.ts';
 import type { APIGuildScheduledEvent } from './guildScheduledEvent.ts';
 import type { APIInviteStageInstance } from './stageInstance.ts';
@@ -43,7 +43,7 @@ export interface APIInvite {
 	 *
 	 * @see {@link https://discord.com/developers/docs/resources/channel#channel-object}
 	 */
-	channel: Required<APIPartialChannel> | null;
+	channel: APIInviteChannel | null;
 	/**
 	 * The user who created the invite
 	 *

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -33,6 +33,22 @@ export interface APIPartialChannel {
 }
 
 /**
+ * A channel obtained from fetching an invite.
+ */
+export interface APIInviteChannel extends Required<APIPartialChannel> {
+	/**
+	 * Icon hash.
+	 */
+	icon?: string | undefined;
+	/**
+	 * The invite channel's recipients.
+	 *
+	 * @remarks Only includes usernames of users.
+	 */
+	recipients?: Pick<APIUser, 'username'>[] | undefined;
+}
+
+/**
  * This interface is used to allow easy extension for other channel types. While
  * also allowing `APIPartialChannel` to be used without breaking.
  */

--- a/deno/payloads/v9/invite.ts
+++ b/deno/payloads/v9/invite.ts
@@ -3,7 +3,7 @@
  */
 
 import type { APIApplication } from './application.ts';
-import type { APIPartialChannel } from './channel.ts';
+import type { APIInviteChannel } from './channel.ts';
 import type { APIGuild } from './guild.ts';
 import type { APIGuildScheduledEvent } from './guildScheduledEvent.ts';
 import type { APIInviteStageInstance } from './stageInstance.ts';
@@ -43,7 +43,7 @@ export interface APIInvite {
 	 *
 	 * @see {@link https://discord.com/developers/docs/resources/channel#channel-object}
 	 */
-	channel: Required<APIPartialChannel> | null;
+	channel: APIInviteChannel | null;
 	/**
 	 * The user who created the invite
 	 *

--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -33,6 +33,22 @@ export interface APIPartialChannel {
 }
 
 /**
+ * A channel obtained from fetching an invite.
+ */
+export interface APIInviteChannel extends Required<APIPartialChannel> {
+	/**
+	 * Icon hash.
+	 */
+	icon?: string | undefined;
+	/**
+	 * The invite channel's recipients.
+	 *
+	 * @remarks Only includes usernames of users.
+	 */
+	recipients?: Pick<APIUser, 'username'>[] | undefined;
+}
+
+/**
  * This interface is used to allow easy extension for other channel types. While
  * also allowing `APIPartialChannel` to be used without breaking.
  */

--- a/payloads/v10/invite.ts
+++ b/payloads/v10/invite.ts
@@ -3,7 +3,7 @@
  */
 
 import type { APIApplication } from './application';
-import type { APIPartialChannel } from './channel';
+import type { APIInviteChannel } from './channel';
 import type { APIGuild } from './guild';
 import type { APIGuildScheduledEvent } from './guildScheduledEvent';
 import type { APIInviteStageInstance } from './stageInstance';
@@ -43,7 +43,7 @@ export interface APIInvite {
 	 *
 	 * @see {@link https://discord.com/developers/docs/resources/channel#channel-object}
 	 */
-	channel: Required<APIPartialChannel> | null;
+	channel: APIInviteChannel | null;
 	/**
 	 * The user who created the invite
 	 *

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -33,6 +33,22 @@ export interface APIPartialChannel {
 }
 
 /**
+ * A channel obtained from fetching an invite.
+ */
+export interface APIInviteChannel extends Required<APIPartialChannel> {
+	/**
+	 * Icon hash.
+	 */
+	icon?: string | undefined;
+	/**
+	 * The invite channel's recipients.
+	 *
+	 * @remarks Only includes usernames of users.
+	 */
+	recipients?: Pick<APIUser, 'username'>[] | undefined;
+}
+
+/**
  * This interface is used to allow easy extension for other channel types. While
  * also allowing `APIPartialChannel` to be used without breaking.
  */

--- a/payloads/v9/invite.ts
+++ b/payloads/v9/invite.ts
@@ -3,7 +3,7 @@
  */
 
 import type { APIApplication } from './application';
-import type { APIPartialChannel } from './channel';
+import type { APIInviteChannel } from './channel';
 import type { APIGuild } from './guild';
 import type { APIGuildScheduledEvent } from './guildScheduledEvent';
 import type { APIInviteStageInstance } from './stageInstance';
@@ -43,7 +43,7 @@ export interface APIInvite {
 	 *
 	 * @see {@link https://discord.com/developers/docs/resources/channel#channel-object}
 	 */
-	channel: Required<APIPartialChannel> | null;
+	channel: APIInviteChannel | null;
 	/**
 	 * The user who created the invite
 	 *


### PR DESCRIPTION
The channel of an `APIInvite` did not have all associated properties. Taken from the [specification](https://github.com/discord/discord-api-spec/blob/bed14af32d02a6feb2c0e1a778a7b1e8eebd1570/specs/openapi.json#L23018) (alongside testing), a more accurate interface has been created.