### PR TITLE
fix: optional `client_id` and `client_secret` in access token data

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -41,6 +41,7 @@
 							"RESTAPIMessageReference",
 							"RESTAPIPartialCurrentUserGuild",
 							"RESTAPIPoll",
+							"RESTOAuth2TokenOptionalClientCredentials",
 
 							"RESTOAuth2AdvancedBotAuthorizationQuery",
 							"RESTOAuth2AdvancedBotAuthorizationQueryResult",

--- a/deno/rest/v10/oauth2.ts
+++ b/deno/rest/v10/oauth2.ts
@@ -62,11 +62,14 @@ export interface RESTPostOAuth2AuthorizationQueryResult {
 export type RESTOAuth2AuthorizationQueryResult = RESTPostOAuth2AuthorizationQueryResult;
 
 /**
+ * @remarks
+ * This endpoint requires either HTTP Basic authentication using `client_id:client_secret`,
+ * or the `client_id` and `client_secret` must be provided in the form body.
  * @see {@link https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-redirect-url-example}
  */
 export interface RESTPostOAuth2AccessTokenURLEncodedData {
-	client_id: Snowflake;
-	client_secret: string;
+	client_id?: Snowflake;
+	client_secret?: string;
 	grant_type: 'authorization_code';
 	code: string;
 	redirect_uri?: string;
@@ -84,11 +87,14 @@ export interface RESTPostOAuth2AccessTokenResult {
 }
 
 /**
+ * @remarks
+ * This endpoint requires either HTTP Basic authentication using `client_id:client_secret`,
+ * or the `client_id` and `client_secret` must be provided in the form body.
  * @see {@link https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-refresh-token-exchange-example}
  */
 export interface RESTPostOAuth2RefreshTokenURLEncodedData {
-	client_id: Snowflake;
-	client_secret: string;
+	client_id?: Snowflake;
+	client_secret?: string;
 	grant_type: 'refresh_token';
 	refresh_token: string;
 }

--- a/deno/rest/v10/oauth2.ts
+++ b/deno/rest/v10/oauth2.ts
@@ -67,13 +67,15 @@ export type RESTOAuth2AuthorizationQueryResult = RESTPostOAuth2AuthorizationQuer
  * or the `client_id` and `client_secret` must be provided in the form body.
  * @see {@link https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-redirect-url-example}
  */
-export interface RESTPostOAuth2AccessTokenURLEncodedData {
-	client_id?: Snowflake;
-	client_secret?: string;
+export type RESTPostOAuth2AccessTokenURLEncodedData = RESTOAuth2TokenOptionalClientCredentials & {
 	grant_type: 'authorization_code';
 	code: string;
 	redirect_uri?: string;
-}
+};
+
+export type RESTOAuth2TokenOptionalClientCredentials =
+	| { client_id: Snowflake; client_secret: string }
+	| { client_id?: never; client_secret?: never };
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-access-token-response}
@@ -92,12 +94,10 @@ export interface RESTPostOAuth2AccessTokenResult {
  * or the `client_id` and `client_secret` must be provided in the form body.
  * @see {@link https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-refresh-token-exchange-example}
  */
-export interface RESTPostOAuth2RefreshTokenURLEncodedData {
-	client_id?: Snowflake;
-	client_secret?: string;
+export type RESTPostOAuth2RefreshTokenURLEncodedData = RESTOAuth2TokenOptionalClientCredentials & {
 	grant_type: 'refresh_token';
 	refresh_token: string;
-}
+};
 
 export type RESTPostOAuth2RefreshTokenResult = RESTPostOAuth2AccessTokenResult;
 

--- a/deno/rest/v9/oauth2.ts
+++ b/deno/rest/v9/oauth2.ts
@@ -62,11 +62,14 @@ export interface RESTPostOAuth2AuthorizationQueryResult {
 export type RESTOAuth2AuthorizationQueryResult = RESTPostOAuth2AuthorizationQueryResult;
 
 /**
+ * @remarks
+ * This endpoint requires either HTTP Basic authentication using `client_id:client_secret`,
+ * or the `client_id` and `client_secret` must be provided in the form body.
  * @see {@link https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-redirect-url-example}
  */
 export interface RESTPostOAuth2AccessTokenURLEncodedData {
-	client_id: Snowflake;
-	client_secret: string;
+	client_id?: Snowflake;
+	client_secret?: string;
 	grant_type: 'authorization_code';
 	code: string;
 	redirect_uri?: string;
@@ -84,11 +87,14 @@ export interface RESTPostOAuth2AccessTokenResult {
 }
 
 /**
+ * @remarks
+ * This endpoint requires either HTTP Basic authentication using `client_id:client_secret`,
+ * or the `client_id` and `client_secret` must be provided in the form body.
  * @see {@link https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-refresh-token-exchange-example}
  */
 export interface RESTPostOAuth2RefreshTokenURLEncodedData {
-	client_id: Snowflake;
-	client_secret: string;
+	client_id?: Snowflake;
+	client_secret?: string;
 	grant_type: 'refresh_token';
 	refresh_token: string;
 }

--- a/deno/rest/v9/oauth2.ts
+++ b/deno/rest/v9/oauth2.ts
@@ -67,13 +67,15 @@ export type RESTOAuth2AuthorizationQueryResult = RESTPostOAuth2AuthorizationQuer
  * or the `client_id` and `client_secret` must be provided in the form body.
  * @see {@link https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-redirect-url-example}
  */
-export interface RESTPostOAuth2AccessTokenURLEncodedData {
-	client_id?: Snowflake;
-	client_secret?: string;
+export type RESTPostOAuth2AccessTokenURLEncodedData = RESTOAuth2TokenOptionalClientCredentials & {
 	grant_type: 'authorization_code';
 	code: string;
 	redirect_uri?: string;
-}
+};
+
+export type RESTOAuth2TokenOptionalClientCredentials =
+	| { client_id: Snowflake; client_secret: string }
+	| { client_id?: never; client_secret?: never };
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-access-token-response}
@@ -92,12 +94,10 @@ export interface RESTPostOAuth2AccessTokenResult {
  * or the `client_id` and `client_secret` must be provided in the form body.
  * @see {@link https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-refresh-token-exchange-example}
  */
-export interface RESTPostOAuth2RefreshTokenURLEncodedData {
-	client_id?: Snowflake;
-	client_secret?: string;
+export type RESTPostOAuth2RefreshTokenURLEncodedData = RESTOAuth2TokenOptionalClientCredentials & {
 	grant_type: 'refresh_token';
 	refresh_token: string;
-}
+};
 
 export type RESTPostOAuth2RefreshTokenResult = RESTPostOAuth2AccessTokenResult;
 

--- a/rest/v10/oauth2.ts
+++ b/rest/v10/oauth2.ts
@@ -62,11 +62,14 @@ export interface RESTPostOAuth2AuthorizationQueryResult {
 export type RESTOAuth2AuthorizationQueryResult = RESTPostOAuth2AuthorizationQueryResult;
 
 /**
+ * @remarks
+ * This endpoint requires either HTTP Basic authentication using `client_id:client_secret`,
+ * or the `client_id` and `client_secret` must be provided in the form body.
  * @see {@link https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-redirect-url-example}
  */
 export interface RESTPostOAuth2AccessTokenURLEncodedData {
-	client_id: Snowflake;
-	client_secret: string;
+	client_id?: Snowflake;
+	client_secret?: string;
 	grant_type: 'authorization_code';
 	code: string;
 	redirect_uri?: string;
@@ -84,11 +87,14 @@ export interface RESTPostOAuth2AccessTokenResult {
 }
 
 /**
+ * @remarks
+ * This endpoint requires either HTTP Basic authentication using `client_id:client_secret`,
+ * or the `client_id` and `client_secret` must be provided in the form body.
  * @see {@link https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-refresh-token-exchange-example}
  */
 export interface RESTPostOAuth2RefreshTokenURLEncodedData {
-	client_id: Snowflake;
-	client_secret: string;
+	client_id?: Snowflake;
+	client_secret?: string;
 	grant_type: 'refresh_token';
 	refresh_token: string;
 }

--- a/rest/v10/oauth2.ts
+++ b/rest/v10/oauth2.ts
@@ -67,13 +67,15 @@ export type RESTOAuth2AuthorizationQueryResult = RESTPostOAuth2AuthorizationQuer
  * or the `client_id` and `client_secret` must be provided in the form body.
  * @see {@link https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-redirect-url-example}
  */
-export interface RESTPostOAuth2AccessTokenURLEncodedData {
-	client_id?: Snowflake;
-	client_secret?: string;
+export type RESTPostOAuth2AccessTokenURLEncodedData = RESTOAuth2TokenOptionalClientCredentials & {
 	grant_type: 'authorization_code';
 	code: string;
 	redirect_uri?: string;
-}
+};
+
+export type RESTOAuth2TokenOptionalClientCredentials =
+	| { client_id: Snowflake; client_secret: string }
+	| { client_id?: never; client_secret?: never };
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-access-token-response}
@@ -92,12 +94,10 @@ export interface RESTPostOAuth2AccessTokenResult {
  * or the `client_id` and `client_secret` must be provided in the form body.
  * @see {@link https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-refresh-token-exchange-example}
  */
-export interface RESTPostOAuth2RefreshTokenURLEncodedData {
-	client_id?: Snowflake;
-	client_secret?: string;
+export type RESTPostOAuth2RefreshTokenURLEncodedData = RESTOAuth2TokenOptionalClientCredentials & {
 	grant_type: 'refresh_token';
 	refresh_token: string;
-}
+};
 
 export type RESTPostOAuth2RefreshTokenResult = RESTPostOAuth2AccessTokenResult;
 

--- a/rest/v9/oauth2.ts
+++ b/rest/v9/oauth2.ts
@@ -62,11 +62,14 @@ export interface RESTPostOAuth2AuthorizationQueryResult {
 export type RESTOAuth2AuthorizationQueryResult = RESTPostOAuth2AuthorizationQueryResult;
 
 /**
+ * @remarks
+ * This endpoint requires either HTTP Basic authentication using `client_id:client_secret`,
+ * or the `client_id` and `client_secret` must be provided in the form body.
  * @see {@link https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-redirect-url-example}
  */
 export interface RESTPostOAuth2AccessTokenURLEncodedData {
-	client_id: Snowflake;
-	client_secret: string;
+	client_id?: Snowflake;
+	client_secret?: string;
 	grant_type: 'authorization_code';
 	code: string;
 	redirect_uri?: string;
@@ -84,11 +87,14 @@ export interface RESTPostOAuth2AccessTokenResult {
 }
 
 /**
+ * @remarks
+ * This endpoint requires either HTTP Basic authentication using `client_id:client_secret`,
+ * or the `client_id` and `client_secret` must be provided in the form body.
  * @see {@link https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-refresh-token-exchange-example}
  */
 export interface RESTPostOAuth2RefreshTokenURLEncodedData {
-	client_id: Snowflake;
-	client_secret: string;
+	client_id?: Snowflake;
+	client_secret?: string;
 	grant_type: 'refresh_token';
 	refresh_token: string;
 }

--- a/rest/v9/oauth2.ts
+++ b/rest/v9/oauth2.ts
@@ -67,13 +67,15 @@ export type RESTOAuth2AuthorizationQueryResult = RESTPostOAuth2AuthorizationQuer
  * or the `client_id` and `client_secret` must be provided in the form body.
  * @see {@link https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-redirect-url-example}
  */
-export interface RESTPostOAuth2AccessTokenURLEncodedData {
-	client_id?: Snowflake;
-	client_secret?: string;
+export type RESTPostOAuth2AccessTokenURLEncodedData = RESTOAuth2TokenOptionalClientCredentials & {
 	grant_type: 'authorization_code';
 	code: string;
 	redirect_uri?: string;
-}
+};
+
+export type RESTOAuth2TokenOptionalClientCredentials =
+	| { client_id: Snowflake; client_secret: string }
+	| { client_id?: never; client_secret?: never };
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-access-token-response}
@@ -92,12 +94,10 @@ export interface RESTPostOAuth2AccessTokenResult {
  * or the `client_id` and `client_secret` must be provided in the form body.
  * @see {@link https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-refresh-token-exchange-example}
  */
-export interface RESTPostOAuth2RefreshTokenURLEncodedData {
-	client_id?: Snowflake;
-	client_secret?: string;
+export type RESTPostOAuth2RefreshTokenURLEncodedData = RESTOAuth2TokenOptionalClientCredentials & {
 	grant_type: 'refresh_token';
 	refresh_token: string;
-}
+};
 
 export type RESTPostOAuth2RefreshTokenResult = RESTPostOAuth2AccessTokenResult;
 

--- a/tests/v10/oauth2.ts
+++ b/tests/v10/oauth2.ts
@@ -1,4 +1,10 @@
-import type { OAuth2Scopes, RESTOAuth2BotAuthorizationQuery, RESTOAuth2AdvancedBotAuthorizationQuery } from '../../v10';
+import type {
+	OAuth2Scopes,
+	RESTOAuth2BotAuthorizationQuery,
+	RESTOAuth2AdvancedBotAuthorizationQuery,
+	RESTPostOAuth2AccessTokenURLEncodedData,
+	RESTPostOAuth2RefreshTokenURLEncodedData,
+} from '../../v10';
 import { expectAssignable, expectNotAssignable } from '../__utils__/type-assertions';
 
 declare const validBotScope:
@@ -22,3 +28,63 @@ expectNotAssignable<RESTOAuth2BotAuthorizationQuery['scope']>(invalidBotScope);
 expectAssignable<RESTOAuth2AdvancedBotAuthorizationQuery['scope']>(validBotScope);
 // @ts-expect-error - invalid scope
 expectNotAssignable<RESTOAuth2AdvancedBotAuthorizationQuery['scope']>(invalidBotScope);
+
+{
+	expectAssignable<RESTPostOAuth2AccessTokenURLEncodedData>({
+		code: 'code',
+		grant_type: 'authorization_code',
+		redirect_uri: 'https://discord.com',
+	});
+
+	expectAssignable<RESTPostOAuth2AccessTokenURLEncodedData>({
+		client_id: '123456789',
+		client_secret: 'very secret',
+		code: 'code',
+		grant_type: 'authorization_code',
+		redirect_uri: 'https://discord.com',
+	});
+
+	// @ts-expect-error - client_secret is missing
+	expectNotAssignable<RESTPostOAuth2AccessTokenURLEncodedData>({
+		client_id: '123456789',
+		code: 'code',
+		grant_type: 'authorization_code',
+		redirect_uri: 'https://discord.com',
+	});
+
+	// @ts-expect-error - client_id is missing
+	expectNotAssignable<RESTPostOAuth2AccessTokenURLEncodedData>({
+		client_secret: 'very secret',
+		code: 'code',
+		grant_type: 'authorization_code',
+		redirect_uri: 'https://discord.com',
+	});
+}
+
+{
+	expectAssignable<RESTPostOAuth2RefreshTokenURLEncodedData>({
+		grant_type: 'refresh_token',
+		refresh_token: 'a real token this is',
+	});
+
+	expectAssignable<RESTPostOAuth2RefreshTokenURLEncodedData>({
+		client_id: '123456789',
+		client_secret: 'very secret',
+		grant_type: 'refresh_token',
+		refresh_token: 'a real token this is',
+	});
+
+	// @ts-expect-error - client_secret is missing
+	expectNotAssignable<RESTPostOAuth2RefreshTokenURLEncodedData>({
+		client_id: '123456789',
+		grant_type: 'refresh_token',
+		refresh_token: 'a real token this is',
+	});
+
+	// @ts-expect-error - client_id is missing
+	expectNotAssignable<RESTPostOAuth2RefreshTokenURLEncodedData>({
+		client_secret: 'very secret',
+		grant_type: 'refresh_token',
+		refresh_token: 'a real token this is',
+	});
+}

--- a/tests/v9/oauth2.ts
+++ b/tests/v9/oauth2.ts
@@ -1,4 +1,10 @@
-import type { OAuth2Scopes, RESTOAuth2BotAuthorizationQuery, RESTOAuth2AdvancedBotAuthorizationQuery } from '../../v9';
+import type {
+	OAuth2Scopes,
+	RESTOAuth2BotAuthorizationQuery,
+	RESTOAuth2AdvancedBotAuthorizationQuery,
+	RESTPostOAuth2AccessTokenURLEncodedData,
+	RESTPostOAuth2RefreshTokenURLEncodedData,
+} from '../../v9';
 import { expectAssignable, expectNotAssignable } from '../__utils__/type-assertions';
 
 declare const validBotScope:
@@ -20,3 +26,62 @@ expectNotAssignable<RESTOAuth2BotAuthorizationQuery['scope']>(invalidBotScope);
 expectAssignable<RESTOAuth2AdvancedBotAuthorizationQuery['scope']>(validBotScope);
 // @ts-expect-error - invalid scope
 expectNotAssignable<RESTOAuth2AdvancedBotAuthorizationQuery['scope']>(invalidBotScope);
+{
+	expectAssignable<RESTPostOAuth2AccessTokenURLEncodedData>({
+		code: 'code',
+		grant_type: 'authorization_code',
+		redirect_uri: 'https://discord.com',
+	});
+
+	expectAssignable<RESTPostOAuth2AccessTokenURLEncodedData>({
+		client_id: '123456789',
+		client_secret: 'very secret',
+		code: 'code',
+		grant_type: 'authorization_code',
+		redirect_uri: 'https://discord.com',
+	});
+
+	// @ts-expect-error - client_secret is missing
+	expectNotAssignable<RESTPostOAuth2AccessTokenURLEncodedData>({
+		client_id: '123456789',
+		code: 'code',
+		grant_type: 'authorization_code',
+		redirect_uri: 'https://discord.com',
+	});
+
+	// @ts-expect-error - client_id is missing
+	expectNotAssignable<RESTPostOAuth2AccessTokenURLEncodedData>({
+		client_secret: 'very secret',
+		code: 'code',
+		grant_type: 'authorization_code',
+		redirect_uri: 'https://discord.com',
+	});
+}
+
+{
+	expectAssignable<RESTPostOAuth2RefreshTokenURLEncodedData>({
+		grant_type: 'refresh_token',
+		refresh_token: 'a real token this is',
+	});
+
+	expectAssignable<RESTPostOAuth2RefreshTokenURLEncodedData>({
+		client_id: '123456789',
+		client_secret: 'very secret',
+		grant_type: 'refresh_token',
+		refresh_token: 'a real token this is',
+	});
+
+	// @ts-expect-error - client_secret is missing
+	expectNotAssignable<RESTPostOAuth2RefreshTokenURLEncodedData>({
+		client_id: '123456789',
+		grant_type: 'refresh_token',
+		refresh_token: 'a real token this is',
+	});
+
+	// @ts-expect-error - client_id is missing
+	expectNotAssignable<RESTPostOAuth2RefreshTokenURLEncodedData>({
+		client_secret: 'very secret',
+		grant_type: 'refresh_token',
+		refresh_token: 'a real token this is',
+	});
+}


### PR DESCRIPTION
<https://discord.com/developers/docs/topics/oauth2#authorization-code-grant>

All the examples in the documentation use HTTP basic authentication instead of the `client_id` and `client_secret` fields approach