### PR TITLE
fix(APIApplicationCommandChannelOption): Exclude directory channels

### DIFF
--- a/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/channel.ts
+++ b/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/channel.ts
@@ -5,7 +5,7 @@ import type { ApplicationCommandOptionType } from './shared.ts';
 
 export interface APIApplicationCommandChannelOption
 	extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.Channel> {
-	channel_types?: Exclude<ChannelType, ChannelType.DM | ChannelType.GroupDM>[];
+	channel_types?: Exclude<ChannelType, ChannelType.DM | ChannelType.GroupDM | ChannelType.GuildDirectory>[];
 }
 
 export type APIApplicationCommandInteractionDataChannelOption = APIInteractionDataOptionBase<

--- a/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/channel.ts
+++ b/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/channel.ts
@@ -5,7 +5,7 @@ import type { ApplicationCommandOptionType } from './shared.ts';
 
 export interface APIApplicationCommandChannelOption
 	extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.Channel> {
-	channel_types?: Exclude<ChannelType, ChannelType.DM | ChannelType.GroupDM>[];
+	channel_types?: Exclude<ChannelType, ChannelType.DM | ChannelType.GroupDM | ChannelType.GuildDirectory>[];
 }
 
 export type APIApplicationCommandInteractionDataChannelOption = APIInteractionDataOptionBase<

--- a/payloads/v10/_interactions/_applicationCommands/_chatInput/channel.ts
+++ b/payloads/v10/_interactions/_applicationCommands/_chatInput/channel.ts
@@ -5,7 +5,7 @@ import type { ApplicationCommandOptionType } from './shared';
 
 export interface APIApplicationCommandChannelOption
 	extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.Channel> {
-	channel_types?: Exclude<ChannelType, ChannelType.DM | ChannelType.GroupDM>[];
+	channel_types?: Exclude<ChannelType, ChannelType.DM | ChannelType.GroupDM | ChannelType.GuildDirectory>[];
 }
 
 export type APIApplicationCommandInteractionDataChannelOption = APIInteractionDataOptionBase<

--- a/payloads/v9/_interactions/_applicationCommands/_chatInput/channel.ts
+++ b/payloads/v9/_interactions/_applicationCommands/_chatInput/channel.ts
@@ -5,7 +5,7 @@ import type { ApplicationCommandOptionType } from './shared';
 
 export interface APIApplicationCommandChannelOption
 	extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.Channel> {
-	channel_types?: Exclude<ChannelType, ChannelType.DM | ChannelType.GroupDM>[];
+	channel_types?: Exclude<ChannelType, ChannelType.DM | ChannelType.GroupDM | ChannelType.GuildDirectory>[];
 }
 
 export type APIApplicationCommandInteractionDataChannelOption = APIInteractionDataOptionBase<


### PR DESCRIPTION
In a hub, there are no channels to type in – only a directory channel. Commands cannot be used (applications are not populated), so there is no chance of getting a directory channel.