### PR TITLE
feat: `APIWebhookSourceChannel`

### DIFF
--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -3,6 +3,7 @@
  */
 
 import type { Permissions, Snowflake } from '../../globals.ts';
+import type { _NonNullableFields } from '../../utils/internals.ts';
 import type { APIApplication } from './application.ts';
 import type { APIPartialEmoji } from './emoji.ts';
 import type { APIGuildMember } from './guild.ts';
@@ -47,6 +48,11 @@ export interface APIInviteChannel extends Required<APIPartialChannel> {
 	 */
 	recipients?: Pick<APIUser, 'username'>[] | undefined;
 }
+
+/**
+ * Source channel of channel follower webhooks.
+ */
+export type APIWebhookSourceChannel = Required<_NonNullableFields<Pick<APIPartialChannel, 'id' | 'name'>>>;
 
 /**
  * This interface is used to allow easy extension for other channel types. While

--- a/deno/payloads/v10/webhook.ts
+++ b/deno/payloads/v10/webhook.ts
@@ -6,11 +6,11 @@ import type { Snowflake } from '../../globals.ts';
 import type {
 	APIEntitlement,
 	APIGuild,
-	APIPartialChannel,
 	APIPartialGuild,
 	APIUser,
 	ApplicationIntegrationType,
 	OAuth2Scopes,
+	APIWebhookSourceChannel,
 } from './mod.ts';
 
 /**
@@ -64,7 +64,7 @@ export interface APIWebhook {
 	/**
 	 * The channel that this webhook is following (returned for Channel Follower Webhooks)
 	 */
-	source_channel?: APIPartialChannel;
+	source_channel?: APIWebhookSourceChannel;
 	/**
 	 * The url used for executing the webhook (returned by the webhooks OAuth2 flow)
 	 */

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -3,6 +3,7 @@
  */
 
 import type { Permissions, Snowflake } from '../../globals.ts';
+import type { _NonNullableFields } from '../../utils/internals.ts';
 import type { APIApplication } from './application.ts';
 import type { APIPartialEmoji } from './emoji.ts';
 import type { APIGuildMember } from './guild.ts';
@@ -47,6 +48,11 @@ export interface APIInviteChannel extends Required<APIPartialChannel> {
 	 */
 	recipients?: Pick<APIUser, 'username'>[] | undefined;
 }
+
+/**
+ * Source channel of channel follower webhooks.
+ */
+export type APIWebhookSourceChannel = Required<_NonNullableFields<Pick<APIPartialChannel, 'id' | 'name'>>>;
 
 /**
  * This interface is used to allow easy extension for other channel types. While

--- a/deno/payloads/v9/webhook.ts
+++ b/deno/payloads/v9/webhook.ts
@@ -6,11 +6,11 @@ import type { Snowflake } from '../../globals.ts';
 import type {
 	APIEntitlement,
 	APIGuild,
-	APIPartialChannel,
 	APIPartialGuild,
 	APIUser,
 	ApplicationIntegrationType,
 	OAuth2Scopes,
+	APIWebhookSourceChannel,
 } from './mod.ts';
 
 /**
@@ -64,7 +64,7 @@ export interface APIWebhook {
 	/**
 	 * The channel that this webhook is following (returned for Channel Follower Webhooks)
 	 */
-	source_channel?: APIPartialChannel;
+	source_channel?: APIWebhookSourceChannel;
 	/**
 	 * The url used for executing the webhook (returned by the webhooks OAuth2 flow)
 	 */

--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -3,6 +3,7 @@
  */
 
 import type { Permissions, Snowflake } from '../../globals';
+import type { _NonNullableFields } from '../../utils/internals';
 import type { APIApplication } from './application';
 import type { APIPartialEmoji } from './emoji';
 import type { APIGuildMember } from './guild';
@@ -47,6 +48,11 @@ export interface APIInviteChannel extends Required<APIPartialChannel> {
 	 */
 	recipients?: Pick<APIUser, 'username'>[] | undefined;
 }
+
+/**
+ * Source channel of channel follower webhooks.
+ */
+export type APIWebhookSourceChannel = Required<_NonNullableFields<Pick<APIPartialChannel, 'id' | 'name'>>>;
 
 /**
  * This interface is used to allow easy extension for other channel types. While

--- a/payloads/v10/webhook.ts
+++ b/payloads/v10/webhook.ts
@@ -6,11 +6,11 @@ import type { Snowflake } from '../../globals';
 import type {
 	APIEntitlement,
 	APIGuild,
-	APIPartialChannel,
 	APIPartialGuild,
 	APIUser,
 	ApplicationIntegrationType,
 	OAuth2Scopes,
+	APIWebhookSourceChannel,
 } from './index';
 
 /**
@@ -64,7 +64,7 @@ export interface APIWebhook {
 	/**
 	 * The channel that this webhook is following (returned for Channel Follower Webhooks)
 	 */
-	source_channel?: APIPartialChannel;
+	source_channel?: APIWebhookSourceChannel;
 	/**
 	 * The url used for executing the webhook (returned by the webhooks OAuth2 flow)
 	 */

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -3,6 +3,7 @@
  */
 
 import type { Permissions, Snowflake } from '../../globals';
+import type { _NonNullableFields } from '../../utils/internals';
 import type { APIApplication } from './application';
 import type { APIPartialEmoji } from './emoji';
 import type { APIGuildMember } from './guild';
@@ -47,6 +48,11 @@ export interface APIInviteChannel extends Required<APIPartialChannel> {
 	 */
 	recipients?: Pick<APIUser, 'username'>[] | undefined;
 }
+
+/**
+ * Source channel of channel follower webhooks.
+ */
+export type APIWebhookSourceChannel = Required<_NonNullableFields<Pick<APIPartialChannel, 'id' | 'name'>>>;
 
 /**
  * This interface is used to allow easy extension for other channel types. While

--- a/payloads/v9/webhook.ts
+++ b/payloads/v9/webhook.ts
@@ -6,11 +6,11 @@ import type { Snowflake } from '../../globals';
 import type {
 	APIEntitlement,
 	APIGuild,
-	APIPartialChannel,
 	APIPartialGuild,
 	APIUser,
 	ApplicationIntegrationType,
 	OAuth2Scopes,
+	APIWebhookSourceChannel,
 } from './index';
 
 /**
@@ -64,7 +64,7 @@ export interface APIWebhook {
 	/**
 	 * The channel that this webhook is following (returned for Channel Follower Webhooks)
 	 */
-	source_channel?: APIPartialChannel;
+	source_channel?: APIWebhookSourceChannel;
 	/**
 	 * The url used for executing the webhook (returned by the webhooks OAuth2 flow)
 	 */


### PR DESCRIPTION
The source channel of a webhook was previously typed to include `type`. However, from testing, `type` is not received:

```JavaScript
{
  application_id: null,
  avatar: '8d2f3da86b058d315a43e541094f0b55',
  channel_id: '1089219063567360130',
  guild_id: '1089217648996401242',
  id: '1370316514422423584',
  name: '[need a ducking name] #important-innit',
  type: 2,
  user: {...},
  source_guild: {
    id: '1089217648996401242',
    icon: '8d2f3da86b058d315a43e541094f0b55',
    name: '[need a ducking name]'
  },
  source_channel: { id: '1370316432482631720', name: 'important-innit' }
}
```

[The specification](https://github.com/discord/discord-api-spec/blob/18275bc9b9d4c354136b43c531a97057c8789ff4/specs/openapi.json#L33084-L33098) also states it is not present.