### PR TITLE
fix: tsdoc unstable tag is block not modifier

### DIFF
--- a/tsdoc.json
+++ b/tsdoc.json
@@ -19,7 +19,7 @@
 		},
 		{
 			"tagName": "@unstable",
-			"syntaxKind": "modifier"
+			"syntaxKind": "block"
 		},
 		{
 			"tagName": "@default",


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Needed to be parsed correctly by TSDoc for display on discord.js docs website

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
