### PR TITLE
chore: fix weird issue with api-extractor

### DIFF
--- a/deno/rest/v10/emoji.ts
+++ b/deno/rest/v10/emoji.ts
@@ -1,5 +1,5 @@
 import type { Snowflake } from '../../globals.ts';
-import type { APIApplicationEmoji, APIEmoji } from '../../payloads/v10.ts';
+import type { APIApplicationEmoji, APIEmoji } from '../../payloads/v10/mod.ts';
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/emoji#list-guild-emojis}

--- a/deno/rest/v9/emoji.ts
+++ b/deno/rest/v9/emoji.ts
@@ -1,5 +1,5 @@
 import type { Snowflake } from '../../globals.ts';
-import type { APIApplicationEmoji, APIEmoji } from '../../payloads/v9.ts';
+import type { APIApplicationEmoji, APIEmoji } from '../../payloads/v9/mod.ts';
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/emoji#list-guild-emojis}

--- a/rest/v10/emoji.ts
+++ b/rest/v10/emoji.ts
@@ -1,5 +1,5 @@
 import type { Snowflake } from '../../globals';
-import type { APIApplicationEmoji, APIEmoji } from '../../payloads/v10';
+import type { APIApplicationEmoji, APIEmoji } from '../../payloads/v10/index';
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/emoji#list-guild-emojis}

--- a/rest/v9/emoji.ts
+++ b/rest/v9/emoji.ts
@@ -1,5 +1,5 @@
 import type { Snowflake } from '../../globals';
-import type { APIApplicationEmoji, APIEmoji } from '../../payloads/v9';
+import type { APIApplicationEmoji, APIEmoji } from '../../payloads/v9/index';
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/emoji#list-guild-emojis}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

For whatever reasons (tell me if you know) the removal of the explicit `/index´ caused `api-extractor` to error with

```js
Error: Internal Error: Cannot assign isExternal=true for the symbol APIEmoji because it was previously registered with isExternal=false
```

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
