### PR TITLE
feat(Webhooks): add social SDK events

### DIFF
--- a/deno/payloads/v10/webhook.ts
+++ b/deno/payloads/v10/webhook.ts
@@ -11,7 +11,105 @@ import type {
 	ApplicationIntegrationType,
 	OAuth2Scopes,
 	APIWebhookSourceChannel,
+	MessageFlags,
+	MessageType,
+	APIChannel,
+	APIMessage,
 } from './mod.ts';
+
+/**
+ * @see {@link https://discord.com/developers/docs/events/webhook-events#lobby-message-object}
+ */
+export interface APILobbyMessage {
+	/**
+	 * ID of the message
+	 */
+	id: Snowflake;
+	/**
+	 * Type of message
+	 *
+	 * @see {@link https://discord.com/developers/docs/resources/message#message-object-message-types}
+	 */
+	type: MessageType;
+	/**
+	 * Contents of the message
+	 */
+	content: string;
+	/**
+	 * ID of the lobby where the message was sent
+	 */
+	lobby_id: Snowflake;
+	/**
+	 * ID of the channel the message was sent in
+	 */
+	channel_id: Snowflake;
+	/**
+	 * 	Author of the message
+	 */
+	author: APIUser;
+	/**
+	 * Additional metadata for the message (key-value pairs)
+	 */
+	metadata?: Record<string, string>;
+	/**
+	 * Message flags combined as a bitfield
+	 *
+	 * @see {@link https://discord.com/developers/docs/resources/message#message-object-message-flags}
+	 * @see {@link https://en.wikipedia.org/wiki/Bit_field}
+	 */
+	flags: MessageFlags;
+	/**
+	 * ID of the application (only present during active Social SDK sessions)
+	 */
+	application_id?: Snowflake;
+}
+
+/**
+ * @see {@link https://discord.com/developers/docs/events/webhook-events#passthrough-message-object}
+ */
+export interface APIPassthroughMessage {
+	/**
+	 * ID of the message
+	 */
+	id: Snowflake;
+	/**
+	 * Type of message
+	 *
+	 * @see {@link https://discord.com/developers/docs/resources/message#message-object-message-types}
+	 */
+	type: MessageType;
+	/**
+	 * Contents of the message
+	 */
+	content: string;
+	/**
+	 * ID of the channel the message was sent in
+	 */
+	channel_id: Snowflake;
+	/**
+	 * ID of the message recipient
+	 */
+	recipient_id: Snowflake;
+	/**
+	 * 	Author of the message
+	 */
+	author: APIUser;
+	/**
+	 * Message flags combined as a bitfield
+	 *
+	 * @see {@link https://discord.com/developers/docs/resources/message#message-object-message-flags}
+	 * @see {@link https://en.wikipedia.org/wiki/Bit_field}
+	 */
+	flags: MessageFlags;
+	/**
+	 * ID of the application that created the message
+	 */
+	application_id: Snowflake;
+	/**
+	 * Channel object with recipient information
+	 */
+	channel: APIChannel;
+}
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#webhook-object}
@@ -90,9 +188,24 @@ export type APIWebhookEventBody =
 			ApplicationWebhookEventType.ApplicationDeauthorized,
 			APIWebhookEventApplicationDeauthorizedData
 	  >
+	| APIWebhookEventEventBase<
+			ApplicationWebhookEventType.GameDirectMessageCreate,
+			APIWebhookEventGameDirectMessageCreateData
+	  >
+	| APIWebhookEventEventBase<
+			ApplicationWebhookEventType.GameDirectMessageDelete,
+			APIWebhookEventGameDirectMessageDeleteData
+	  >
+	| APIWebhookEventEventBase<
+			ApplicationWebhookEventType.GameDirectMessageUpdate,
+			APIWebhookEventGameDirectMessageUpdateData
+	  >
 	| APIWebhookEventEventBase<ApplicationWebhookEventType.EntitlementCreate, APIWebhookEventEntitlementCreateData>
 	| APIWebhookEventEventBase<ApplicationWebhookEventType.EntitlementDelete, APIWebhookEventEntitlementDeleteData>
 	| APIWebhookEventEventBase<ApplicationWebhookEventType.EntitlementUpdate, APIWebhookEventEntitlementUpdateData>
+	| APIWebhookEventEventBase<ApplicationWebhookEventType.LobbyMessageCreate, APIWebhookEventLobbyMessageCreateData>
+	| APIWebhookEventEventBase<ApplicationWebhookEventType.LobbyMessageDelete, APIWebhookEventLobbyMessageDeleteData>
+	| APIWebhookEventEventBase<ApplicationWebhookEventType.LobbyMessageUpdate, APIWebhookEventLobbyMessageUpdateData>
 	| APIWebhookEventEventBase<ApplicationWebhookEventType.QuestUserEnrollment, APIWebhookEventQuestUserEnrollmentData>;
 
 export interface APIWebhookEventApplicationAuthorizedData {
@@ -132,6 +245,60 @@ export type APIWebhookEventEntitlementDeleteData = APIEntitlement;
  * @unstable
  */
 export type APIWebhookEventEntitlementUpdateData = APIEntitlement;
+
+export type APIWebhookEventGameDirectMessageCreateData =
+	| APIPassthroughMessage
+	| (APIMessage & {
+			/**
+			 * ID of the lobby where the message was created (only present in Linked Channel messages)
+			 */
+			lobby_id?: Snowflake;
+			/**
+			 * Channel object with recipient information
+			 */
+			channel: APIChannel;
+	  });
+
+export type APIWebhookEventGameDirectMessageDeleteData =
+	| APIPassthroughMessage
+	| (APIMessage & {
+			/**
+			 * ID of the lobby where the message was created (only present in Linked Channel messages)
+			 */
+			lobby_id?: Snowflake;
+			/**
+			 * Channel object with recipient information
+			 */
+			channel: APIChannel;
+	  });
+
+export type APIWebhookEventGameDirectMessageUpdateData =
+	| APIPassthroughMessage
+	| (APIMessage & {
+			/**
+			 * ID of the lobby where the message was created (only present in Linked Channel messages)
+			 */
+			lobby_id?: Snowflake;
+			/**
+			 * Channel object with recipient information
+			 */
+			channel: APIChannel;
+	  });
+
+export type APIWebhookEventLobbyMessageCreateData = APILobbyMessage;
+
+export interface APIWebhookEventLobbyMessageDeleteData {
+	/**
+	 * ID of the message
+	 */
+	id: Snowflake;
+	/**
+	 * ID of the lobby where the message was sent
+	 */
+	lobby_id: Snowflake;
+}
+
+export type APIWebhookEventLobbyMessageUpdateData = APILobbyMessage;
 
 export type APIWebhookEventQuestUserEnrollmentData = never;
 
@@ -215,6 +382,30 @@ export enum ApplicationWebhookEventType {
 	 * User was added to a Quest (currently unavailable)
 	 */
 	QuestUserEnrollment = 'QUEST_USER_ENROLLMENT',
+	/**
+	 * Sent when a message is created in a lobby
+	 */
+	LobbyMessageCreate = 'LOBBY_MESSAGE_CREATE',
+	/**
+	 * Sent when a message is updated in a lobby
+	 */
+	LobbyMessageUpdate = 'LOBBY_MESSAGE_UPDATE',
+	/**
+	 * Sent when a message is deleted from a lobby
+	 */
+	LobbyMessageDelete = 'LOBBY_MESSAGE_DELETE',
+	/**
+	 * Sent when a direct message is created during an active Social SDK session
+	 */
+	GameDirectMessageCreate = 'GAME_DIRECT_MESSAGE_CREATE',
+	/**
+	 * Sent when a direct message is updated during an active Social SDK session
+	 */
+	GameDirectMessageUpdate = 'GAME_DIRECT_MESSAGE_UPDATE',
+	/**
+	 * Sent when a direct message is deleted during an active Social SDK session
+	 */
+	GameDirectMessageDelete = 'GAME_DIRECT_MESSAGE_DELETE',
 }
 
 /**

--- a/deno/payloads/v9/webhook.ts
+++ b/deno/payloads/v9/webhook.ts
@@ -11,7 +11,105 @@ import type {
 	ApplicationIntegrationType,
 	OAuth2Scopes,
 	APIWebhookSourceChannel,
+	MessageFlags,
+	MessageType,
+	APIChannel,
+	APIMessage,
 } from './mod.ts';
+
+/**
+ * @see {@link https://discord.com/developers/docs/events/webhook-events#lobby-message-object}
+ */
+export interface APILobbyMessage {
+	/**
+	 * ID of the message
+	 */
+	id: Snowflake;
+	/**
+	 * Type of message
+	 *
+	 * @see {@link https://discord.com/developers/docs/resources/message#message-object-message-types}
+	 */
+	type: MessageType;
+	/**
+	 * Contents of the message
+	 */
+	content: string;
+	/**
+	 * ID of the lobby where the message was sent
+	 */
+	lobby_id: Snowflake;
+	/**
+	 * ID of the channel the message was sent in
+	 */
+	channel_id: Snowflake;
+	/**
+	 * 	Author of the message
+	 */
+	author: APIUser;
+	/**
+	 * Additional metadata for the message (key-value pairs)
+	 */
+	metadata?: Record<string, string>;
+	/**
+	 * Message flags combined as a bitfield
+	 *
+	 * @see {@link https://discord.com/developers/docs/resources/message#message-object-message-flags}
+	 * @see {@link https://en.wikipedia.org/wiki/Bit_field}
+	 */
+	flags: MessageFlags;
+	/**
+	 * ID of the application (only present during active Social SDK sessions)
+	 */
+	application_id?: Snowflake;
+}
+
+/**
+ * @see {@link https://discord.com/developers/docs/events/webhook-events#passthrough-message-object}
+ */
+export interface APIPassthroughMessage {
+	/**
+	 * ID of the message
+	 */
+	id: Snowflake;
+	/**
+	 * Type of message
+	 *
+	 * @see {@link https://discord.com/developers/docs/resources/message#message-object-message-types}
+	 */
+	type: MessageType;
+	/**
+	 * Contents of the message
+	 */
+	content: string;
+	/**
+	 * ID of the channel the message was sent in
+	 */
+	channel_id: Snowflake;
+	/**
+	 * ID of the message recipient
+	 */
+	recipient_id: Snowflake;
+	/**
+	 * 	Author of the message
+	 */
+	author: APIUser;
+	/**
+	 * Message flags combined as a bitfield
+	 *
+	 * @see {@link https://discord.com/developers/docs/resources/message#message-object-message-flags}
+	 * @see {@link https://en.wikipedia.org/wiki/Bit_field}
+	 */
+	flags: MessageFlags;
+	/**
+	 * ID of the application that created the message
+	 */
+	application_id: Snowflake;
+	/**
+	 * Channel object with recipient information
+	 */
+	channel: APIChannel;
+}
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#webhook-object}
@@ -90,9 +188,24 @@ export type APIWebhookEventBody =
 			ApplicationWebhookEventType.ApplicationDeauthorized,
 			APIWebhookEventApplicationDeauthorizedData
 	  >
+	| APIWebhookEventEventBase<
+			ApplicationWebhookEventType.GameDirectMessageCreate,
+			APIWebhookEventGameDirectMessageCreateData
+	  >
+	| APIWebhookEventEventBase<
+			ApplicationWebhookEventType.GameDirectMessageDelete,
+			APIWebhookEventGameDirectMessageDeleteData
+	  >
+	| APIWebhookEventEventBase<
+			ApplicationWebhookEventType.GameDirectMessageUpdate,
+			APIWebhookEventGameDirectMessageUpdateData
+	  >
 	| APIWebhookEventEventBase<ApplicationWebhookEventType.EntitlementCreate, APIWebhookEventEntitlementCreateData>
 	| APIWebhookEventEventBase<ApplicationWebhookEventType.EntitlementDelete, APIWebhookEventEntitlementDeleteData>
 	| APIWebhookEventEventBase<ApplicationWebhookEventType.EntitlementUpdate, APIWebhookEventEntitlementUpdateData>
+	| APIWebhookEventEventBase<ApplicationWebhookEventType.LobbyMessageCreate, APIWebhookEventLobbyMessageCreateData>
+	| APIWebhookEventEventBase<ApplicationWebhookEventType.LobbyMessageDelete, APIWebhookEventLobbyMessageDeleteData>
+	| APIWebhookEventEventBase<ApplicationWebhookEventType.LobbyMessageUpdate, APIWebhookEventLobbyMessageUpdateData>
 	| APIWebhookEventEventBase<ApplicationWebhookEventType.QuestUserEnrollment, APIWebhookEventQuestUserEnrollmentData>;
 
 export interface APIWebhookEventApplicationAuthorizedData {
@@ -132,6 +245,60 @@ export type APIWebhookEventEntitlementDeleteData = APIEntitlement;
  * @unstable
  */
 export type APIWebhookEventEntitlementUpdateData = APIEntitlement;
+
+export type APIWebhookEventGameDirectMessageCreateData =
+	| APIPassthroughMessage
+	| (APIMessage & {
+			/**
+			 * ID of the lobby where the message was created (only present in Linked Channel messages)
+			 */
+			lobby_id?: Snowflake;
+			/**
+			 * Channel object with recipient information
+			 */
+			channel: APIChannel;
+	  });
+
+export type APIWebhookEventGameDirectMessageDeleteData =
+	| APIPassthroughMessage
+	| (APIMessage & {
+			/**
+			 * ID of the lobby where the message was created (only present in Linked Channel messages)
+			 */
+			lobby_id?: Snowflake;
+			/**
+			 * Channel object with recipient information
+			 */
+			channel: APIChannel;
+	  });
+
+export type APIWebhookEventGameDirectMessageUpdateData =
+	| APIPassthroughMessage
+	| (APIMessage & {
+			/**
+			 * ID of the lobby where the message was created (only present in Linked Channel messages)
+			 */
+			lobby_id?: Snowflake;
+			/**
+			 * Channel object with recipient information
+			 */
+			channel: APIChannel;
+	  });
+
+export type APIWebhookEventLobbyMessageCreateData = APILobbyMessage;
+
+export interface APIWebhookEventLobbyMessageDeleteData {
+	/**
+	 * ID of the message
+	 */
+	id: Snowflake;
+	/**
+	 * ID of the lobby where the message was sent
+	 */
+	lobby_id: Snowflake;
+}
+
+export type APIWebhookEventLobbyMessageUpdateData = APILobbyMessage;
 
 export type APIWebhookEventQuestUserEnrollmentData = never;
 
@@ -215,6 +382,30 @@ export enum ApplicationWebhookEventType {
 	 * User was added to a Quest (currently unavailable)
 	 */
 	QuestUserEnrollment = 'QUEST_USER_ENROLLMENT',
+	/**
+	 * Sent when a message is created in a lobby
+	 */
+	LobbyMessageCreate = 'LOBBY_MESSAGE_CREATE',
+	/**
+	 * Sent when a message is updated in a lobby
+	 */
+	LobbyMessageUpdate = 'LOBBY_MESSAGE_UPDATE',
+	/**
+	 * Sent when a message is deleted from a lobby
+	 */
+	LobbyMessageDelete = 'LOBBY_MESSAGE_DELETE',
+	/**
+	 * Sent when a direct message is created during an active Social SDK session
+	 */
+	GameDirectMessageCreate = 'GAME_DIRECT_MESSAGE_CREATE',
+	/**
+	 * Sent when a direct message is updated during an active Social SDK session
+	 */
+	GameDirectMessageUpdate = 'GAME_DIRECT_MESSAGE_UPDATE',
+	/**
+	 * Sent when a direct message is deleted during an active Social SDK session
+	 */
+	GameDirectMessageDelete = 'GAME_DIRECT_MESSAGE_DELETE',
 }
 
 /**

--- a/payloads/v10/webhook.ts
+++ b/payloads/v10/webhook.ts
@@ -15,6 +15,8 @@ import type {
 	MessageType,
 	APIChannel,
 	APIMessage,
+	APIMessageActivity,
+	APIApplication,
 } from './index';
 
 /**
@@ -65,9 +67,9 @@ export interface APILobbyMessage {
 }
 
 /**
- * @see {@link https://discord.com/developers/docs/events/webhook-events#passthrough-message-object}
+ * @see {@link https://docs.discord.com/developers/events/webhook-events#sdk-dm-message-object}
  */
-export interface APIPassthroughMessage {
+export interface APISDKDMMessage {
 	/**
 	 * ID of the message
 	 */
@@ -109,6 +111,18 @@ export interface APIPassthroughMessage {
 	 * Channel object with recipient information
 	 */
 	channel: APIChannel;
+	/**
+	 * Sent with Rich Presence-related chat embeds
+	 *
+	 * @see {@link https://discord.com/developers/docs/resources/message#message-object-message-activity-structure}
+	 */
+	activity?: APIMessageActivity;
+	/**
+	 * Sent with Rich Presence-related chat embeds
+	 *
+	 * @see {@link https://discord.com/developers/docs/resources/application#application-object}
+	 */
+	application?: Partial<APIApplication>;
 }
 
 /**
@@ -247,7 +261,7 @@ export type APIWebhookEventEntitlementDeleteData = APIEntitlement;
 export type APIWebhookEventEntitlementUpdateData = APIEntitlement;
 
 export type APIWebhookEventGameDirectMessageCreateData =
-	| APIPassthroughMessage
+	| APISDKDMMessage
 	| (APIMessage & {
 			/**
 			 * ID of the lobby where the message was created (only present in Linked Channel messages)
@@ -260,7 +274,7 @@ export type APIWebhookEventGameDirectMessageCreateData =
 	  });
 
 export type APIWebhookEventGameDirectMessageDeleteData =
-	| APIPassthroughMessage
+	| APISDKDMMessage
 	| (APIMessage & {
 			/**
 			 * ID of the lobby where the message was created (only present in Linked Channel messages)
@@ -273,7 +287,7 @@ export type APIWebhookEventGameDirectMessageDeleteData =
 	  });
 
 export type APIWebhookEventGameDirectMessageUpdateData =
-	| APIPassthroughMessage
+	| APISDKDMMessage
 	| (APIMessage & {
 			/**
 			 * ID of the lobby where the message was created (only present in Linked Channel messages)

--- a/payloads/v9/webhook.ts
+++ b/payloads/v9/webhook.ts
@@ -15,6 +15,8 @@ import type {
 	MessageType,
 	APIChannel,
 	APIMessage,
+	APIMessageActivity,
+	APIApplication,
 } from './index';
 
 /**
@@ -65,9 +67,9 @@ export interface APILobbyMessage {
 }
 
 /**
- * @see {@link https://discord.com/developers/docs/events/webhook-events#passthrough-message-object}
+ * @see {@link https://docs.discord.com/developers/events/webhook-events#sdk-dm-message-object}
  */
-export interface APIPassthroughMessage {
+export interface APISDKDMMessage {
 	/**
 	 * ID of the message
 	 */
@@ -109,6 +111,18 @@ export interface APIPassthroughMessage {
 	 * Channel object with recipient information
 	 */
 	channel: APIChannel;
+	/**
+	 * Sent with Rich Presence-related chat embeds
+	 *
+	 * @see {@link https://discord.com/developers/docs/resources/message#message-object-message-activity-structure}
+	 */
+	activity?: APIMessageActivity;
+	/**
+	 * Sent with Rich Presence-related chat embeds
+	 *
+	 * @see {@link https://discord.com/developers/docs/resources/application#application-object}
+	 */
+	application?: Partial<APIApplication>;
 }
 
 /**
@@ -247,7 +261,7 @@ export type APIWebhookEventEntitlementDeleteData = APIEntitlement;
 export type APIWebhookEventEntitlementUpdateData = APIEntitlement;
 
 export type APIWebhookEventGameDirectMessageCreateData =
-	| APIPassthroughMessage
+	| APISDKDMMessage
 	| (APIMessage & {
 			/**
 			 * ID of the lobby where the message was created (only present in Linked Channel messages)
@@ -260,7 +274,7 @@ export type APIWebhookEventGameDirectMessageCreateData =
 	  });
 
 export type APIWebhookEventGameDirectMessageDeleteData =
-	| APIPassthroughMessage
+	| APISDKDMMessage
 	| (APIMessage & {
 			/**
 			 * ID of the lobby where the message was created (only present in Linked Channel messages)
@@ -273,7 +287,7 @@ export type APIWebhookEventGameDirectMessageDeleteData =
 	  });
 
 export type APIWebhookEventGameDirectMessageUpdateData =
-	| APIPassthroughMessage
+	| APISDKDMMessage
 	| (APIMessage & {
 			/**
 			 * ID of the lobby where the message was created (only present in Linked Channel messages)


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Adds types for the following webhook events;
- LOBBY_MESSAGE_CREATE
- LOBBY_MESSAGE_UPDATE
- LOBBY_MESSAGE_DELETE
- GAME_DIRECT_MESSAGE_CREATE
- GAME_DIRECT_MESSAGE_UPDATE
- GAME_DIRECT_MESSAGE_DELETE

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
- https://github.com/discord/discord-api-docs/pull/7822
