### PR TITLE
feat: `APIWebhookSourceGuild`

### DIFF
--- a/deno/payloads/v10/guild.ts
+++ b/deno/payloads/v10/guild.ts
@@ -74,6 +74,11 @@ export interface APIPartialGuild extends Omit<APIUnavailableGuild, 'unavailable'
 }
 
 /**
+ * Source guild of channel follower webhooks.
+ */
+export type APIWebhookSourceGuild = Pick<APIPartialGuild, 'icon' | 'id' | 'name'>;
+
+/**
  * @see {@link https://discord.com/developers/docs/resources/guild#guild-object-guild-structure}
  */
 export interface APIGuild extends APIPartialGuild {

--- a/deno/payloads/v10/webhook.ts
+++ b/deno/payloads/v10/webhook.ts
@@ -6,8 +6,8 @@ import type { Snowflake } from '../../globals.ts';
 import type {
 	APIEntitlement,
 	APIGuild,
-	APIPartialGuild,
 	APIUser,
+	APIWebhookSourceGuild,
 	ApplicationIntegrationType,
 	OAuth2Scopes,
 	APIWebhookSourceChannel,
@@ -60,7 +60,7 @@ export interface APIWebhook {
 	/**
 	 * The guild of the channel that this webhook is following (returned for Channel Follower Webhooks)
 	 */
-	source_guild?: APIPartialGuild;
+	source_guild?: APIWebhookSourceGuild;
 	/**
 	 * The channel that this webhook is following (returned for Channel Follower Webhooks)
 	 */

--- a/deno/payloads/v9/guild.ts
+++ b/deno/payloads/v9/guild.ts
@@ -74,6 +74,11 @@ export interface APIPartialGuild extends Omit<APIUnavailableGuild, 'unavailable'
 }
 
 /**
+ * Source guild of channel follower webhooks.
+ */
+export type APIWebhookSourceGuild = Pick<APIPartialGuild, 'icon' | 'id' | 'name'>;
+
+/**
  * @see {@link https://discord.com/developers/docs/resources/guild#guild-object-guild-structure}
  */
 export interface APIGuild extends APIPartialGuild {

--- a/deno/payloads/v9/webhook.ts
+++ b/deno/payloads/v9/webhook.ts
@@ -6,8 +6,8 @@ import type { Snowflake } from '../../globals.ts';
 import type {
 	APIEntitlement,
 	APIGuild,
-	APIPartialGuild,
 	APIUser,
+	APIWebhookSourceGuild,
 	ApplicationIntegrationType,
 	OAuth2Scopes,
 	APIWebhookSourceChannel,
@@ -60,7 +60,7 @@ export interface APIWebhook {
 	/**
 	 * The guild of the channel that this webhook is following (returned for Channel Follower Webhooks)
 	 */
-	source_guild?: APIPartialGuild;
+	source_guild?: APIWebhookSourceGuild;
 	/**
 	 * The channel that this webhook is following (returned for Channel Follower Webhooks)
 	 */

--- a/payloads/v10/guild.ts
+++ b/payloads/v10/guild.ts
@@ -74,6 +74,11 @@ export interface APIPartialGuild extends Omit<APIUnavailableGuild, 'unavailable'
 }
 
 /**
+ * Source guild of channel follower webhooks.
+ */
+export type APIWebhookSourceGuild = Pick<APIPartialGuild, 'icon' | 'id' | 'name'>;
+
+/**
  * @see {@link https://discord.com/developers/docs/resources/guild#guild-object-guild-structure}
  */
 export interface APIGuild extends APIPartialGuild {

--- a/payloads/v10/webhook.ts
+++ b/payloads/v10/webhook.ts
@@ -6,8 +6,8 @@ import type { Snowflake } from '../../globals';
 import type {
 	APIEntitlement,
 	APIGuild,
-	APIPartialGuild,
 	APIUser,
+	APIWebhookSourceGuild,
 	ApplicationIntegrationType,
 	OAuth2Scopes,
 	APIWebhookSourceChannel,
@@ -60,7 +60,7 @@ export interface APIWebhook {
 	/**
 	 * The guild of the channel that this webhook is following (returned for Channel Follower Webhooks)
 	 */
-	source_guild?: APIPartialGuild;
+	source_guild?: APIWebhookSourceGuild;
 	/**
 	 * The channel that this webhook is following (returned for Channel Follower Webhooks)
 	 */

--- a/payloads/v9/guild.ts
+++ b/payloads/v9/guild.ts
@@ -74,6 +74,11 @@ export interface APIPartialGuild extends Omit<APIUnavailableGuild, 'unavailable'
 }
 
 /**
+ * Source guild of channel follower webhooks.
+ */
+export type APIWebhookSourceGuild = Pick<APIPartialGuild, 'icon' | 'id' | 'name'>;
+
+/**
  * @see {@link https://discord.com/developers/docs/resources/guild#guild-object-guild-structure}
  */
 export interface APIGuild extends APIPartialGuild {

--- a/payloads/v9/webhook.ts
+++ b/payloads/v9/webhook.ts
@@ -6,8 +6,8 @@ import type { Snowflake } from '../../globals';
 import type {
 	APIEntitlement,
 	APIGuild,
-	APIPartialGuild,
 	APIUser,
+	APIWebhookSourceGuild,
 	ApplicationIntegrationType,
 	OAuth2Scopes,
 	APIWebhookSourceChannel,
@@ -60,7 +60,7 @@ export interface APIWebhook {
 	/**
 	 * The guild of the channel that this webhook is following (returned for Channel Follower Webhooks)
 	 */
-	source_guild?: APIPartialGuild;
+	source_guild?: APIWebhookSourceGuild;
 	/**
 	 * The channel that this webhook is following (returned for Channel Follower Webhooks)
 	 */


### PR DESCRIPTION
Noticed from #1235, the source guild is typed to contain many properties it does not have. [The specification](https://github.com/discord/discord-api-spec/blob/18275bc9b9d4c354136b43c531a97057c8789ff4/specs/openapi.json#L33099-L33119) only lists 3.