### PR TITLE
fix: export missing properties and use interfaces on GatewayActivityAssets

### DIFF
--- a/deno/payloads/v10/gateway.ts
+++ b/deno/payloads/v10/gateway.ts
@@ -350,14 +350,57 @@ export interface GatewayActivityParty {
 /**
  * @see {@link https://discord.com/developers/docs/topics/gateway-events#activity-object-activity-assets}
  */
-export type GatewayActivityAssets = Partial<
-	Record<'large_image' | 'large_text' | 'large_url' | 'small_image' | 'small_text' | 'small_url', string>
->;
+export interface GatewayActivityAssets {
+	/**
+	 * @see {@link https://discord.com/developers/docs/events/gateway-events#activity-object-activity-asset-image}
+	 */
+	large_image?: string;
+	/**
+	 * Text displayed when hovering over the large image of the activity
+	 */
+	large_text?: string;
+	/**
+	 * URL that is opened when clicking on the large image
+	 */
+	large_url?: string;
+	/**
+	 * @see {@link https://discord.com/developers/docs/events/gateway-events#activity-object-activity-asset-image}
+	 */
+	small_image?: string;
+	/**
+	 * Text displayed when hovering over the small image of the activity
+	 */
+	small_text?: string;
+	/**
+	 * URL that is opened when clicking on the small image
+	 */
+	small_url?: string;
+	/**
+	 * See Activity Asset Image. Displayed as a banner on a Game Invite.
+	 *
+	 * @see {@link https://discord.com/developers/docs/events/gateway-events#activity-object-activity-asset-image | Activity Asset Image}
+	 * @see {@link https://discord.com/developers/docs/discord-social-sdk/development-guides/managing-game-invites | Game Invite}
+	 */
+	invite_cover_image?: string;
+}
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/gateway-events#activity-object-activity-secrets}
  */
-export type GatewayActivitySecrets = Partial<Record<'join' | 'match' | 'spectate', string>>;
+export interface GatewayActivitySecrets {
+	/**
+	 * The secret for joining a party
+	 */
+	join?: string;
+	/**
+	 * The secret for spectating a game
+	 */
+	spectate?: string;
+	/**
+	 * The secret for a specific instance of a match
+	 */
+	match?: string;
+}
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/gateway-events#activity-object-activity-flags}

--- a/deno/payloads/v10/gateway.ts
+++ b/deno/payloads/v10/gateway.ts
@@ -376,7 +376,7 @@ export interface GatewayActivityAssets {
 	 */
 	small_url?: string;
 	/**
-	 * See Activity Asset Image. Displayed as a banner on a Game Invite.
+	 * Displayed as a banner on a Game Invite.
 	 *
 	 * @see {@link https://discord.com/developers/docs/events/gateway-events#activity-object-activity-asset-image | Activity Asset Image}
 	 * @see {@link https://discord.com/developers/docs/discord-social-sdk/development-guides/managing-game-invites | Game Invite}

--- a/deno/payloads/v9/gateway.ts
+++ b/deno/payloads/v9/gateway.ts
@@ -338,14 +338,57 @@ export interface GatewayActivityParty {
 /**
  * @see {@link https://discord.com/developers/docs/topics/gateway-events#activity-object-activity-assets}
  */
-export type GatewayActivityAssets = Partial<
-	Record<'large_image' | 'large_text' | 'large_url' | 'small_image' | 'small_text' | 'small_url', string>
->;
+export interface GatewayActivityAssets {
+	/**
+	 * @see {@link https://discord.com/developers/docs/events/gateway-events#activity-object-activity-asset-image}
+	 */
+	large_image?: string;
+	/**
+	 * Text displayed when hovering over the large image of the activity
+	 */
+	large_text?: string;
+	/**
+	 * URL that is opened when clicking on the large image
+	 */
+	large_url?: string;
+	/**
+	 * @see {@link https://discord.com/developers/docs/events/gateway-events#activity-object-activity-asset-image}
+	 */
+	small_image?: string;
+	/**
+	 * Text displayed when hovering over the small image of the activity
+	 */
+	small_text?: string;
+	/**
+	 * URL that is opened when clicking on the small image
+	 */
+	small_url?: string;
+	/**
+	 * Displayed as a banner on a Game Invite.
+	 *
+	 * @see {@link https://discord.com/developers/docs/events/gateway-events#activity-object-activity-asset-image | Activity Asset Image}
+	 * @see {@link https://discord.com/developers/docs/discord-social-sdk/development-guides/managing-game-invites | Game Invite}
+	 */
+	invite_cover_image?: string;
+}
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/gateway-events#activity-object-activity-secrets}
  */
-export type GatewayActivitySecrets = Partial<Record<'join' | 'match' | 'spectate', string>>;
+export interface GatewayActivitySecrets {
+	/**
+	 * The secret for joining a party
+	 */
+	join?: string;
+	/**
+	 * The secret for spectating a game
+	 */
+	spectate?: string;
+	/**
+	 * The secret for a specific instance of a match
+	 */
+	match?: string;
+}
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/gateway-events#activity-object-activity-flags}

--- a/payloads/v10/gateway.ts
+++ b/payloads/v10/gateway.ts
@@ -350,14 +350,57 @@ export interface GatewayActivityParty {
 /**
  * @see {@link https://discord.com/developers/docs/topics/gateway-events#activity-object-activity-assets}
  */
-export type GatewayActivityAssets = Partial<
-	Record<'large_image' | 'large_text' | 'large_url' | 'small_image' | 'small_text' | 'small_url', string>
->;
+export interface GatewayActivityAssets {
+	/**
+	 * @see {@link https://discord.com/developers/docs/events/gateway-events#activity-object-activity-asset-image}
+	 */
+	large_image?: string;
+	/**
+	 * Text displayed when hovering over the large image of the activity
+	 */
+	large_text?: string;
+	/**
+	 * URL that is opened when clicking on the large image
+	 */
+	large_url?: string;
+	/**
+	 * @see {@link https://discord.com/developers/docs/events/gateway-events#activity-object-activity-asset-image}
+	 */
+	small_image?: string;
+	/**
+	 * Text displayed when hovering over the small image of the activity
+	 */
+	small_text?: string;
+	/**
+	 * URL that is opened when clicking on the small image
+	 */
+	small_url?: string;
+	/**
+	 * See Activity Asset Image. Displayed as a banner on a Game Invite.
+	 *
+	 * @see {@link https://discord.com/developers/docs/events/gateway-events#activity-object-activity-asset-image | Activity Asset Image}
+	 * @see {@link https://discord.com/developers/docs/discord-social-sdk/development-guides/managing-game-invites | Game Invite}
+	 */
+	invite_cover_image?: string;
+}
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/gateway-events#activity-object-activity-secrets}
  */
-export type GatewayActivitySecrets = Partial<Record<'join' | 'match' | 'spectate', string>>;
+export interface GatewayActivitySecrets {
+	/**
+	 * The secret for joining a party
+	 */
+	join?: string;
+	/**
+	 * The secret for spectating a game
+	 */
+	spectate?: string;
+	/**
+	 * The secret for a specific instance of a match
+	 */
+	match?: string;
+}
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/gateway-events#activity-object-activity-flags}

--- a/payloads/v10/gateway.ts
+++ b/payloads/v10/gateway.ts
@@ -376,7 +376,7 @@ export interface GatewayActivityAssets {
 	 */
 	small_url?: string;
 	/**
-	 * See Activity Asset Image. Displayed as a banner on a Game Invite.
+	 * Displayed as a banner on a Game Invite.
 	 *
 	 * @see {@link https://discord.com/developers/docs/events/gateway-events#activity-object-activity-asset-image | Activity Asset Image}
 	 * @see {@link https://discord.com/developers/docs/discord-social-sdk/development-guides/managing-game-invites | Game Invite}

--- a/payloads/v9/gateway.ts
+++ b/payloads/v9/gateway.ts
@@ -338,14 +338,57 @@ export interface GatewayActivityParty {
 /**
  * @see {@link https://discord.com/developers/docs/topics/gateway-events#activity-object-activity-assets}
  */
-export type GatewayActivityAssets = Partial<
-	Record<'large_image' | 'large_text' | 'large_url' | 'small_image' | 'small_text' | 'small_url', string>
->;
+export interface GatewayActivityAssets {
+	/**
+	 * @see {@link https://discord.com/developers/docs/events/gateway-events#activity-object-activity-asset-image}
+	 */
+	large_image?: string;
+	/**
+	 * Text displayed when hovering over the large image of the activity
+	 */
+	large_text?: string;
+	/**
+	 * URL that is opened when clicking on the large image
+	 */
+	large_url?: string;
+	/**
+	 * @see {@link https://discord.com/developers/docs/events/gateway-events#activity-object-activity-asset-image}
+	 */
+	small_image?: string;
+	/**
+	 * Text displayed when hovering over the small image of the activity
+	 */
+	small_text?: string;
+	/**
+	 * URL that is opened when clicking on the small image
+	 */
+	small_url?: string;
+	/**
+	 * Displayed as a banner on a Game Invite.
+	 *
+	 * @see {@link https://discord.com/developers/docs/events/gateway-events#activity-object-activity-asset-image | Activity Asset Image}
+	 * @see {@link https://discord.com/developers/docs/discord-social-sdk/development-guides/managing-game-invites | Game Invite}
+	 */
+	invite_cover_image?: string;
+}
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/gateway-events#activity-object-activity-secrets}
  */
-export type GatewayActivitySecrets = Partial<Record<'join' | 'match' | 'spectate', string>>;
+export interface GatewayActivitySecrets {
+	/**
+	 * The secret for joining a party
+	 */
+	join?: string;
+	/**
+	 * The secret for spectating a game
+	 */
+	spectate?: string;
+	/**
+	 * The secret for a specific instance of a match
+	 */
+	match?: string;
+}
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/gateway-events#activity-object-activity-flags}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR will add a missing property to the `GatewayActivityAssets` type, and will use an interface on `GatewayActivityAssets `, and`GatewayActivitySecrets`.

Tests were run through `npm run test:types` and are passing.

<img width="383" height="63" alt="image" src="https://github.com/user-attachments/assets/5b45a270-d499-4dc2-b40a-035baa1ac7d7" />


**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**

[Activity Assets](https://discord.com/developers/docs/events/gateway-events#activity-object-activity-assets), [Activity Secrets](https://discord.com/developers/docs/events/gateway-events#activity-object-activity-secrets)

Successful merge of this PR will unblock https://github.com/discordjs/discord.js/pull/11411.

Closes #1517