### PR TITLE
fix(CDNRoutes): correct `guildTagBadge` route

### DIFF
--- a/deno/rest/v10/mod.ts
+++ b/deno/rest/v10/mod.ts
@@ -1406,12 +1406,12 @@ export const CDNRoutes = {
 
 	/**
 	 * Route for:
-	 * - GET `/clan-badges/{guild.id}/{badge}.{png|jpeg|webp}`
+	 * - GET `/guild-tag-badges/{guild.id}/{badge}.{png|jpeg|webp}`
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
 	guildTagBadge<Format extends GuildTagBadgeFormat>(guildId: Snowflake, guildTagBadge: string, format: Format) {
-		return `/clan-badges/${guildId}/${guildTagBadge}.${format}` as const;
+		return `/guild-tag-badges/${guildId}/${guildTagBadge}.${format}` as const;
 	},
 };
 

--- a/deno/rest/v9/mod.ts
+++ b/deno/rest/v9/mod.ts
@@ -1415,12 +1415,12 @@ export const CDNRoutes = {
 
 	/**
 	 * Route for:
-	 * - GET `/clan-badges/{guild.id}/{badge}.{png|jpeg|webp}`
+	 * - GET `/guild-tag-badges/{guild.id}/{badge}.{png|jpeg|webp}`
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
 	guildTagBadge<Format extends GuildTagBadgeFormat>(guildId: Snowflake, guildTagBadge: string, format: Format) {
-		return `/clan-badges/${guildId}/${guildTagBadge}.${format}` as const;
+		return `/guild-tag-badges/${guildId}/${guildTagBadge}.${format}` as const;
 	},
 };
 

--- a/rest/v10/index.ts
+++ b/rest/v10/index.ts
@@ -1406,12 +1406,12 @@ export const CDNRoutes = {
 
 	/**
 	 * Route for:
-	 * - GET `/clan-badges/{guild.id}/{badge}.{png|jpeg|webp}`
+	 * - GET `/guild-tag-badges/{guild.id}/{badge}.{png|jpeg|webp}`
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
 	guildTagBadge<Format extends GuildTagBadgeFormat>(guildId: Snowflake, guildTagBadge: string, format: Format) {
-		return `/clan-badges/${guildId}/${guildTagBadge}.${format}` as const;
+		return `/guild-tag-badges/${guildId}/${guildTagBadge}.${format}` as const;
 	},
 };
 

--- a/rest/v9/index.ts
+++ b/rest/v9/index.ts
@@ -1415,12 +1415,12 @@ export const CDNRoutes = {
 
 	/**
 	 * Route for:
-	 * - GET `/clan-badges/{guild.id}/{badge}.{png|jpeg|webp}`
+	 * - GET `/guild-tag-badges/{guild.id}/{badge}.{png|jpeg|webp}`
 	 *
 	 * This route supports the extensions: PNG, JPEG, WebP
 	 */
 	guildTagBadge<Format extends GuildTagBadgeFormat>(guildId: Snowflake, guildTagBadge: string, format: Format) {
-		return `/clan-badges/${guildId}/${guildTagBadge}.${format}` as const;
+		return `/guild-tag-badges/${guildId}/${guildTagBadge}.${format}` as const;
 	},
 };
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Missed this change made just before the upstream PR was merged

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
- https://github.com/discord/discord-api-docs/pull/6836