### PR TITLE
fix(voice): fix remaining payload typos

### DIFF
--- a/deno/voice/v8.ts
+++ b/deno/voice/v8.ts
@@ -533,9 +533,9 @@ export interface VoiceSelectProtocolData {
  */
 export interface VoiceUDPProtocolData {
 	/**
-	 * External IP
+	 * External address
 	 */
-	ip: string;
+	address: string;
 	/**
 	 * External UDP port
 	 */
@@ -635,9 +635,9 @@ export interface VoiceDavePrepareEpoch {
  */
 export interface VoiceDavePrepareEpochData {
 	/**
-	 * The transition id
+	 * The protocol version
 	 */
-	transition_id: number;
+	protocol_version: number;
 	/**
 	 * The epoch id
 	 */

--- a/voice/v8.ts
+++ b/voice/v8.ts
@@ -533,9 +533,9 @@ export interface VoiceSelectProtocolData {
  */
 export interface VoiceUDPProtocolData {
 	/**
-	 * External IP
+	 * External address
 	 */
-	ip: string;
+	address: string;
 	/**
 	 * External UDP port
 	 */
@@ -635,9 +635,9 @@ export interface VoiceDavePrepareEpoch {
  */
 export interface VoiceDavePrepareEpochData {
 	/**
-	 * The transition id
+	 * The protocol version
 	 */
-	transition_id: number;
+	protocol_version: number;
 	/**
 	 * The epoch id
 	 */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixed typos in `VoiceUDPProtocolData` and `VoiceDavePrepareEpochData`

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
