### PR TITLE
feat: Add application deauthorised webhook event

### DIFF
--- a/deno/payloads/v10/webhook.ts
+++ b/deno/payloads/v10/webhook.ts
@@ -86,6 +86,10 @@ export type APIWebhookEventBody =
 			ApplicationWebhookEventType.ApplicationAuthorized,
 			APIWebhookEventApplicationAuthorizedData
 	  >
+	| APIWebhookEventEventBase<
+			ApplicationWebhookEventType.ApplicationDeauthorized,
+			APIWebhookEventApplicationDeauthorizedData
+	  >
 	| APIWebhookEventEventBase<ApplicationWebhookEventType.EntitlementCreate, APIWebhookEventEntitlementCreateData>
 	| APIWebhookEventEventBase<ApplicationWebhookEventType.QuestUserEnrollment, APIWebhookEventQuestUserEnrollmentData>;
 
@@ -106,6 +110,16 @@ export interface APIWebhookEventApplicationAuthorizedData {
 	 * Server which app was authorized for (when integration type is `0`)
 	 */
 	guild?: APIGuild;
+}
+
+/**
+ * @unstable
+ */
+export interface APIWebhookEventApplicationDeauthorizedData {
+	/**
+	 * User who deauthorized the app
+	 */
+	user: APIUser;
 }
 
 export type APIWebhookEventEntitlementCreateData = APIEntitlement;
@@ -168,6 +182,12 @@ export enum ApplicationWebhookEventType {
 	 * Sent when an app was authorized by a user to a server or their account
 	 */
 	ApplicationAuthorized = 'APPLICATION_AUTHORIZED',
+	/**
+	 * Sent when an app was deauthorized by a user
+	 *
+	 * @unstable
+	 */
+	ApplicationDeauthorized = 'APPLICATION_DEAUTHORIZED',
 	/**
 	 * Entitlement was created
 	 */

--- a/deno/payloads/v9/webhook.ts
+++ b/deno/payloads/v9/webhook.ts
@@ -86,6 +86,10 @@ export type APIWebhookEventBody =
 			ApplicationWebhookEventType.ApplicationAuthorized,
 			APIWebhookEventApplicationAuthorizedData
 	  >
+	| APIWebhookEventEventBase<
+			ApplicationWebhookEventType.ApplicationDeauthorized,
+			APIWebhookEventApplicationDeauthorizedData
+	  >
 	| APIWebhookEventEventBase<ApplicationWebhookEventType.EntitlementCreate, APIWebhookEventEntitlementCreateData>
 	| APIWebhookEventEventBase<ApplicationWebhookEventType.QuestUserEnrollment, APIWebhookEventQuestUserEnrollmentData>;
 
@@ -106,6 +110,16 @@ export interface APIWebhookEventApplicationAuthorizedData {
 	 * Server which app was authorized for (when integration type is `0`)
 	 */
 	guild?: APIGuild;
+}
+
+/**
+ * @unstable
+ */
+export interface APIWebhookEventApplicationDeauthorizedData {
+	/**
+	 * User who deauthorized the app
+	 */
+	user: APIUser;
 }
 
 export type APIWebhookEventEntitlementCreateData = APIEntitlement;
@@ -168,6 +182,12 @@ export enum ApplicationWebhookEventType {
 	 * Sent when an app was authorized by a user to a server or their account
 	 */
 	ApplicationAuthorized = 'APPLICATION_AUTHORIZED',
+	/**
+	 * Sent when an app was deauthorized by a user
+	 *
+	 * @unstable
+	 */
+	ApplicationDeauthorized = 'APPLICATION_DEAUTHORIZED',
 	/**
 	 * Entitlement was created
 	 */

--- a/payloads/v10/webhook.ts
+++ b/payloads/v10/webhook.ts
@@ -86,6 +86,10 @@ export type APIWebhookEventBody =
 			ApplicationWebhookEventType.ApplicationAuthorized,
 			APIWebhookEventApplicationAuthorizedData
 	  >
+	| APIWebhookEventEventBase<
+			ApplicationWebhookEventType.ApplicationDeauthorized,
+			APIWebhookEventApplicationDeauthorizedData
+	  >
 	| APIWebhookEventEventBase<ApplicationWebhookEventType.EntitlementCreate, APIWebhookEventEntitlementCreateData>
 	| APIWebhookEventEventBase<ApplicationWebhookEventType.QuestUserEnrollment, APIWebhookEventQuestUserEnrollmentData>;
 
@@ -106,6 +110,16 @@ export interface APIWebhookEventApplicationAuthorizedData {
 	 * Server which app was authorized for (when integration type is `0`)
 	 */
 	guild?: APIGuild;
+}
+
+/**
+ * @unstable
+ */
+export interface APIWebhookEventApplicationDeauthorizedData {
+	/**
+	 * User who deauthorized the app
+	 */
+	user: APIUser;
 }
 
 export type APIWebhookEventEntitlementCreateData = APIEntitlement;
@@ -168,6 +182,12 @@ export enum ApplicationWebhookEventType {
 	 * Sent when an app was authorized by a user to a server or their account
 	 */
 	ApplicationAuthorized = 'APPLICATION_AUTHORIZED',
+	/**
+	 * Sent when an app was deauthorized by a user
+	 *
+	 * @unstable
+	 */
+	ApplicationDeauthorized = 'APPLICATION_DEAUTHORIZED',
 	/**
 	 * Entitlement was created
 	 */

--- a/payloads/v9/webhook.ts
+++ b/payloads/v9/webhook.ts
@@ -86,6 +86,10 @@ export type APIWebhookEventBody =
 			ApplicationWebhookEventType.ApplicationAuthorized,
 			APIWebhookEventApplicationAuthorizedData
 	  >
+	| APIWebhookEventEventBase<
+			ApplicationWebhookEventType.ApplicationDeauthorized,
+			APIWebhookEventApplicationDeauthorizedData
+	  >
 	| APIWebhookEventEventBase<ApplicationWebhookEventType.EntitlementCreate, APIWebhookEventEntitlementCreateData>
 	| APIWebhookEventEventBase<ApplicationWebhookEventType.QuestUserEnrollment, APIWebhookEventQuestUserEnrollmentData>;
 
@@ -106,6 +110,16 @@ export interface APIWebhookEventApplicationAuthorizedData {
 	 * Server which app was authorized for (when integration type is `0`)
 	 */
 	guild?: APIGuild;
+}
+
+/**
+ * @unstable
+ */
+export interface APIWebhookEventApplicationDeauthorizedData {
+	/**
+	 * User who deauthorized the app
+	 */
+	user: APIUser;
 }
 
 export type APIWebhookEventEntitlementCreateData = APIEntitlement;
@@ -168,6 +182,12 @@ export enum ApplicationWebhookEventType {
 	 * Sent when an app was authorized by a user to a server or their account
 	 */
 	ApplicationAuthorized = 'APPLICATION_AUTHORIZED',
+	/**
+	 * Sent when an app was deauthorized by a user
+	 *
+	 * @unstable
+	 */
+	ApplicationDeauthorized = 'APPLICATION_DEAUTHORIZED',
 	/**
 	 * Entitlement was created
 	 */


### PR DESCRIPTION
The developer portal exposes more options that do not appear to be documented. This one will add `APPLICATION_DEAUTHORIZED` with the unstable tag.

Example payload:

```JSON
{
	"data": {
		"user": {
			"avatar": "1f341400799da66e593f58e2e4bdf066",
			"clan": {
				"identity_enabled": false
			},
			"discriminator": "0",
			"global_name": "Jiralite",
			"id": "<id>",
			"primary_guild": {
				"identity_enabled": false
			},
			"public_flags": 4210944,
			"username": "jiralite"
		}
	},
	"timestamp": "2025-05-28T18:14:24.852266",
	"type": "APPLICATION_DEAUTHORIZED"
}
```