### PR TITLE
chore: Update code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,11 @@
 * @vladfrangu
 
-/*.ts @discordjs/discord-api-types @discordjs/core
-gateway/ @discordjs/discord-api-types @discordjs/core
-payloads/ @discordjs/discord-api-types @discordjs/core
-rest/ @discordjs/discord-api-types @discordjs/core
-rpc/ @discordjs/discord-api-types @discordjs/core
-tests/ @discordjs/discord-api-types @discordjs/core
-utils/ @discordjs/discord-api-types @discordjs/core
-voice/ @discordjs/discord-api-types @discordjs/core
+/*.ts @discordjs/discord-api-types
+deno/ @discordjs/discord-api-types
+gateway/ @discordjs/discord-api-types
+payloads/ @discordjs/discord-api-types
+rest/ @discordjs/discord-api-types
+rpc/ @discordjs/discord-api-types
+tests/ @discordjs/discord-api-types
+utils/ @discordjs/discord-api-types
+voice/ @discordjs/discord-api-types


### PR DESCRIPTION
Since the introduction of code owners (over 2 years ago), there has been ~600 pull requests with ~5 reviewed by those in the core team that are not already in discord-api-types (Vlad). That speaks for itself.

Made `deno/` owned by discord-api-types. All pull requests would end up needing Vlad anyway without this change, which makes this entire file useless otherwise.