### PR TITLE
feat(Webhooks): add entitlement update and delete events

### DIFF
--- a/deno/payloads/v10/webhook.ts
+++ b/deno/payloads/v10/webhook.ts
@@ -126,12 +126,12 @@ export type APIWebhookEventEntitlementCreateData = APIEntitlement;
 /**
  * @unstable
  */
-export type APIWebhookEventEntitlementUpdateData = APIEntitlement;
+export type APIWebhookEventEntitlementDeleteData = APIEntitlement;
 
 /**
  * @unstable
  */
-export type APIWebhookEventEntitlementDeleteData = APIEntitlement;
+export type APIWebhookEventEntitlementUpdateData = APIEntitlement;
 
 export type APIWebhookEventQuestUserEnrollmentData = never;
 

--- a/deno/payloads/v9/webhook.ts
+++ b/deno/payloads/v9/webhook.ts
@@ -126,12 +126,12 @@ export type APIWebhookEventEntitlementCreateData = APIEntitlement;
 /**
  * @unstable
  */
-export type APIWebhookEventEntitlementUpdateData = APIEntitlement;
+export type APIWebhookEventEntitlementDeleteData = APIEntitlement;
 
 /**
  * @unstable
  */
-export type APIWebhookEventEntitlementDeleteData = APIEntitlement;
+export type APIWebhookEventEntitlementUpdateData = APIEntitlement;
 
 export type APIWebhookEventQuestUserEnrollmentData = never;
 

--- a/payloads/v10/webhook.ts
+++ b/payloads/v10/webhook.ts
@@ -126,12 +126,12 @@ export type APIWebhookEventEntitlementCreateData = APIEntitlement;
 /**
  * @unstable
  */
-export type APIWebhookEventEntitlementUpdateData = APIEntitlement;
+export type APIWebhookEventEntitlementDeleteData = APIEntitlement;
 
 /**
  * @unstable
  */
-export type APIWebhookEventEntitlementDeleteData = APIEntitlement;
+export type APIWebhookEventEntitlementUpdateData = APIEntitlement;
 
 export type APIWebhookEventQuestUserEnrollmentData = never;
 

--- a/payloads/v9/webhook.ts
+++ b/payloads/v9/webhook.ts
@@ -126,12 +126,12 @@ export type APIWebhookEventEntitlementCreateData = APIEntitlement;
 /**
  * @unstable
  */
-export type APIWebhookEventEntitlementUpdateData = APIEntitlement;
+export type APIWebhookEventEntitlementDeleteData = APIEntitlement;
 
 /**
  * @unstable
  */
-export type APIWebhookEventEntitlementDeleteData = APIEntitlement;
+export type APIWebhookEventEntitlementUpdateData = APIEntitlement;
 
 export type APIWebhookEventQuestUserEnrollmentData = never;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The `ENTITLEMENT_UPDATE` and `ENTITLEMENT_DELETE` webhook events are usable through the developer portal and use the same payload as you would get from the gateway, but they aren't documented yet.

<img width="497" height="439" alt="image" src="https://github.com/user-attachments/assets/ffbfcaa3-9a38-4b4b-bf22-0c7a2f3350d5" />

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
