### PR TITLE
fix(voice): add clients connect and client disconnect recieve payload

### DIFF
--- a/deno/voice/v8.ts
+++ b/deno/voice/v8.ts
@@ -230,6 +230,8 @@ export type VoiceSendPayload =
 	| VoiceSpeakingSend;
 
 export type VoiceReceivePayload =
+	| VoiceClientDisconnect
+	| VoiceClientsConnect
 	| VoiceDaveExecuteTransition
 	| VoiceDavePrepareEpoch
 	| VoiceDavePrepareTransition

--- a/voice/v8.ts
+++ b/voice/v8.ts
@@ -230,6 +230,8 @@ export type VoiceSendPayload =
 	| VoiceSpeakingSend;
 
 export type VoiceReceivePayload =
+	| VoiceClientDisconnect
+	| VoiceClientsConnect
 	| VoiceDaveExecuteTransition
 	| VoiceDavePrepareEpoch
 	| VoiceDavePrepareTransition


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Forgot to include `VoiceClientDisconnect` and `VoiceClientsConnect` to the `VoiceReceivePayload` union type.

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
