### PR TITLE
fix(RESTPatchAPIWebhookWithTokenMessageJSONBody): Pick `flags`

### DIFF
--- a/deno/rest/v10/webhook.ts
+++ b/deno/rest/v10/webhook.ts
@@ -263,7 +263,9 @@ export interface RESTGetAPIWebhookWithTokenMessageQuery {
  * @see {@link https://discord.com/developers/docs/resources/webhook#edit-webhook-message}
  */
 export type RESTPatchAPIWebhookWithTokenMessageJSONBody = _AddUndefinedToPossiblyUndefinedPropertiesOfInterface<
-	_Nullable<Pick<RESTPostAPIWebhookWithTokenJSONBody, 'allowed_mentions' | 'components' | 'content' | 'embeds'>>
+	_Nullable<
+		Pick<RESTPostAPIWebhookWithTokenJSONBody, 'allowed_mentions' | 'components' | 'content' | 'embeds' | 'flags'>
+	>
 > & {
 	/**
 	 * Attached files to keep

--- a/deno/rest/v9/webhook.ts
+++ b/deno/rest/v9/webhook.ts
@@ -263,7 +263,9 @@ export interface RESTGetAPIWebhookWithTokenMessageQuery {
  * @see {@link https://discord.com/developers/docs/resources/webhook#edit-webhook-message}
  */
 export type RESTPatchAPIWebhookWithTokenMessageJSONBody = _AddUndefinedToPossiblyUndefinedPropertiesOfInterface<
-	_Nullable<Pick<RESTPostAPIWebhookWithTokenJSONBody, 'allowed_mentions' | 'components' | 'content' | 'embeds'>>
+	_Nullable<
+		Pick<RESTPostAPIWebhookWithTokenJSONBody, 'allowed_mentions' | 'components' | 'content' | 'embeds' | 'flags'>
+	>
 > & {
 	/**
 	 * Attached files to keep

--- a/rest/v10/webhook.ts
+++ b/rest/v10/webhook.ts
@@ -263,7 +263,9 @@ export interface RESTGetAPIWebhookWithTokenMessageQuery {
  * @see {@link https://discord.com/developers/docs/resources/webhook#edit-webhook-message}
  */
 export type RESTPatchAPIWebhookWithTokenMessageJSONBody = _AddUndefinedToPossiblyUndefinedPropertiesOfInterface<
-	_Nullable<Pick<RESTPostAPIWebhookWithTokenJSONBody, 'allowed_mentions' | 'components' | 'content' | 'embeds'>>
+	_Nullable<
+		Pick<RESTPostAPIWebhookWithTokenJSONBody, 'allowed_mentions' | 'components' | 'content' | 'embeds' | 'flags'>
+	>
 > & {
 	/**
 	 * Attached files to keep

--- a/rest/v9/webhook.ts
+++ b/rest/v9/webhook.ts
@@ -263,7 +263,9 @@ export interface RESTGetAPIWebhookWithTokenMessageQuery {
  * @see {@link https://discord.com/developers/docs/resources/webhook#edit-webhook-message}
  */
 export type RESTPatchAPIWebhookWithTokenMessageJSONBody = _AddUndefinedToPossiblyUndefinedPropertiesOfInterface<
-	_Nullable<Pick<RESTPostAPIWebhookWithTokenJSONBody, 'allowed_mentions' | 'components' | 'content' | 'embeds'>>
+	_Nullable<
+		Pick<RESTPostAPIWebhookWithTokenJSONBody, 'allowed_mentions' | 'components' | 'content' | 'embeds' | 'flags'>
+	>
 > & {
 	/**
 	 * Attached files to keep


### PR DESCRIPTION
Resolves #1292.

`flags` should be allowed here per https://discord.com/developers/docs/resources/webhook#edit-webhook-message-jsonform-params.