### PR TITLE
feat(RESTPostAPIChannelThreadsResult): Narrow response

### DIFF
--- a/deno/rest/v10/channel.ts
+++ b/deno/rest/v10/channel.ts
@@ -25,6 +25,9 @@ import type {
 	APIAttachment,
 	APIMessageTopLevelComponent,
 	APIMessagePin,
+	APIAnnouncementThreadChannel,
+	APIPrivateThreadChannel,
+	APIPublicThreadChannel,
 } from '../../payloads/v10/mod.ts';
 import type { _AddUndefinedToPossiblyUndefinedPropertiesOfInterface, _StrictPartial } from '../../utils/internals.ts';
 import type { RESTAPIPoll } from './poll.ts';
@@ -767,7 +770,10 @@ export interface RESTPostAPIChannelThreadsJSONBody extends RESTPostAPIChannelMes
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#start-thread-without-message}
  */
-export type RESTPostAPIChannelThreadsResult = APIChannel;
+export type RESTPostAPIChannelThreadsResult =
+	| APIAnnouncementThreadChannel
+	| APIPrivateThreadChannel
+	| APIPublicThreadChannel;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#join-thread}

--- a/deno/rest/v9/channel.ts
+++ b/deno/rest/v9/channel.ts
@@ -25,6 +25,9 @@ import type {
 	APIAttachment,
 	APIMessageTopLevelComponent,
 	APIMessagePin,
+	APIAnnouncementThreadChannel,
+	APIPrivateThreadChannel,
+	APIPublicThreadChannel,
 } from '../../payloads/v9/mod.ts';
 import type { _AddUndefinedToPossiblyUndefinedPropertiesOfInterface, _StrictPartial } from '../../utils/internals.ts';
 import type { RESTAPIPoll } from './poll.ts';
@@ -780,7 +783,10 @@ export interface RESTPostAPIChannelThreadsJSONBody extends RESTPostAPIChannelMes
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#start-thread-without-message}
  */
-export type RESTPostAPIChannelThreadsResult = APIChannel;
+export type RESTPostAPIChannelThreadsResult =
+	| APIAnnouncementThreadChannel
+	| APIPrivateThreadChannel
+	| APIPublicThreadChannel;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#join-thread}

--- a/rest/v10/channel.ts
+++ b/rest/v10/channel.ts
@@ -25,6 +25,9 @@ import type {
 	APIAttachment,
 	APIMessageTopLevelComponent,
 	APIMessagePin,
+	APIAnnouncementThreadChannel,
+	APIPrivateThreadChannel,
+	APIPublicThreadChannel,
 } from '../../payloads/v10/index';
 import type { _AddUndefinedToPossiblyUndefinedPropertiesOfInterface, _StrictPartial } from '../../utils/internals';
 import type { RESTAPIPoll } from './poll';
@@ -767,7 +770,10 @@ export interface RESTPostAPIChannelThreadsJSONBody extends RESTPostAPIChannelMes
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#start-thread-without-message}
  */
-export type RESTPostAPIChannelThreadsResult = APIChannel;
+export type RESTPostAPIChannelThreadsResult =
+	| APIAnnouncementThreadChannel
+	| APIPrivateThreadChannel
+	| APIPublicThreadChannel;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#join-thread}

--- a/rest/v9/channel.ts
+++ b/rest/v9/channel.ts
@@ -25,6 +25,9 @@ import type {
 	APIAttachment,
 	APIMessageTopLevelComponent,
 	APIMessagePin,
+	APIAnnouncementThreadChannel,
+	APIPrivateThreadChannel,
+	APIPublicThreadChannel,
 } from '../../payloads/v9/index';
 import type { _AddUndefinedToPossiblyUndefinedPropertiesOfInterface, _StrictPartial } from '../../utils/internals';
 import type { RESTAPIPoll } from './poll';
@@ -780,7 +783,10 @@ export interface RESTPostAPIChannelThreadsJSONBody extends RESTPostAPIChannelMes
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#start-thread-without-message}
  */
-export type RESTPostAPIChannelThreadsResult = APIChannel;
+export type RESTPostAPIChannelThreadsResult =
+	| APIAnnouncementThreadChannel
+	| APIPrivateThreadChannel
+	| APIPublicThreadChannel;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#join-thread}


### PR DESCRIPTION
When starting a thread, Discord returns the thread. This narrows the type down.