### PR TITLE
fix(voice): add `max_dave_protocol_version` to identify

### DIFF
--- a/deno/voice/v8.ts
+++ b/deno/voice/v8.ts
@@ -476,6 +476,10 @@ export interface VoiceIdentifyData {
 	 * Voice connection token
 	 */
 	token: string;
+	/**
+	 * The maximum DAVE protocol version supported
+	 */
+	max_dave_protocol_version?: number;
 }
 
 /**

--- a/voice/v8.ts
+++ b/voice/v8.ts
@@ -476,6 +476,10 @@ export interface VoiceIdentifyData {
 	 * Voice connection token
 	 */
 	token: string;
+	/**
+	 * The maximum DAVE protocol version supported
+	 */
+	max_dave_protocol_version?: number;
 }
 
 /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Added `max_dave_protocol_version` to the voice identify payload, missed this from the whitepaper.

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
