### PR TITLE
fix: add guild_id back to GatewayVoiceStateUpdateDispatchData

### DIFF
--- a/deno/gateway/v10.ts
+++ b/deno/gateway/v10.ts
@@ -879,7 +879,7 @@ export interface GatewayGuildCreateDispatchData extends APIGuild {
 	 *
 	 * @see {@link https://discord.com/developers/docs/resources/voice#voice-state-object}
 	 */
-	voice_states: GatewayVoiceStateUpdateDispatchData[];
+	voice_states: (APIBaseVoiceState & APIVoiceStateMember)[];
 	/**
 	 * Users in the guild
 	 *

--- a/deno/gateway/v10.ts
+++ b/deno/gateway/v10.ts
@@ -47,6 +47,7 @@ import type {
 	GatewayGuildMembersChunkPresence,
 	APIBaseMessage,
 	APIVoiceStateMember,
+	APIVoiceState,
 } from '../payloads/v10/mod.ts';
 import type { ReactionType } from '../rest/v10/mod.ts';
 import type { _Nullable } from '../utils/internals.ts';
@@ -2098,7 +2099,7 @@ export type GatewayVoiceStateUpdateDispatch = _DataPayload<
 /**
  * @see {@link https://discord.com/developers/docs/topics/gateway-events#voice-state-update}
  */
-export interface GatewayVoiceStateUpdateDispatchData extends APIBaseVoiceState, APIVoiceStateMember {}
+export type GatewayVoiceStateUpdateDispatchData = APIVoiceState;
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/gateway-events#voice-server-update}

--- a/deno/gateway/v10.ts
+++ b/deno/gateway/v10.ts
@@ -46,7 +46,6 @@ import type {
 	APIGuildMemberUser,
 	GatewayGuildMembersChunkPresence,
 	APIBaseMessage,
-	APIVoiceStateMember,
 	APIVoiceState,
 } from '../payloads/v10/mod.ts';
 import type { ReactionType } from '../rest/v10/mod.ts';
@@ -880,7 +879,7 @@ export interface GatewayGuildCreateDispatchData extends APIGuild {
 	 *
 	 * @see {@link https://discord.com/developers/docs/resources/voice#voice-state-object}
 	 */
-	voice_states: (APIBaseVoiceState & APIVoiceStateMember)[];
+	voice_states: APIBaseVoiceState[];
 	/**
 	 * Users in the guild
 	 *

--- a/deno/gateway/v9.ts
+++ b/deno/gateway/v9.ts
@@ -878,7 +878,7 @@ export interface GatewayGuildCreateDispatchData extends APIGuild {
 	 *
 	 * @see {@link https://discord.com/developers/docs/resources/voice#voice-state-object}
 	 */
-	voice_states: GatewayVoiceStateUpdateDispatchData[];
+	voice_states: (APIBaseVoiceState & APIVoiceStateMember)[];
 	/**
 	 * Users in the guild
 	 *

--- a/deno/gateway/v9.ts
+++ b/deno/gateway/v9.ts
@@ -47,6 +47,7 @@ import type {
 	APIBaseMessage,
 	APIGuildMemberJoined,
 	APIVoiceStateMember,
+	APIVoiceState,
 } from '../payloads/v9/mod.ts';
 import type { ReactionType } from '../rest/v9/mod.ts';
 import type { _Nullable } from '../utils/internals.ts';
@@ -2097,7 +2098,7 @@ export type GatewayVoiceStateUpdateDispatch = _DataPayload<
 /**
  * @see {@link https://discord.com/developers/docs/topics/gateway-events#voice-state-update}
  */
-export interface GatewayVoiceStateUpdateDispatchData extends APIBaseVoiceState, APIVoiceStateMember {}
+export type GatewayVoiceStateUpdateDispatchData = APIVoiceState;
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/gateway-events#voice-server-update}

--- a/deno/gateway/v9.ts
+++ b/deno/gateway/v9.ts
@@ -46,7 +46,6 @@ import type {
 	GatewayGuildMembersChunkPresence,
 	APIBaseMessage,
 	APIGuildMemberJoined,
-	APIVoiceStateMember,
 	APIVoiceState,
 } from '../payloads/v9/mod.ts';
 import type { ReactionType } from '../rest/v9/mod.ts';
@@ -879,7 +878,7 @@ export interface GatewayGuildCreateDispatchData extends APIGuild {
 	 *
 	 * @see {@link https://discord.com/developers/docs/resources/voice#voice-state-object}
 	 */
-	voice_states: (APIBaseVoiceState & APIVoiceStateMember)[];
+	voice_states: APIBaseVoiceState[];
 	/**
 	 * Users in the guild
 	 *

--- a/deno/payloads/v10/voice.ts
+++ b/deno/payloads/v10/voice.ts
@@ -26,6 +26,7 @@ export interface APIBaseVoiceState {
 	/**
 	 * The guild member this voice state is for
 	 *
+	 * @remarks The member field will have `joined_at` set to `null` if the member was invited as a guest.
 	 * @see {@link https://discord.com/developers/docs/resources/guild#guild-member-object}
 	 */
 	member?: APIGuildMember;

--- a/deno/payloads/v10/voice.ts
+++ b/deno/payloads/v10/voice.ts
@@ -24,6 +24,12 @@ export interface APIBaseVoiceState {
 	 */
 	user_id: Snowflake;
 	/**
+	 * The guild member this voice state is for
+	 *
+	 * @see {@link https://discord.com/developers/docs/resources/guild#guild-member-object}
+	 */
+	member?: APIGuildMember;
+	/**
 	 * The session id for this voice state
 	 */
 	session_id: string;
@@ -61,20 +67,10 @@ export interface APIBaseVoiceState {
 	request_to_speak_timestamp: string | null;
 }
 
-export interface APIVoiceStateMember {
-	/**
-	 * The guild member this voice state is for
-	 *
-	 * @remarks The member field will have `joined_at` set to `null` if the member was invited as a guest.
-	 * @see {@link https://discord.com/developers/docs/resources/guild#guild-member-object}
-	 */
-	member?: APIGuildMember;
-}
-
 /**
  * @see {@link https://discord.com/developers/docs/resources/voice#voice-state-object}
  */
-export interface APIVoiceState extends APIBaseVoiceState, APIVoiceStateMember {
+export interface APIVoiceState extends APIBaseVoiceState {
 	/**
 	 * The guild id this voice state is for
 	 */

--- a/deno/payloads/v9/voice.ts
+++ b/deno/payloads/v9/voice.ts
@@ -21,6 +21,12 @@ export interface APIBaseVoiceState {
 	 */
 	user_id: Snowflake;
 	/**
+	 * The guild member this voice state is for
+	 *
+	 * @see {@link https://discord.com/developers/docs/resources/guild#guild-member-object}
+	 */
+	member?: APIGuildMember;
+	/**
 	 * The session id for this voice state
 	 */
 	session_id: string;
@@ -58,20 +64,10 @@ export interface APIBaseVoiceState {
 	request_to_speak_timestamp: string | null;
 }
 
-export interface APIVoiceStateMember {
-	/**
-	 * The guild member this voice state is for
-	 *
-	 * @remarks The member field will have `joined_at` set to `null` if the member was invited as a guest.
-	 * @see {@link https://discord.com/developers/docs/resources/guild#guild-member-object}
-	 */
-	member?: APIGuildMember;
-}
-
 /**
  * @see {@link https://discord.com/developers/docs/resources/voice#voice-state-object}
  */
-export interface APIVoiceState extends APIBaseVoiceState, APIVoiceStateMember {
+export interface APIVoiceState extends APIBaseVoiceState {
 	/**
 	 * The guild id this voice state is for
 	 */

--- a/deno/payloads/v9/voice.ts
+++ b/deno/payloads/v9/voice.ts
@@ -23,6 +23,7 @@ export interface APIBaseVoiceState {
 	/**
 	 * The guild member this voice state is for
 	 *
+	 * @remarks The member field will have `joined_at` set to `null` if the member was invited as a guest.
 	 * @see {@link https://discord.com/developers/docs/resources/guild#guild-member-object}
 	 */
 	member?: APIGuildMember;

--- a/gateway/v10.ts
+++ b/gateway/v10.ts
@@ -46,7 +46,6 @@ import type {
 	APIGuildMemberUser,
 	GatewayGuildMembersChunkPresence,
 	APIBaseMessage,
-	APIVoiceStateMember,
 	APIVoiceState,
 } from '../payloads/v10/index';
 import type { ReactionType } from '../rest/v10/index';
@@ -880,7 +879,7 @@ export interface GatewayGuildCreateDispatchData extends APIGuild {
 	 *
 	 * @see {@link https://discord.com/developers/docs/resources/voice#voice-state-object}
 	 */
-	voice_states: (APIBaseVoiceState & APIVoiceStateMember)[];
+	voice_states: APIBaseVoiceState[];
 	/**
 	 * Users in the guild
 	 *

--- a/gateway/v10.ts
+++ b/gateway/v10.ts
@@ -879,7 +879,7 @@ export interface GatewayGuildCreateDispatchData extends APIGuild {
 	 *
 	 * @see {@link https://discord.com/developers/docs/resources/voice#voice-state-object}
 	 */
-	voice_states: GatewayVoiceStateUpdateDispatchData[];
+	voice_states: (APIBaseVoiceState & APIVoiceStateMember)[];
 	/**
 	 * Users in the guild
 	 *

--- a/gateway/v10.ts
+++ b/gateway/v10.ts
@@ -47,6 +47,7 @@ import type {
 	GatewayGuildMembersChunkPresence,
 	APIBaseMessage,
 	APIVoiceStateMember,
+	APIVoiceState,
 } from '../payloads/v10/index';
 import type { ReactionType } from '../rest/v10/index';
 import type { _Nullable } from '../utils/internals';
@@ -2098,7 +2099,7 @@ export type GatewayVoiceStateUpdateDispatch = _DataPayload<
 /**
  * @see {@link https://discord.com/developers/docs/topics/gateway-events#voice-state-update}
  */
-export interface GatewayVoiceStateUpdateDispatchData extends APIBaseVoiceState, APIVoiceStateMember {}
+export type GatewayVoiceStateUpdateDispatchData = APIVoiceState;
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/gateway-events#voice-server-update}

--- a/gateway/v9.ts
+++ b/gateway/v9.ts
@@ -878,7 +878,7 @@ export interface GatewayGuildCreateDispatchData extends APIGuild {
 	 *
 	 * @see {@link https://discord.com/developers/docs/resources/voice#voice-state-object}
 	 */
-	voice_states: GatewayVoiceStateUpdateDispatchData[];
+	voice_states: (APIBaseVoiceState & APIVoiceStateMember)[];
 	/**
 	 * Users in the guild
 	 *

--- a/gateway/v9.ts
+++ b/gateway/v9.ts
@@ -46,7 +46,6 @@ import type {
 	GatewayGuildMembersChunkPresence,
 	APIBaseMessage,
 	APIGuildMemberJoined,
-	APIVoiceStateMember,
 	APIVoiceState,
 } from '../payloads/v9/index';
 import type { ReactionType } from '../rest/v9/index';
@@ -879,7 +878,7 @@ export interface GatewayGuildCreateDispatchData extends APIGuild {
 	 *
 	 * @see {@link https://discord.com/developers/docs/resources/voice#voice-state-object}
 	 */
-	voice_states: (APIBaseVoiceState & APIVoiceStateMember)[];
+	voice_states: APIBaseVoiceState[];
 	/**
 	 * Users in the guild
 	 *

--- a/gateway/v9.ts
+++ b/gateway/v9.ts
@@ -47,6 +47,7 @@ import type {
 	APIBaseMessage,
 	APIGuildMemberJoined,
 	APIVoiceStateMember,
+	APIVoiceState,
 } from '../payloads/v9/index';
 import type { ReactionType } from '../rest/v9/index';
 import type { _Nullable } from '../utils/internals';
@@ -2097,7 +2098,7 @@ export type GatewayVoiceStateUpdateDispatch = _DataPayload<
 /**
  * @see {@link https://discord.com/developers/docs/topics/gateway-events#voice-state-update}
  */
-export interface GatewayVoiceStateUpdateDispatchData extends APIBaseVoiceState, APIVoiceStateMember {}
+export type GatewayVoiceStateUpdateDispatchData = APIVoiceState;
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/gateway-events#voice-server-update}

--- a/payloads/v10/voice.ts
+++ b/payloads/v10/voice.ts
@@ -26,6 +26,7 @@ export interface APIBaseVoiceState {
 	/**
 	 * The guild member this voice state is for
 	 *
+	 * @remarks The member field will have `joined_at` set to `null` if the member was invited as a guest.
 	 * @see {@link https://discord.com/developers/docs/resources/guild#guild-member-object}
 	 */
 	member?: APIGuildMember;

--- a/payloads/v10/voice.ts
+++ b/payloads/v10/voice.ts
@@ -24,6 +24,12 @@ export interface APIBaseVoiceState {
 	 */
 	user_id: Snowflake;
 	/**
+	 * The guild member this voice state is for
+	 *
+	 * @see {@link https://discord.com/developers/docs/resources/guild#guild-member-object}
+	 */
+	member?: APIGuildMember;
+	/**
 	 * The session id for this voice state
 	 */
 	session_id: string;
@@ -61,20 +67,10 @@ export interface APIBaseVoiceState {
 	request_to_speak_timestamp: string | null;
 }
 
-export interface APIVoiceStateMember {
-	/**
-	 * The guild member this voice state is for
-	 *
-	 * @remarks The member field will have `joined_at` set to `null` if the member was invited as a guest.
-	 * @see {@link https://discord.com/developers/docs/resources/guild#guild-member-object}
-	 */
-	member?: APIGuildMember;
-}
-
 /**
  * @see {@link https://discord.com/developers/docs/resources/voice#voice-state-object}
  */
-export interface APIVoiceState extends APIBaseVoiceState, APIVoiceStateMember {
+export interface APIVoiceState extends APIBaseVoiceState {
 	/**
 	 * The guild id this voice state is for
 	 */

--- a/payloads/v9/voice.ts
+++ b/payloads/v9/voice.ts
@@ -21,6 +21,12 @@ export interface APIBaseVoiceState {
 	 */
 	user_id: Snowflake;
 	/**
+	 * The guild member this voice state is for
+	 *
+	 * @see {@link https://discord.com/developers/docs/resources/guild#guild-member-object}
+	 */
+	member?: APIGuildMember;
+	/**
 	 * The session id for this voice state
 	 */
 	session_id: string;
@@ -58,20 +64,10 @@ export interface APIBaseVoiceState {
 	request_to_speak_timestamp: string | null;
 }
 
-export interface APIVoiceStateMember {
-	/**
-	 * The guild member this voice state is for
-	 *
-	 * @remarks The member field will have `joined_at` set to `null` if the member was invited as a guest.
-	 * @see {@link https://discord.com/developers/docs/resources/guild#guild-member-object}
-	 */
-	member?: APIGuildMember;
-}
-
 /**
  * @see {@link https://discord.com/developers/docs/resources/voice#voice-state-object}
  */
-export interface APIVoiceState extends APIBaseVoiceState, APIVoiceStateMember {
+export interface APIVoiceState extends APIBaseVoiceState {
 	/**
 	 * The guild id this voice state is for
 	 */

--- a/payloads/v9/voice.ts
+++ b/payloads/v9/voice.ts
@@ -23,6 +23,7 @@ export interface APIBaseVoiceState {
 	/**
 	 * The guild member this voice state is for
 	 *
+	 * @remarks The member field will have `joined_at` set to `null` if the member was invited as a guest.
 	 * @see {@link https://discord.com/developers/docs/resources/guild#guild-member-object}
 	 */
 	member?: APIGuildMember;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
#1290 accidentally stripped the `guild_id` from `GatewayVoiceStateUpdateDispatchData`. After re-adding this back, I noticed it loops back around to being 1:1 with `APIVoiceState` making the whole change to `GatewayVoiceStateUpdateDispatchData` unnecessary in the first place.

As for how `GatewayVoiceStateUpdateDispatchData` was used in `GatewayGuildCreateDispatchData`, I noticed the aforementioned PR already looped back around to `APIVoiceStateMember#member` being the same as it was originally as `APIBaseVoiceState#member`. So, the changes to `GatewayGuildCreateDispatchData` and `APIBaseVoiceState` were also unnecessary.

Therefore, this partially reverts #1290.

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
