### PR TITLE
fix: Narrow thread-related properties for channels

### DIFF
--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -127,10 +127,6 @@ export interface APIGuildChannel<T extends ChannelType> extends APIChannelBase<T
 	permission_overwrites?: APIOverwrite[];
 	/**
 	 * ID of the parent category for a channel (each parent category can contain up to 50 channels)
-	 *
-	 * OR
-	 *
-	 * ID of the parent channel for a thread
 	 */
 	parent_id?: Snowflake | null;
 	/**
@@ -163,7 +159,9 @@ export interface APIGuildTextChannel<T extends ChannelType.GuildForum | ChannelT
 
 export type APITextChannel = APIGuildTextChannel<ChannelType.GuildText>;
 export type APINewsChannel = APIGuildTextChannel<ChannelType.GuildAnnouncement>;
-export interface APIGuildCategoryChannel extends APIGuildChannel<ChannelType.GuildCategory>, APISortableChannel {}
+export interface APIGuildCategoryChannel extends APIGuildChannel<ChannelType.GuildCategory>, APISortableChannel {
+	parent_id?: null;
+}
 
 export interface APIVoiceChannelBase<T extends ChannelType>
 	extends APIGuildChannel<T>,
@@ -277,6 +275,10 @@ export interface APIThreadChannel<Type extends ThreadChannelType = ThreadChannel
 	 * The IDs of the set of tags that have been applied to a thread in a thread-only channel
 	 */
 	applied_tags: Snowflake[];
+  /**
+	 * ID of the parent channel for the thread
+	 */
+	parent_id?: Snowflake;
 }
 
 export type APIPublicThreadChannel = APIThreadChannel<ChannelType.PublicThread>;

--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -271,7 +271,7 @@ export interface APIThreadChannel<Type extends ThreadChannelType = ThreadChannel
 	 * Similar to `message_count` on message creation, but won't decrement when a message is deleted
 	 */
 	total_message_sent?: number;
-  /**
+	/**
 	 * ID of the parent channel for the thread
 	 */
 	parent_id?: Snowflake;
@@ -397,7 +397,7 @@ export interface APIThreadOnlyChannel<T extends ChannelType.GuildForum | Channel
 	 * The default sort order type used to order posts in a thread-only channel
 	 */
 	default_sort_order: SortOrderType | null;
-  /**
+	/**
 	 * The IDs of the set of tags that have been applied to a thread in a thread-only channel
 	 */
 	applied_tags: Snowflake[];

--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -271,10 +271,6 @@ export interface APIThreadChannel<Type extends ThreadChannelType = ThreadChannel
 	 * Similar to `message_count` on message creation, but won't decrement when a message is deleted
 	 */
 	total_message_sent?: number;
-	/**
-	 * The IDs of the set of tags that have been applied to a thread in a thread-only channel
-	 */
-	applied_tags: Snowflake[];
   /**
 	 * ID of the parent channel for the thread
 	 */
@@ -401,6 +397,10 @@ export interface APIThreadOnlyChannel<T extends ChannelType.GuildForum | Channel
 	 * The default sort order type used to order posts in a thread-only channel
 	 */
 	default_sort_order: SortOrderType | null;
+  /**
+	 * The IDs of the set of tags that have been applied to a thread in a thread-only channel
+	 */
+	applied_tags: Snowflake[];
 }
 
 export interface APIGuildForumChannel extends APIThreadOnlyChannel<ChannelType.GuildForum> {

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -125,12 +125,8 @@ export interface APIGuildChannel<T extends ChannelType> extends APIChannelBase<T
 	 * @see {@link https://discord.com/developers/docs/resources/channel#overwrite-object}
 	 */
 	permission_overwrites?: APIOverwrite[];
-	/**
+  /**
 	 * ID of the parent category for a channel (each parent category can contain up to 50 channels)
-	 *
-	 * OR
-	 *
-	 * ID of the parent channel for a thread
 	 */
 	parent_id?: Snowflake | null;
 	/**
@@ -163,7 +159,9 @@ export interface APIGuildTextChannel<T extends ChannelType.GuildForum | ChannelT
 
 export type APITextChannel = APIGuildTextChannel<ChannelType.GuildText>;
 export type APINewsChannel = APIGuildTextChannel<ChannelType.GuildAnnouncement>;
-export interface APIGuildCategoryChannel extends APIGuildChannel<ChannelType.GuildCategory>, APISortableChannel {}
+export interface APIGuildCategoryChannel extends APIGuildChannel<ChannelType.GuildCategory>, APISortableChannel {
+  parent_id?: null;
+}
 
 export interface APIVoiceChannelBase<T extends ChannelType>
 	extends APIGuildChannel<T>,
@@ -277,6 +275,10 @@ export interface APIThreadChannel<Type extends ThreadChannelType = ThreadChannel
 	 * The IDs of the set of tags that have been applied to a thread in a thread-only channel
 	 */
 	applied_tags: Snowflake[];
+  /**
+	 * ID of the parent channel for the thread
+	 */
+	parent_id?: Snowflake;
 }
 
 export type APIPublicThreadChannel = APIThreadChannel<ChannelType.PublicThread>;

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -271,10 +271,6 @@ export interface APIThreadChannel<Type extends ThreadChannelType = ThreadChannel
 	 * Similar to `message_count` on message creation, but won't decrement when a message is deleted
 	 */
 	total_message_sent?: number;
-	/**
-	 * The IDs of the set of tags that have been applied to a thread in a thread-only channel
-	 */
-	applied_tags: Snowflake[];
   /**
 	 * ID of the parent channel for the thread
 	 */
@@ -401,6 +397,10 @@ export interface APIThreadOnlyChannel<T extends ChannelType.GuildForum | Channel
 	 * The default sort order type used to order posts in a thread-only channel
 	 */
 	default_sort_order: SortOrderType | null;
+  /**
+	 * The IDs of the set of tags that have been applied to a thread in a thread-only channel
+	 */
+	applied_tags: Snowflake[];
 }
 
 export interface APIGuildForumChannel extends APIThreadOnlyChannel<ChannelType.GuildForum> {

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -125,7 +125,7 @@ export interface APIGuildChannel<T extends ChannelType> extends APIChannelBase<T
 	 * @see {@link https://discord.com/developers/docs/resources/channel#overwrite-object}
 	 */
 	permission_overwrites?: APIOverwrite[];
-  /**
+	/**
 	 * ID of the parent category for a channel (each parent category can contain up to 50 channels)
 	 */
 	parent_id?: Snowflake | null;
@@ -160,7 +160,7 @@ export interface APIGuildTextChannel<T extends ChannelType.GuildForum | ChannelT
 export type APITextChannel = APIGuildTextChannel<ChannelType.GuildText>;
 export type APINewsChannel = APIGuildTextChannel<ChannelType.GuildAnnouncement>;
 export interface APIGuildCategoryChannel extends APIGuildChannel<ChannelType.GuildCategory>, APISortableChannel {
-  parent_id?: null;
+	parent_id?: null;
 }
 
 export interface APIVoiceChannelBase<T extends ChannelType>
@@ -271,7 +271,7 @@ export interface APIThreadChannel<Type extends ThreadChannelType = ThreadChannel
 	 * Similar to `message_count` on message creation, but won't decrement when a message is deleted
 	 */
 	total_message_sent?: number;
-  /**
+	/**
 	 * ID of the parent channel for the thread
 	 */
 	parent_id?: Snowflake;
@@ -397,7 +397,7 @@ export interface APIThreadOnlyChannel<T extends ChannelType.GuildForum | Channel
 	 * The default sort order type used to order posts in a thread-only channel
 	 */
 	default_sort_order: SortOrderType | null;
-  /**
+	/**
 	 * The IDs of the set of tags that have been applied to a thread in a thread-only channel
 	 */
 	applied_tags: Snowflake[];

--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -127,10 +127,6 @@ export interface APIGuildChannel<T extends ChannelType> extends APIChannelBase<T
 	permission_overwrites?: APIOverwrite[];
 	/**
 	 * ID of the parent category for a channel (each parent category can contain up to 50 channels)
-	 *
-	 * OR
-	 *
-	 * ID of the parent channel for a thread
 	 */
 	parent_id?: Snowflake | null;
 	/**
@@ -163,7 +159,9 @@ export interface APIGuildTextChannel<T extends ChannelType.GuildForum | ChannelT
 
 export type APITextChannel = APIGuildTextChannel<ChannelType.GuildText>;
 export type APINewsChannel = APIGuildTextChannel<ChannelType.GuildAnnouncement>;
-export interface APIGuildCategoryChannel extends APIGuildChannel<ChannelType.GuildCategory>, APISortableChannel {}
+export interface APIGuildCategoryChannel extends APIGuildChannel<ChannelType.GuildCategory>, APISortableChannel {
+	parent_id?: null;
+}
 
 export interface APIVoiceChannelBase<T extends ChannelType>
 	extends APIGuildChannel<T>,
@@ -277,6 +275,10 @@ export interface APIThreadChannel<Type extends ThreadChannelType = ThreadChannel
 	 * The IDs of the set of tags that have been applied to a thread in a thread-only channel
 	 */
 	applied_tags: Snowflake[];
+  /**
+	 * ID of the parent channel for the thread
+	 */
+	parent_id?: Snowflake;
 }
 
 export type APIPublicThreadChannel = APIThreadChannel<ChannelType.PublicThread>;

--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -271,7 +271,7 @@ export interface APIThreadChannel<Type extends ThreadChannelType = ThreadChannel
 	 * Similar to `message_count` on message creation, but won't decrement when a message is deleted
 	 */
 	total_message_sent?: number;
-  /**
+	/**
 	 * ID of the parent channel for the thread
 	 */
 	parent_id?: Snowflake;
@@ -397,7 +397,7 @@ export interface APIThreadOnlyChannel<T extends ChannelType.GuildForum | Channel
 	 * The default sort order type used to order posts in a thread-only channel
 	 */
 	default_sort_order: SortOrderType | null;
-  /**
+	/**
 	 * The IDs of the set of tags that have been applied to a thread in a thread-only channel
 	 */
 	applied_tags: Snowflake[];

--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -271,10 +271,6 @@ export interface APIThreadChannel<Type extends ThreadChannelType = ThreadChannel
 	 * Similar to `message_count` on message creation, but won't decrement when a message is deleted
 	 */
 	total_message_sent?: number;
-	/**
-	 * The IDs of the set of tags that have been applied to a thread in a thread-only channel
-	 */
-	applied_tags: Snowflake[];
   /**
 	 * ID of the parent channel for the thread
 	 */
@@ -401,6 +397,10 @@ export interface APIThreadOnlyChannel<T extends ChannelType.GuildForum | Channel
 	 * The default sort order type used to order posts in a thread-only channel
 	 */
 	default_sort_order: SortOrderType | null;
+  /**
+	 * The IDs of the set of tags that have been applied to a thread in a thread-only channel
+	 */
+	applied_tags: Snowflake[];
 }
 
 export interface APIGuildForumChannel extends APIThreadOnlyChannel<ChannelType.GuildForum> {

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -125,12 +125,8 @@ export interface APIGuildChannel<T extends ChannelType> extends APIChannelBase<T
 	 * @see {@link https://discord.com/developers/docs/resources/channel#overwrite-object}
 	 */
 	permission_overwrites?: APIOverwrite[];
-	/**
+  /**
 	 * ID of the parent category for a channel (each parent category can contain up to 50 channels)
-	 *
-	 * OR
-	 *
-	 * ID of the parent channel for a thread
 	 */
 	parent_id?: Snowflake | null;
 	/**
@@ -163,7 +159,9 @@ export interface APIGuildTextChannel<T extends ChannelType.GuildForum | ChannelT
 
 export type APITextChannel = APIGuildTextChannel<ChannelType.GuildText>;
 export type APINewsChannel = APIGuildTextChannel<ChannelType.GuildAnnouncement>;
-export interface APIGuildCategoryChannel extends APIGuildChannel<ChannelType.GuildCategory>, APISortableChannel {}
+export interface APIGuildCategoryChannel extends APIGuildChannel<ChannelType.GuildCategory>, APISortableChannel {
+  parent_id?: null;
+}
 
 export interface APIVoiceChannelBase<T extends ChannelType>
 	extends APIGuildChannel<T>,
@@ -277,6 +275,10 @@ export interface APIThreadChannel<Type extends ThreadChannelType = ThreadChannel
 	 * The IDs of the set of tags that have been applied to a thread in a thread-only channel
 	 */
 	applied_tags: Snowflake[];
+  /**
+	 * ID of the parent channel for the thread
+	 */
+	parent_id?: Snowflake;
 }
 
 export type APIPublicThreadChannel = APIThreadChannel<ChannelType.PublicThread>;

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -271,10 +271,6 @@ export interface APIThreadChannel<Type extends ThreadChannelType = ThreadChannel
 	 * Similar to `message_count` on message creation, but won't decrement when a message is deleted
 	 */
 	total_message_sent?: number;
-	/**
-	 * The IDs of the set of tags that have been applied to a thread in a thread-only channel
-	 */
-	applied_tags: Snowflake[];
   /**
 	 * ID of the parent channel for the thread
 	 */
@@ -401,6 +397,10 @@ export interface APIThreadOnlyChannel<T extends ChannelType.GuildForum | Channel
 	 * The default sort order type used to order posts in a thread-only channel
 	 */
 	default_sort_order: SortOrderType | null;
+  /**
+	 * The IDs of the set of tags that have been applied to a thread in a thread-only channel
+	 */
+	applied_tags: Snowflake[];
 }
 
 export interface APIGuildForumChannel extends APIThreadOnlyChannel<ChannelType.GuildForum> {

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -125,7 +125,7 @@ export interface APIGuildChannel<T extends ChannelType> extends APIChannelBase<T
 	 * @see {@link https://discord.com/developers/docs/resources/channel#overwrite-object}
 	 */
 	permission_overwrites?: APIOverwrite[];
-  /**
+	/**
 	 * ID of the parent category for a channel (each parent category can contain up to 50 channels)
 	 */
 	parent_id?: Snowflake | null;
@@ -160,7 +160,7 @@ export interface APIGuildTextChannel<T extends ChannelType.GuildForum | ChannelT
 export type APITextChannel = APIGuildTextChannel<ChannelType.GuildText>;
 export type APINewsChannel = APIGuildTextChannel<ChannelType.GuildAnnouncement>;
 export interface APIGuildCategoryChannel extends APIGuildChannel<ChannelType.GuildCategory>, APISortableChannel {
-  parent_id?: null;
+	parent_id?: null;
 }
 
 export interface APIVoiceChannelBase<T extends ChannelType>
@@ -271,7 +271,7 @@ export interface APIThreadChannel<Type extends ThreadChannelType = ThreadChannel
 	 * Similar to `message_count` on message creation, but won't decrement when a message is deleted
 	 */
 	total_message_sent?: number;
-  /**
+	/**
 	 * ID of the parent channel for the thread
 	 */
 	parent_id?: Snowflake;
@@ -397,7 +397,7 @@ export interface APIThreadOnlyChannel<T extends ChannelType.GuildForum | Channel
 	 * The default sort order type used to order posts in a thread-only channel
 	 */
 	default_sort_order: SortOrderType | null;
-  /**
+	/**
 	 * The IDs of the set of tags that have been applied to a thread in a thread-only channel
 	 */
 	applied_tags: Snowflake[];


### PR DESCRIPTION
Narrows the property **`parent_id`** for:

- **`APIThreadChannel`**: now includes` parent_id?: Snowflake`,  reflecting its parent thread relationship.

- **`APIGuildCategoryChannel`**: now includes `parent_id?: null`, clarifying that categories do not have a parent.

Narrows the property **`applied_tags`** for:

- **`APIThreadOnlyChannel`**: now **`applied_tags: Snowflake[]`** is explicit to this type.


Reference: https://discord.com/developers/docs/resources/channel#channel-object-channel-structure