### PR TITLE
fix: add missing text display in modal submission

### DIFF
--- a/deno/payloads/v10/_interactions/modalSubmit.ts
+++ b/deno/payloads/v10/_interactions/modalSubmit.ts
@@ -56,7 +56,10 @@ export interface ModalSubmitLabelComponent extends APIBaseComponent<ComponentTyp
 	component: ModalSubmitComponent;
 }
 
-export type APIModalSubmissionComponent = ModalSubmitActionRowComponent | ModalSubmitLabelComponent | ModalSubmitTextDisplayComponent;
+export type APIModalSubmissionComponent =
+	| ModalSubmitActionRowComponent
+	| ModalSubmitLabelComponent
+	| ModalSubmitTextDisplayComponent;
 
 /**
  * @see {@link https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-modal-submit-data-structure}

--- a/deno/payloads/v10/_interactions/modalSubmit.ts
+++ b/deno/payloads/v10/_interactions/modalSubmit.ts
@@ -50,11 +50,13 @@ export interface ModalSubmitActionRowComponent extends APIBaseComponent<Componen
 	components: APIModalSubmitTextInputComponent[];
 }
 
+export interface ModalSubmitTextDisplayComponent extends APIBaseComponent<ComponentType.TextDisplay> {}
+
 export interface ModalSubmitLabelComponent extends APIBaseComponent<ComponentType.Label> {
 	component: ModalSubmitComponent;
 }
 
-export type APIModalSubmissionComponent = ModalSubmitActionRowComponent | ModalSubmitLabelComponent;
+export type APIModalSubmissionComponent = ModalSubmitActionRowComponent | ModalSubmitLabelComponent | ModalSubmitTextDisplayComponent;
 
 /**
  * @see {@link https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-modal-submit-data-structure}

--- a/deno/payloads/v9/_interactions/modalSubmit.ts
+++ b/deno/payloads/v9/_interactions/modalSubmit.ts
@@ -50,11 +50,14 @@ export interface ModalSubmitActionRowComponent extends APIBaseComponent<Componen
 	components: APIModalSubmitTextInputComponent[];
 }
 
+
+export interface ModalSubmitTextDisplayComponent extends APIBaseComponent<ComponentType.TextDisplay> {}
+
 export interface ModalSubmitLabelComponent extends APIBaseComponent<ComponentType.Label> {
 	component: ModalSubmitComponent;
 }
 
-export type APIModalSubmissionComponent = ModalSubmitActionRowComponent | ModalSubmitLabelComponent;
+export type APIModalSubmissionComponent = ModalSubmitActionRowComponent | ModalSubmitLabelComponent | ModalSubmitTextDisplayComponent;
 
 /**
  * @see {@link https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-modal-submit-data-structure}

--- a/deno/payloads/v9/_interactions/modalSubmit.ts
+++ b/deno/payloads/v9/_interactions/modalSubmit.ts
@@ -50,14 +50,16 @@ export interface ModalSubmitActionRowComponent extends APIBaseComponent<Componen
 	components: APIModalSubmitTextInputComponent[];
 }
 
-
 export interface ModalSubmitTextDisplayComponent extends APIBaseComponent<ComponentType.TextDisplay> {}
 
 export interface ModalSubmitLabelComponent extends APIBaseComponent<ComponentType.Label> {
 	component: ModalSubmitComponent;
 }
 
-export type APIModalSubmissionComponent = ModalSubmitActionRowComponent | ModalSubmitLabelComponent | ModalSubmitTextDisplayComponent;
+export type APIModalSubmissionComponent =
+	| ModalSubmitActionRowComponent
+	| ModalSubmitLabelComponent
+	| ModalSubmitTextDisplayComponent;
 
 /**
  * @see {@link https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-modal-submit-data-structure}

--- a/payloads/v10/_interactions/modalSubmit.ts
+++ b/payloads/v10/_interactions/modalSubmit.ts
@@ -56,7 +56,10 @@ export interface ModalSubmitLabelComponent extends APIBaseComponent<ComponentTyp
 	component: ModalSubmitComponent;
 }
 
-export type APIModalSubmissionComponent = ModalSubmitActionRowComponent | ModalSubmitLabelComponent | ModalSubmitTextDisplayComponent;
+export type APIModalSubmissionComponent =
+	| ModalSubmitActionRowComponent
+	| ModalSubmitLabelComponent
+	| ModalSubmitTextDisplayComponent;
 
 /**
  * @see {@link https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-modal-submit-data-structure}

--- a/payloads/v10/_interactions/modalSubmit.ts
+++ b/payloads/v10/_interactions/modalSubmit.ts
@@ -50,11 +50,13 @@ export interface ModalSubmitActionRowComponent extends APIBaseComponent<Componen
 	components: APIModalSubmitTextInputComponent[];
 }
 
+export interface ModalSubmitTextDisplayComponent extends APIBaseComponent<ComponentType.TextDisplay> {}
+
 export interface ModalSubmitLabelComponent extends APIBaseComponent<ComponentType.Label> {
 	component: ModalSubmitComponent;
 }
 
-export type APIModalSubmissionComponent = ModalSubmitActionRowComponent | ModalSubmitLabelComponent;
+export type APIModalSubmissionComponent = ModalSubmitActionRowComponent | ModalSubmitLabelComponent | ModalSubmitTextDisplayComponent;
 
 /**
  * @see {@link https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-modal-submit-data-structure}

--- a/payloads/v9/_interactions/modalSubmit.ts
+++ b/payloads/v9/_interactions/modalSubmit.ts
@@ -50,11 +50,14 @@ export interface ModalSubmitActionRowComponent extends APIBaseComponent<Componen
 	components: APIModalSubmitTextInputComponent[];
 }
 
+
+export interface ModalSubmitTextDisplayComponent extends APIBaseComponent<ComponentType.TextDisplay> {}
+
 export interface ModalSubmitLabelComponent extends APIBaseComponent<ComponentType.Label> {
 	component: ModalSubmitComponent;
 }
 
-export type APIModalSubmissionComponent = ModalSubmitActionRowComponent | ModalSubmitLabelComponent;
+export type APIModalSubmissionComponent = ModalSubmitActionRowComponent | ModalSubmitLabelComponent | ModalSubmitTextDisplayComponent;
 
 /**
  * @see {@link https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-modal-submit-data-structure}

--- a/payloads/v9/_interactions/modalSubmit.ts
+++ b/payloads/v9/_interactions/modalSubmit.ts
@@ -50,14 +50,16 @@ export interface ModalSubmitActionRowComponent extends APIBaseComponent<Componen
 	components: APIModalSubmitTextInputComponent[];
 }
 
-
 export interface ModalSubmitTextDisplayComponent extends APIBaseComponent<ComponentType.TextDisplay> {}
 
 export interface ModalSubmitLabelComponent extends APIBaseComponent<ComponentType.Label> {
 	component: ModalSubmitComponent;
 }
 
-export type APIModalSubmissionComponent = ModalSubmitActionRowComponent | ModalSubmitLabelComponent | ModalSubmitTextDisplayComponent;
+export type APIModalSubmissionComponent =
+	| ModalSubmitActionRowComponent
+	| ModalSubmitLabelComponent
+	| ModalSubmitTextDisplayComponent;
 
 /**
  * @see {@link https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-modal-submit-data-structure}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Apparently text display is also returned in components in modal submissions.

ref: https://canary.discord.com/channels/1317206872763404478/1317208024682725426/1413548755470389338

