### PR TITLE
fix: `@unstable` membership screening

### DIFF
--- a/deno/payloads/v10/guild.ts
+++ b/deno/payloads/v10/guild.ts
@@ -1074,6 +1074,9 @@ export interface APIGuildWelcomeScreenChannel {
 	emoji_name: string | null;
 }
 
+/**
+ * @unstable https://github.com/discord/discord-api-docs/pull/2547
+ */
 export interface APIGuildMembershipScreening {
 	/**
 	 * When the fields were last updated
@@ -1089,8 +1092,9 @@ export interface APIGuildMembershipScreening {
 	description: string | null;
 }
 
-// TODO: make this a union based on the type in the future, when new types are added
-
+/**
+ * @unstable https://github.com/discord/discord-api-docs/pull/2547
+ */
 export interface APIGuildMembershipScreeningField {
 	/**
 	 * The type of field
@@ -1110,6 +1114,9 @@ export interface APIGuildMembershipScreeningField {
 	required: boolean;
 }
 
+/**
+ * @unstable https://github.com/discord/discord-api-docs/pull/2547
+ */
 export enum MembershipScreeningFieldType {
 	/**
 	 * Server Rules

--- a/deno/payloads/v9/guild.ts
+++ b/deno/payloads/v9/guild.ts
@@ -1066,6 +1066,9 @@ export interface APIGuildWelcomeScreenChannel {
 	emoji_name: string | null;
 }
 
+/**
+ * @unstable https://github.com/discord/discord-api-docs/pull/2547
+ */
 export interface APIGuildMembershipScreening {
 	/**
 	 * When the fields were last updated
@@ -1081,8 +1084,9 @@ export interface APIGuildMembershipScreening {
 	description: string | null;
 }
 
-// TODO: make this a union based on the type in the future, when new types are added
-
+/**
+ * @unstable https://github.com/discord/discord-api-docs/pull/2547
+ */
 export interface APIGuildMembershipScreeningField {
 	/**
 	 * The type of field
@@ -1102,6 +1106,9 @@ export interface APIGuildMembershipScreeningField {
 	required: boolean;
 }
 
+/**
+ * @unstable https://github.com/discord/discord-api-docs/pull/2547
+ */
 export enum MembershipScreeningFieldType {
 	/**
 	 * Server Rules

--- a/deno/rest/v10/guild.ts
+++ b/deno/rest/v10/guild.ts
@@ -931,6 +931,9 @@ export type RESTGetAPIGuildWidgetImageResult = ArrayBuffer;
 
 export type RESTGetAPIGuildMemberVerificationResult = APIGuildMembershipScreening;
 
+/**
+ * @unstable https://github.com/discord/discord-api-docs/pull/2547
+ */
 export interface RESTPatchAPIGuildMemberVerificationJSONBody {
 	/**
 	 * Whether Membership Screening is enabled
@@ -946,6 +949,9 @@ export interface RESTPatchAPIGuildMemberVerificationJSONBody {
 	description?: string | null | undefined;
 }
 
+/**
+ * @unstable https://github.com/discord/discord-api-docs/pull/2547
+ */
 export type RESTPatchAPIGuildMemberVerificationResult = APIGuildMembershipScreening;
 
 /**

--- a/deno/rest/v10/mod.ts
+++ b/deno/rest/v10/mod.ts
@@ -808,6 +808,8 @@ export const Routes = {
 	 * Route for:
 	 * - GET   `/guilds/{guild.id}/member-verification`
 	 * - PATCH `/guilds/{guild.id}/member-verification`
+	 *
+	 * @unstable https://github.com/discord/discord-api-docs/pull/2547
 	 */
 	guildMemberVerification(guildId: Snowflake) {
 		return `/guilds/${guildId}/member-verification` as const;

--- a/deno/rest/v9/guild.ts
+++ b/deno/rest/v9/guild.ts
@@ -937,6 +937,9 @@ export type RESTGetAPIGuildWidgetImageResult = ArrayBuffer;
 
 export type RESTGetAPIGuildMemberVerificationResult = APIGuildMembershipScreening;
 
+/**
+ * @unstable https://github.com/discord/discord-api-docs/pull/2547
+ */
 export interface RESTPatchAPIGuildMemberVerificationJSONBody {
 	/**
 	 * Whether Membership Screening is enabled
@@ -952,6 +955,9 @@ export interface RESTPatchAPIGuildMemberVerificationJSONBody {
 	description?: string | null | undefined;
 }
 
+/**
+ * @unstable https://github.com/discord/discord-api-docs/pull/2547
+ */
 export type RESTPatchAPIGuildMemberVerificationResult = APIGuildMembershipScreening;
 
 /**

--- a/deno/rest/v9/mod.ts
+++ b/deno/rest/v9/mod.ts
@@ -817,6 +817,8 @@ export const Routes = {
 	 * Route for:
 	 * - GET   `/guilds/{guild.id}/member-verification`
 	 * - PATCH `/guilds/{guild.id}/member-verification`
+	 *
+	 * @unstable https://github.com/discord/discord-api-docs/pull/2547
 	 */
 	guildMemberVerification(guildId: Snowflake) {
 		return `/guilds/${guildId}/member-verification` as const;

--- a/payloads/v10/guild.ts
+++ b/payloads/v10/guild.ts
@@ -1074,6 +1074,9 @@ export interface APIGuildWelcomeScreenChannel {
 	emoji_name: string | null;
 }
 
+/**
+ * @unstable https://github.com/discord/discord-api-docs/pull/2547
+ */
 export interface APIGuildMembershipScreening {
 	/**
 	 * When the fields were last updated
@@ -1089,8 +1092,9 @@ export interface APIGuildMembershipScreening {
 	description: string | null;
 }
 
-// TODO: make this a union based on the type in the future, when new types are added
-
+/**
+ * @unstable https://github.com/discord/discord-api-docs/pull/2547
+ */
 export interface APIGuildMembershipScreeningField {
 	/**
 	 * The type of field
@@ -1110,6 +1114,9 @@ export interface APIGuildMembershipScreeningField {
 	required: boolean;
 }
 
+/**
+ * @unstable https://github.com/discord/discord-api-docs/pull/2547
+ */
 export enum MembershipScreeningFieldType {
 	/**
 	 * Server Rules

--- a/payloads/v9/guild.ts
+++ b/payloads/v9/guild.ts
@@ -1066,6 +1066,9 @@ export interface APIGuildWelcomeScreenChannel {
 	emoji_name: string | null;
 }
 
+/**
+ * @unstable https://github.com/discord/discord-api-docs/pull/2547
+ */
 export interface APIGuildMembershipScreening {
 	/**
 	 * When the fields were last updated
@@ -1081,8 +1084,9 @@ export interface APIGuildMembershipScreening {
 	description: string | null;
 }
 
-// TODO: make this a union based on the type in the future, when new types are added
-
+/**
+ * @unstable https://github.com/discord/discord-api-docs/pull/2547
+ */
 export interface APIGuildMembershipScreeningField {
 	/**
 	 * The type of field
@@ -1102,6 +1106,9 @@ export interface APIGuildMembershipScreeningField {
 	required: boolean;
 }
 
+/**
+ * @unstable https://github.com/discord/discord-api-docs/pull/2547
+ */
 export enum MembershipScreeningFieldType {
 	/**
 	 * Server Rules

--- a/rest/v10/guild.ts
+++ b/rest/v10/guild.ts
@@ -931,6 +931,9 @@ export type RESTGetAPIGuildWidgetImageResult = ArrayBuffer;
 
 export type RESTGetAPIGuildMemberVerificationResult = APIGuildMembershipScreening;
 
+/**
+ * @unstable https://github.com/discord/discord-api-docs/pull/2547
+ */
 export interface RESTPatchAPIGuildMemberVerificationJSONBody {
 	/**
 	 * Whether Membership Screening is enabled
@@ -946,6 +949,9 @@ export interface RESTPatchAPIGuildMemberVerificationJSONBody {
 	description?: string | null | undefined;
 }
 
+/**
+ * @unstable https://github.com/discord/discord-api-docs/pull/2547
+ */
 export type RESTPatchAPIGuildMemberVerificationResult = APIGuildMembershipScreening;
 
 /**

--- a/rest/v10/index.ts
+++ b/rest/v10/index.ts
@@ -808,6 +808,8 @@ export const Routes = {
 	 * Route for:
 	 * - GET   `/guilds/{guild.id}/member-verification`
 	 * - PATCH `/guilds/{guild.id}/member-verification`
+	 *
+	 * @unstable https://github.com/discord/discord-api-docs/pull/2547
 	 */
 	guildMemberVerification(guildId: Snowflake) {
 		return `/guilds/${guildId}/member-verification` as const;

--- a/rest/v9/guild.ts
+++ b/rest/v9/guild.ts
@@ -937,6 +937,9 @@ export type RESTGetAPIGuildWidgetImageResult = ArrayBuffer;
 
 export type RESTGetAPIGuildMemberVerificationResult = APIGuildMembershipScreening;
 
+/**
+ * @unstable https://github.com/discord/discord-api-docs/pull/2547
+ */
 export interface RESTPatchAPIGuildMemberVerificationJSONBody {
 	/**
 	 * Whether Membership Screening is enabled
@@ -952,6 +955,9 @@ export interface RESTPatchAPIGuildMemberVerificationJSONBody {
 	description?: string | null | undefined;
 }
 
+/**
+ * @unstable https://github.com/discord/discord-api-docs/pull/2547
+ */
 export type RESTPatchAPIGuildMemberVerificationResult = APIGuildMembershipScreening;
 
 /**

--- a/rest/v9/index.ts
+++ b/rest/v9/index.ts
@@ -817,6 +817,8 @@ export const Routes = {
 	 * Route for:
 	 * - GET   `/guilds/{guild.id}/member-verification`
 	 * - PATCH `/guilds/{guild.id}/member-verification`
+	 *
+	 * @unstable https://github.com/discord/discord-api-docs/pull/2547
 	 */
 	guildMemberVerification(guildId: Snowflake) {
 		return `/guilds/${guildId}/member-verification` as const;


### PR DESCRIPTION
Some documentation was removed in https://github.com/discord/discord-api-docs/pull/2547, so existing types are now `@unstable`.