### PR TITLE
fix(Types): replace never usage with undefined

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The exports of each API version is split into three main parts:
         - Some exported types (specifically OAuth2 related ones) may not respect this entire structure due to the nature of the fields. They will start with either `RESTOAuth2` or with something similar to `REST<HTTP Method>OAuth2`
 
     - If a type ends with `Result`, then it represents the expected result by calling its accompanying route.
-        - Types for a Result that will be a `204 No Content` will be typed as `void`
+        - Types for a Result that will be a `204 No Content` will be typed as `undefined`
 
 - Anything else that is miscellaneous will be exported based on what it represents (for example the `REST` route object).
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The exports of each API version is split into three main parts:
         - Some exported types (specifically OAuth2 related ones) may not respect this entire structure due to the nature of the fields. They will start with either `RESTOAuth2` or with something similar to `REST<HTTP Method>OAuth2`
 
     - If a type ends with `Result`, then it represents the expected result by calling its accompanying route.
-        - Types that are exported as `never` usually mean the result will be a `204 No Content`, so you can safely ignore it. This does **not** account for errors.
+        - Types for a Result that will be a `204 No Content` will be typed as `void`
 
 - Anything else that is miscellaneous will be exported based on what it represents (for example the `REST` route object).
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The exports of each API version is split into three main parts:
         - Some exported types (specifically OAuth2 related ones) may not respect this entire structure due to the nature of the fields. They will start with either `RESTOAuth2` or with something similar to `REST<HTTP Method>OAuth2`
 
     - If a type ends with `Result`, then it represents the expected result by calling its accompanying route.
-        - Types for a Result that will be a `204 No Content` will be typed as `undefined`
+        - Types for a Result that will be a `204 No Content` will be typed as `undefined`. This does **not** account for errors
 
 - Anything else that is miscellaneous will be exported based on what it represents (for example the `REST` route object).
 

--- a/deno/README.md
+++ b/deno/README.md
@@ -88,7 +88,7 @@ The exports of each API version is split into three main parts:
         - Some exported types (specifically OAuth2 related ones) may not respect this entire structure due to the nature of the fields. They will start with either `RESTOAuth2` or with something similar to `REST<HTTP Method>OAuth2`
 
     - If a type ends with `Result`, then it represents the expected result by calling its accompanying route.
-        - Types for a Result that will be a `204 No Content` will be typed as `void`
+        - Types for a Result that will be a `204 No Content` will be typed as `undefined`
 
 - Anything else that is miscellaneous will be exported based on what it represents (for example the `REST` route object).
 

--- a/deno/README.md
+++ b/deno/README.md
@@ -88,7 +88,7 @@ The exports of each API version is split into three main parts:
         - Some exported types (specifically OAuth2 related ones) may not respect this entire structure due to the nature of the fields. They will start with either `RESTOAuth2` or with something similar to `REST<HTTP Method>OAuth2`
 
     - If a type ends with `Result`, then it represents the expected result by calling its accompanying route.
-        - Types that are exported as `never` usually mean the result will be a `204 No Content`, so you can safely ignore it. This does **not** account for errors.
+        - Types for a Result that will be a `204 No Content` will be typed as `void`
 
 - Anything else that is miscellaneous will be exported based on what it represents (for example the `REST` route object).
 

--- a/deno/README.md
+++ b/deno/README.md
@@ -88,7 +88,7 @@ The exports of each API version is split into three main parts:
         - Some exported types (specifically OAuth2 related ones) may not respect this entire structure due to the nature of the fields. They will start with either `RESTOAuth2` or with something similar to `REST<HTTP Method>OAuth2`
 
     - If a type ends with `Result`, then it represents the expected result by calling its accompanying route.
-        - Types for a Result that will be a `204 No Content` will be typed as `undefined`
+        - Types for a Result that will be a `204 No Content` will be typed as `undefined`. This does **not** account for errors
 
 - Anything else that is miscellaneous will be exported based on what it represents (for example the `REST` route object).
 

--- a/deno/gateway/v10.ts
+++ b/deno/gateway/v10.ts
@@ -514,7 +514,7 @@ export interface GatewayReadyDispatchData {
 /**
  * @see {@link https://discord.com/developers/docs/topics/gateway-events#resumed}
  */
-export type GatewayResumedDispatch = _DataPayload<GatewayDispatchEvents.Resumed, never>;
+export type GatewayResumedDispatch = _DataPayload<GatewayDispatchEvents.Resumed, void>;
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/gateway-events#auto-moderation-rule-create}

--- a/deno/gateway/v10.ts
+++ b/deno/gateway/v10.ts
@@ -430,7 +430,7 @@ export interface GatewayHelloData {
  */
 export interface GatewayHeartbeatRequest extends _NonDispatchPayload {
 	op: GatewayOpcodes.Heartbeat;
-	d: never;
+	d: undefined;
 }
 
 /**
@@ -438,7 +438,7 @@ export interface GatewayHeartbeatRequest extends _NonDispatchPayload {
  */
 export interface GatewayHeartbeatAck extends _NonDispatchPayload {
 	op: GatewayOpcodes.HeartbeatAck;
-	d: never;
+	d: undefined;
 }
 
 /**
@@ -459,7 +459,7 @@ export type GatewayInvalidSessionData = boolean;
  */
 export interface GatewayReconnect extends _NonDispatchPayload {
 	op: GatewayOpcodes.Reconnect;
-	d: never;
+	d: undefined;
 }
 
 /**
@@ -514,7 +514,7 @@ export interface GatewayReadyDispatchData {
 /**
  * @see {@link https://discord.com/developers/docs/topics/gateway-events#resumed}
  */
-export type GatewayResumedDispatch = _DataPayload<GatewayDispatchEvents.Resumed, void>;
+export type GatewayResumedDispatch = _DataPayload<GatewayDispatchEvents.Resumed, undefined>;
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/gateway-events#auto-moderation-rule-create}

--- a/deno/gateway/v9.ts
+++ b/deno/gateway/v9.ts
@@ -429,7 +429,7 @@ export interface GatewayHelloData {
  */
 export interface GatewayHeartbeatRequest extends _NonDispatchPayload {
 	op: GatewayOpcodes.Heartbeat;
-	d: never;
+	d: undefined;
 }
 
 /**
@@ -437,7 +437,7 @@ export interface GatewayHeartbeatRequest extends _NonDispatchPayload {
  */
 export interface GatewayHeartbeatAck extends _NonDispatchPayload {
 	op: GatewayOpcodes.HeartbeatAck;
-	d: never;
+	d: undefined;
 }
 
 /**
@@ -458,7 +458,7 @@ export type GatewayInvalidSessionData = boolean;
  */
 export interface GatewayReconnect extends _NonDispatchPayload {
 	op: GatewayOpcodes.Reconnect;
-	d: never;
+	d: undefined;
 }
 
 /**
@@ -513,7 +513,7 @@ export interface GatewayReadyDispatchData {
 /**
  * @see {@link https://discord.com/developers/docs/topics/gateway-events#resumed}
  */
-export type GatewayResumedDispatch = _DataPayload<GatewayDispatchEvents.Resumed, void>;
+export type GatewayResumedDispatch = _DataPayload<GatewayDispatchEvents.Resumed, undefined>;
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/gateway-events#auto-moderation-rule-create}

--- a/deno/gateway/v9.ts
+++ b/deno/gateway/v9.ts
@@ -513,7 +513,7 @@ export interface GatewayReadyDispatchData {
 /**
  * @see {@link https://discord.com/developers/docs/topics/gateway-events#resumed}
  */
-export type GatewayResumedDispatch = _DataPayload<GatewayDispatchEvents.Resumed, never>;
+export type GatewayResumedDispatch = _DataPayload<GatewayDispatchEvents.Resumed, void>;
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/gateway-events#auto-moderation-rule-create}

--- a/deno/payloads/v10/_interactions/ping.ts
+++ b/deno/payloads/v10/_interactions/ping.ts
@@ -1,4 +1,4 @@
 import type { APIBaseInteraction } from './base.ts';
 import type { InteractionType } from './responses.ts';
 
-export type APIPingInteraction = Omit<APIBaseInteraction<InteractionType.Ping, never>, 'locale'>;
+export type APIPingInteraction = Omit<APIBaseInteraction<InteractionType.Ping, void>, 'locale'>;

--- a/deno/payloads/v10/_interactions/ping.ts
+++ b/deno/payloads/v10/_interactions/ping.ts
@@ -1,4 +1,4 @@
 import type { APIBaseInteraction } from './base.ts';
 import type { InteractionType } from './responses.ts';
 
-export type APIPingInteraction = Omit<APIBaseInteraction<InteractionType.Ping, void>, 'locale'>;
+export type APIPingInteraction = Omit<APIBaseInteraction<InteractionType.Ping, undefined>, 'locale'>;

--- a/deno/payloads/v10/invite.ts
+++ b/deno/payloads/v10/invite.ts
@@ -90,7 +90,7 @@ export interface APIInvite {
 	 * @deprecated This has been removed from the documentation.
 	 * {@link https://github.com/discord/discord-api-docs/pull/7779 | discord-api-docs#7779}
 	 */
-	stage_instance?: never;
+	stage_instance?: void;
 	/**
 	 * The guild scheduled event data, returned from the `GET /invites/<code>` endpoint when `guild_scheduled_event_id` is a valid guild scheduled event id
 	 */

--- a/deno/payloads/v10/invite.ts
+++ b/deno/payloads/v10/invite.ts
@@ -90,7 +90,7 @@ export interface APIInvite {
 	 * @deprecated This has been removed from the documentation.
 	 * {@link https://github.com/discord/discord-api-docs/pull/7779 | discord-api-docs#7779}
 	 */
-	stage_instance?: void;
+	stage_instance?: undefined;
 	/**
 	 * The guild scheduled event data, returned from the `GET /invites/<code>` endpoint when `guild_scheduled_event_id` is a valid guild scheduled event id
 	 */

--- a/deno/payloads/v10/webhook.ts
+++ b/deno/payloads/v10/webhook.ts
@@ -76,7 +76,7 @@ export interface APIWebhook {
  */
 export type APIWebhookEvent =
 	| APIWebhookEventBase<ApplicationWebhookType.Event, APIWebhookEventBody>
-	| APIWebhookEventBase<ApplicationWebhookType.Ping, never>;
+	| APIWebhookEventBase<ApplicationWebhookType.Ping, void>;
 
 /**
  * @see {@link https://discord.com/developers/docs/events/webhook-events#event-body-object}
@@ -127,7 +127,7 @@ export type APIWebhookEventEntitlementDeleteData = APIEntitlement;
 
 export type APIWebhookEventEntitlementUpdateData = APIEntitlement;
 
-export type APIWebhookEventQuestUserEnrollmentData = never;
+export type APIWebhookEventQuestUserEnrollmentData = void;
 
 export interface APIWebhookEventBase<Type extends ApplicationWebhookType, Event> {
 	/**

--- a/deno/payloads/v10/webhook.ts
+++ b/deno/payloads/v10/webhook.ts
@@ -76,7 +76,7 @@ export interface APIWebhook {
  */
 export type APIWebhookEvent =
 	| APIWebhookEventBase<ApplicationWebhookType.Event, APIWebhookEventBody>
-	| APIWebhookEventBase<ApplicationWebhookType.Ping, void>;
+	| APIWebhookEventBase<ApplicationWebhookType.Ping, undefined>;
 
 /**
  * @see {@link https://discord.com/developers/docs/events/webhook-events#event-body-object}
@@ -127,7 +127,7 @@ export type APIWebhookEventEntitlementDeleteData = APIEntitlement;
 
 export type APIWebhookEventEntitlementUpdateData = APIEntitlement;
 
-export type APIWebhookEventQuestUserEnrollmentData = void;
+export type APIWebhookEventQuestUserEnrollmentData = undefined;
 
 export interface APIWebhookEventBase<Type extends ApplicationWebhookType, Event> {
 	/**

--- a/deno/payloads/v9/_interactions/ping.ts
+++ b/deno/payloads/v9/_interactions/ping.ts
@@ -1,4 +1,4 @@
 import type { APIBaseInteraction } from './base.ts';
 import type { InteractionType } from './responses.ts';
 
-export type APIPingInteraction = Omit<APIBaseInteraction<InteractionType.Ping, never>, 'locale'>;
+export type APIPingInteraction = Omit<APIBaseInteraction<InteractionType.Ping, void>, 'locale'>;

--- a/deno/payloads/v9/_interactions/ping.ts
+++ b/deno/payloads/v9/_interactions/ping.ts
@@ -1,4 +1,4 @@
 import type { APIBaseInteraction } from './base.ts';
 import type { InteractionType } from './responses.ts';
 
-export type APIPingInteraction = Omit<APIBaseInteraction<InteractionType.Ping, void>, 'locale'>;
+export type APIPingInteraction = Omit<APIBaseInteraction<InteractionType.Ping, undefined>, 'locale'>;

--- a/deno/payloads/v9/invite.ts
+++ b/deno/payloads/v9/invite.ts
@@ -90,7 +90,7 @@ export interface APIInvite {
 	 * @deprecated This has been removed from the documentation.
 	 * {@link https://github.com/discord/discord-api-docs/pull/7779 | discord-api-docs#7779}
 	 */
-	stage_instance?: never;
+	stage_instance?: void;
 	/**
 	 * The guild scheduled event data, returned from the `GET /invites/<code>` endpoint when `guild_scheduled_event_id` is a valid guild scheduled event id
 	 */

--- a/deno/payloads/v9/invite.ts
+++ b/deno/payloads/v9/invite.ts
@@ -90,7 +90,7 @@ export interface APIInvite {
 	 * @deprecated This has been removed from the documentation.
 	 * {@link https://github.com/discord/discord-api-docs/pull/7779 | discord-api-docs#7779}
 	 */
-	stage_instance?: void;
+	stage_instance?: undefined;
 	/**
 	 * The guild scheduled event data, returned from the `GET /invites/<code>` endpoint when `guild_scheduled_event_id` is a valid guild scheduled event id
 	 */

--- a/deno/payloads/v9/webhook.ts
+++ b/deno/payloads/v9/webhook.ts
@@ -76,7 +76,7 @@ export interface APIWebhook {
  */
 export type APIWebhookEvent =
 	| APIWebhookEventBase<ApplicationWebhookType.Event, APIWebhookEventBody>
-	| APIWebhookEventBase<ApplicationWebhookType.Ping, never>;
+	| APIWebhookEventBase<ApplicationWebhookType.Ping, void>;
 
 /**
  * @see {@link https://discord.com/developers/docs/events/webhook-events#event-body-object}
@@ -127,7 +127,7 @@ export type APIWebhookEventEntitlementDeleteData = APIEntitlement;
 
 export type APIWebhookEventEntitlementUpdateData = APIEntitlement;
 
-export type APIWebhookEventQuestUserEnrollmentData = never;
+export type APIWebhookEventQuestUserEnrollmentData = void;
 
 export interface APIWebhookEventBase<Type extends ApplicationWebhookType, Event> {
 	/**

--- a/deno/payloads/v9/webhook.ts
+++ b/deno/payloads/v9/webhook.ts
@@ -76,7 +76,7 @@ export interface APIWebhook {
  */
 export type APIWebhookEvent =
 	| APIWebhookEventBase<ApplicationWebhookType.Event, APIWebhookEventBody>
-	| APIWebhookEventBase<ApplicationWebhookType.Ping, void>;
+	| APIWebhookEventBase<ApplicationWebhookType.Ping, undefined>;
 
 /**
  * @see {@link https://discord.com/developers/docs/events/webhook-events#event-body-object}
@@ -127,7 +127,7 @@ export type APIWebhookEventEntitlementDeleteData = APIEntitlement;
 
 export type APIWebhookEventEntitlementUpdateData = APIEntitlement;
 
-export type APIWebhookEventQuestUserEnrollmentData = void;
+export type APIWebhookEventQuestUserEnrollmentData = undefined;
 
 export interface APIWebhookEventBase<Type extends ApplicationWebhookType, Event> {
 	/**

--- a/deno/rest/v10/autoModeration.ts
+++ b/deno/rest/v10/autoModeration.ts
@@ -80,4 +80,4 @@ export type RESTPatchAPIAutoModerationRuleResult = APIAutoModerationRule;
 /**
  * @see {@link https://discord.com/developers/docs/resources/auto-moderation#delete-auto-moderation-rule}
  */
-export type RESTDeleteAPIAutoModerationRuleResult = void;
+export type RESTDeleteAPIAutoModerationRuleResult = undefined;

--- a/deno/rest/v10/autoModeration.ts
+++ b/deno/rest/v10/autoModeration.ts
@@ -80,4 +80,4 @@ export type RESTPatchAPIAutoModerationRuleResult = APIAutoModerationRule;
 /**
  * @see {@link https://discord.com/developers/docs/resources/auto-moderation#delete-auto-moderation-rule}
  */
-export type RESTDeleteAPIAutoModerationRuleResult = never;
+export type RESTDeleteAPIAutoModerationRuleResult = void;

--- a/deno/rest/v10/channel.ts
+++ b/deno/rest/v10/channel.ts
@@ -369,12 +369,12 @@ export type RESTPostAPIChannelMessageCrosspostResult = APIMessage;
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#create-reaction}
  */
-export type RESTPutAPIChannelMessageReactionResult = never;
+export type RESTPutAPIChannelMessageReactionResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#delete-own-reaction}
  */
-export type RESTDeleteAPIChannelMessageOwnReactionResult = never;
+export type RESTDeleteAPIChannelMessageOwnReactionResult = void;
 
 /**
  * @deprecated Use {@link RESTDeleteAPIChannelMessageOwnReactionResult} instead
@@ -384,7 +384,7 @@ export type RESTDeleteAPIChannelMessageOwnReaction = RESTDeleteAPIChannelMessage
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#delete-user-reaction}
  */
-export type RESTDeleteAPIChannelMessageUserReactionResult = never;
+export type RESTDeleteAPIChannelMessageUserReactionResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#get-reactions}
@@ -428,12 +428,12 @@ export type RESTGetAPIChannelMessageReactionUsersResult = APIUser[];
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#delete-all-reactions}
  */
-export type RESTDeleteAPIChannelAllMessageReactionsResult = never;
+export type RESTDeleteAPIChannelAllMessageReactionsResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#delete-all-reactions-for-emoji}
  */
-export type RESTDeleteAPIChannelMessageReactionResult = never;
+export type RESTDeleteAPIChannelMessageReactionResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#edit-message}
@@ -500,7 +500,7 @@ export type RESTPatchAPIChannelMessageResult = APIMessage;
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#delete-message}
  */
-export type RESTDeleteAPIChannelMessageResult = never;
+export type RESTDeleteAPIChannelMessageResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#bulk-delete-messages}
@@ -515,7 +515,7 @@ export interface RESTPostAPIChannelMessagesBulkDeleteJSONBody {
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#bulk-delete-messages}
  */
-export type RESTPostAPIChannelMessagesBulkDeleteResult = never;
+export type RESTPostAPIChannelMessagesBulkDeleteResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#edit-channel-permissions}
@@ -544,7 +544,7 @@ export interface RESTPutAPIChannelPermissionJSONBody {
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#edit-channel-permissions}
  */
-export type RESTPutAPIChannelPermissionResult = never;
+export type RESTPutAPIChannelPermissionResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#get-channel-invites}
@@ -632,7 +632,7 @@ export type RESTPostAPIChannelInviteResult = APIExtendedInvite;
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#delete-channel-permission}
  */
-export type RESTDeleteAPIChannelPermissionResult = never;
+export type RESTDeleteAPIChannelPermissionResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#follow-news-channel}
@@ -652,7 +652,7 @@ export type RESTPostAPIChannelFollowersResult = APIFollowedChannel;
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#trigger-typing-indicator}
  */
-export type RESTPostAPIChannelTypingResult = never;
+export type RESTPostAPIChannelTypingResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/message#get-channel-pins}
@@ -687,12 +687,12 @@ export interface RESTGetAPIChannelMessagesPinsResult {
 /**
  * @see {@link https://discord.com/developers/docs/resources/message#pin-message}
  */
-export type RESTPutAPIChannelMessagesPinResult = never;
+export type RESTPutAPIChannelMessagesPinResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/message#unpin-message}
  */
-export type RESTDeleteAPIChannelMessagesPinResult = never;
+export type RESTDeleteAPIChannelMessagesPinResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/message#get-pinned-messages-deprecated}
@@ -704,13 +704,13 @@ export type RESTGetAPIChannelPinsResult = APIMessage[];
  * @see {@link https://discord.com/developers/docs/resources/message#pin-message-deprecated}
  * @deprecated
  */
-export type RESTPutAPIChannelPinResult = never;
+export type RESTPutAPIChannelPinResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/message#unpin-message-deprecated}
  * @deprecated
  */
-export type RESTDeleteAPIChannelPinResult = never;
+export type RESTDeleteAPIChannelPinResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#group-dm-add-recipient}
@@ -816,12 +816,12 @@ export type RESTPostAPIChannelThreadsResult =
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#join-thread}
  */
-export type RESTPutAPIChannelThreadMembersResult = never;
+export type RESTPutAPIChannelThreadMembersResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#leave-thread}
  */
-export type RESTDeleteAPIChannelThreadMembersResult = never;
+export type RESTDeleteAPIChannelThreadMembersResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#get-thread-member}

--- a/deno/rest/v10/channel.ts
+++ b/deno/rest/v10/channel.ts
@@ -369,12 +369,12 @@ export type RESTPostAPIChannelMessageCrosspostResult = APIMessage;
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#create-reaction}
  */
-export type RESTPutAPIChannelMessageReactionResult = void;
+export type RESTPutAPIChannelMessageReactionResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#delete-own-reaction}
  */
-export type RESTDeleteAPIChannelMessageOwnReactionResult = void;
+export type RESTDeleteAPIChannelMessageOwnReactionResult = undefined;
 
 /**
  * @deprecated Use {@link RESTDeleteAPIChannelMessageOwnReactionResult} instead
@@ -384,7 +384,7 @@ export type RESTDeleteAPIChannelMessageOwnReaction = RESTDeleteAPIChannelMessage
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#delete-user-reaction}
  */
-export type RESTDeleteAPIChannelMessageUserReactionResult = void;
+export type RESTDeleteAPIChannelMessageUserReactionResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#get-reactions}
@@ -428,12 +428,12 @@ export type RESTGetAPIChannelMessageReactionUsersResult = APIUser[];
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#delete-all-reactions}
  */
-export type RESTDeleteAPIChannelAllMessageReactionsResult = void;
+export type RESTDeleteAPIChannelAllMessageReactionsResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#delete-all-reactions-for-emoji}
  */
-export type RESTDeleteAPIChannelMessageReactionResult = void;
+export type RESTDeleteAPIChannelMessageReactionResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#edit-message}
@@ -500,7 +500,7 @@ export type RESTPatchAPIChannelMessageResult = APIMessage;
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#delete-message}
  */
-export type RESTDeleteAPIChannelMessageResult = void;
+export type RESTDeleteAPIChannelMessageResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#bulk-delete-messages}
@@ -515,7 +515,7 @@ export interface RESTPostAPIChannelMessagesBulkDeleteJSONBody {
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#bulk-delete-messages}
  */
-export type RESTPostAPIChannelMessagesBulkDeleteResult = void;
+export type RESTPostAPIChannelMessagesBulkDeleteResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#edit-channel-permissions}
@@ -544,7 +544,7 @@ export interface RESTPutAPIChannelPermissionJSONBody {
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#edit-channel-permissions}
  */
-export type RESTPutAPIChannelPermissionResult = void;
+export type RESTPutAPIChannelPermissionResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#get-channel-invites}
@@ -632,7 +632,7 @@ export type RESTPostAPIChannelInviteResult = APIExtendedInvite;
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#delete-channel-permission}
  */
-export type RESTDeleteAPIChannelPermissionResult = void;
+export type RESTDeleteAPIChannelPermissionResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#follow-news-channel}
@@ -652,7 +652,7 @@ export type RESTPostAPIChannelFollowersResult = APIFollowedChannel;
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#trigger-typing-indicator}
  */
-export type RESTPostAPIChannelTypingResult = void;
+export type RESTPostAPIChannelTypingResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/message#get-channel-pins}
@@ -687,12 +687,12 @@ export interface RESTGetAPIChannelMessagesPinsResult {
 /**
  * @see {@link https://discord.com/developers/docs/resources/message#pin-message}
  */
-export type RESTPutAPIChannelMessagesPinResult = void;
+export type RESTPutAPIChannelMessagesPinResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/message#unpin-message}
  */
-export type RESTDeleteAPIChannelMessagesPinResult = void;
+export type RESTDeleteAPIChannelMessagesPinResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/message#get-pinned-messages-deprecated}
@@ -704,13 +704,13 @@ export type RESTGetAPIChannelPinsResult = APIMessage[];
  * @see {@link https://discord.com/developers/docs/resources/message#pin-message-deprecated}
  * @deprecated
  */
-export type RESTPutAPIChannelPinResult = void;
+export type RESTPutAPIChannelPinResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/message#unpin-message-deprecated}
  * @deprecated
  */
-export type RESTDeleteAPIChannelPinResult = void;
+export type RESTDeleteAPIChannelPinResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#group-dm-add-recipient}
@@ -816,12 +816,12 @@ export type RESTPostAPIChannelThreadsResult =
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#join-thread}
  */
-export type RESTPutAPIChannelThreadMembersResult = void;
+export type RESTPutAPIChannelThreadMembersResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#leave-thread}
  */
-export type RESTDeleteAPIChannelThreadMembersResult = void;
+export type RESTDeleteAPIChannelThreadMembersResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#get-thread-member}

--- a/deno/rest/v10/emoji.ts
+++ b/deno/rest/v10/emoji.ts
@@ -58,7 +58,7 @@ export type RESTPatchAPIGuildEmojiResult = APIEmoji;
 /**
  * @see {@link https://discord.com/developers/docs/resources/emoji#delete-guild-emoji}
  */
-export type RESTDeleteAPIGuildEmojiResult = void;
+export type RESTDeleteAPIGuildEmojiResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/emoji#list-application-emojis}
@@ -95,4 +95,4 @@ export type RESTPatchAPIApplicationEmojiResult = APIApplicationEmoji;
 /**
  * @see {@link https://discord.com/developers/docs/resources/emoji#delete-application-emoji}
  */
-export type RESTDeleteAPIApplicationEmojiResult = void;
+export type RESTDeleteAPIApplicationEmojiResult = undefined;

--- a/deno/rest/v10/emoji.ts
+++ b/deno/rest/v10/emoji.ts
@@ -58,7 +58,7 @@ export type RESTPatchAPIGuildEmojiResult = APIEmoji;
 /**
  * @see {@link https://discord.com/developers/docs/resources/emoji#delete-guild-emoji}
  */
-export type RESTDeleteAPIGuildEmojiResult = never;
+export type RESTDeleteAPIGuildEmojiResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/emoji#list-application-emojis}
@@ -95,4 +95,4 @@ export type RESTPatchAPIApplicationEmojiResult = APIApplicationEmoji;
 /**
  * @see {@link https://discord.com/developers/docs/resources/emoji#delete-application-emoji}
  */
-export type RESTDeleteAPIApplicationEmojiResult = never;
+export type RESTDeleteAPIApplicationEmojiResult = void;

--- a/deno/rest/v10/guild.ts
+++ b/deno/rest/v10/guild.ts
@@ -360,7 +360,7 @@ export type RESTPatchAPIGuildResult = APIGuild;
  * @see {@link https://discord.com/developers/docs/change-log#guild-create-deprecation}
  * @deprecated
  */
-export type RESTDeleteAPIGuildResult = void;
+export type RESTDeleteAPIGuildResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#get-guild-channels}
@@ -402,7 +402,7 @@ export type RESTPatchAPIGuildChannelPositionsJSONBody = {
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#modify-guild-channel-positions}
  */
-export type RESTPatchAPIGuildChannelPositionsResult = void;
+export type RESTPatchAPIGuildChannelPositionsResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#list-active-guild-threads}
@@ -739,17 +739,17 @@ export type RESTPatchAPICurrentGuildMemberResult = APIGuildMember;
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#add-guild-member-role}
  */
-export type RESTPutAPIGuildMemberRoleResult = void;
+export type RESTPutAPIGuildMemberRoleResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#remove-guild-member-role}
  */
-export type RESTDeleteAPIGuildMemberRoleResult = void;
+export type RESTDeleteAPIGuildMemberRoleResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#remove-guild-member}
  */
-export type RESTDeleteAPIGuildMemberResult = void;
+export type RESTDeleteAPIGuildMemberResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#get-guild-bans}
@@ -800,12 +800,12 @@ export interface RESTPutAPIGuildBanJSONBody {
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#create-guild-ban}
  */
-export type RESTPutAPIGuildBanResult = void;
+export type RESTPutAPIGuildBanResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#remove-guild-ban}
  */
-export type RESTDeleteAPIGuildBanResult = void;
+export type RESTDeleteAPIGuildBanResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#bulk-guild-ban}
@@ -969,7 +969,7 @@ export type RESTPatchAPIGuildRoleResult = APIRole;
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#delete-guild-role}
  */
-export type RESTDeleteAPIGuildRoleResult = void;
+export type RESTDeleteAPIGuildRoleResult = undefined;
 
 /**
  * A record mapping role IDs to the number of members that have that role.
@@ -1054,7 +1054,7 @@ export type RESTGetAPIGuildIntegrationsResult = APIGuildIntegration[];
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#delete-guild-integration}
  */
-export type RESTDeleteAPIGuildIntegrationResult = void;
+export type RESTDeleteAPIGuildIntegrationResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#get-guild-widget-settings}

--- a/deno/rest/v10/guild.ts
+++ b/deno/rest/v10/guild.ts
@@ -360,7 +360,7 @@ export type RESTPatchAPIGuildResult = APIGuild;
  * @see {@link https://discord.com/developers/docs/change-log#guild-create-deprecation}
  * @deprecated
  */
-export type RESTDeleteAPIGuildResult = never;
+export type RESTDeleteAPIGuildResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#get-guild-channels}
@@ -402,7 +402,7 @@ export type RESTPatchAPIGuildChannelPositionsJSONBody = {
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#modify-guild-channel-positions}
  */
-export type RESTPatchAPIGuildChannelPositionsResult = never;
+export type RESTPatchAPIGuildChannelPositionsResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#list-active-guild-threads}
@@ -739,17 +739,17 @@ export type RESTPatchAPICurrentGuildMemberResult = APIGuildMember;
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#add-guild-member-role}
  */
-export type RESTPutAPIGuildMemberRoleResult = never;
+export type RESTPutAPIGuildMemberRoleResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#remove-guild-member-role}
  */
-export type RESTDeleteAPIGuildMemberRoleResult = never;
+export type RESTDeleteAPIGuildMemberRoleResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#remove-guild-member}
  */
-export type RESTDeleteAPIGuildMemberResult = never;
+export type RESTDeleteAPIGuildMemberResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#get-guild-bans}
@@ -800,12 +800,12 @@ export interface RESTPutAPIGuildBanJSONBody {
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#create-guild-ban}
  */
-export type RESTPutAPIGuildBanResult = never;
+export type RESTPutAPIGuildBanResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#remove-guild-ban}
  */
-export type RESTDeleteAPIGuildBanResult = never;
+export type RESTDeleteAPIGuildBanResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#bulk-guild-ban}
@@ -969,7 +969,7 @@ export type RESTPatchAPIGuildRoleResult = APIRole;
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#delete-guild-role}
  */
-export type RESTDeleteAPIGuildRoleResult = never;
+export type RESTDeleteAPIGuildRoleResult = void;
 
 /**
  * A record mapping role IDs to the number of members that have that role.
@@ -1054,7 +1054,7 @@ export type RESTGetAPIGuildIntegrationsResult = APIGuildIntegration[];
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#delete-guild-integration}
  */
-export type RESTDeleteAPIGuildIntegrationResult = never;
+export type RESTDeleteAPIGuildIntegrationResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#get-guild-widget-settings}

--- a/deno/rest/v10/guildScheduledEvent.ts
+++ b/deno/rest/v10/guildScheduledEvent.ts
@@ -118,7 +118,7 @@ export type RESTPatchAPIGuildScheduledEventResult = APIGuildScheduledEvent;
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild-scheduled-event#delete-guild-scheduled-event}
  */
-export type RESTDeleteAPIGuildScheduledEventResult = void;
+export type RESTDeleteAPIGuildScheduledEventResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild-scheduled-event#get-guild-scheduled-event-users}

--- a/deno/rest/v10/guildScheduledEvent.ts
+++ b/deno/rest/v10/guildScheduledEvent.ts
@@ -118,7 +118,7 @@ export type RESTPatchAPIGuildScheduledEventResult = APIGuildScheduledEvent;
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild-scheduled-event#delete-guild-scheduled-event}
  */
-export type RESTDeleteAPIGuildScheduledEventResult = never;
+export type RESTDeleteAPIGuildScheduledEventResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild-scheduled-event#get-guild-scheduled-event-users}

--- a/deno/rest/v10/interactions.ts
+++ b/deno/rest/v10/interactions.ts
@@ -212,7 +212,7 @@ export type RESTPostAPIInteractionCallbackFormDataBody =
 /**
  * @see {@link https://discord.com/developers/docs/interactions/receiving-and-responding#create-interaction-response}
  */
-export type RESTPostAPIInteractionCallbackResult = void;
+export type RESTPostAPIInteractionCallbackResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-callback-interaction-callback-response-object}

--- a/deno/rest/v10/interactions.ts
+++ b/deno/rest/v10/interactions.ts
@@ -212,7 +212,7 @@ export type RESTPostAPIInteractionCallbackFormDataBody =
 /**
  * @see {@link https://discord.com/developers/docs/interactions/receiving-and-responding#create-interaction-response}
  */
-export type RESTPostAPIInteractionCallbackResult = never;
+export type RESTPostAPIInteractionCallbackResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-callback-interaction-callback-response-object}

--- a/deno/rest/v10/monetization.ts
+++ b/deno/rest/v10/monetization.ts
@@ -95,7 +95,7 @@ export enum EntitlementOwnerType {
 /**
  * @see {@link https://discord.com/developers/docs/resources/entitlement#delete-test-entitlement}
  */
-export type RESTDeleteAPIEntitlementResult = void;
+export type RESTDeleteAPIEntitlementResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/sku#list-skus}
@@ -105,7 +105,7 @@ export type RESTGetAPISKUsResult = APISKU[];
 /**
  * @see {@link https://discord.com/developers/docs/resources/entitlement#consume-an-entitlement}
  */
-export type RESTPostAPIEntitlementConsumeResult = void;
+export type RESTPostAPIEntitlementConsumeResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/subscription#query-string-params}

--- a/deno/rest/v10/monetization.ts
+++ b/deno/rest/v10/monetization.ts
@@ -95,7 +95,7 @@ export enum EntitlementOwnerType {
 /**
  * @see {@link https://discord.com/developers/docs/resources/entitlement#delete-test-entitlement}
  */
-export type RESTDeleteAPIEntitlementResult = never;
+export type RESTDeleteAPIEntitlementResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/sku#list-skus}
@@ -105,7 +105,7 @@ export type RESTGetAPISKUsResult = APISKU[];
 /**
  * @see {@link https://discord.com/developers/docs/resources/entitlement#consume-an-entitlement}
  */
-export type RESTPostAPIEntitlementConsumeResult = never;
+export type RESTPostAPIEntitlementConsumeResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/subscription#query-string-params}

--- a/deno/rest/v10/oauth2.ts
+++ b/deno/rest/v10/oauth2.ts
@@ -82,7 +82,7 @@ export type RESTPostOAuth2AccessTokenURLEncodedData = RESTOAuth2TokenOptionalCli
 
 export type RESTOAuth2TokenOptionalClientCredentials =
 	| { client_id: Snowflake; client_secret: string }
-	| { client_id?: never; client_secret?: never };
+	| { client_id?: void; client_secret?: void };
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-access-token-response}

--- a/deno/rest/v10/oauth2.ts
+++ b/deno/rest/v10/oauth2.ts
@@ -82,7 +82,7 @@ export type RESTPostOAuth2AccessTokenURLEncodedData = RESTOAuth2TokenOptionalCli
 
 export type RESTOAuth2TokenOptionalClientCredentials =
 	| { client_id: Snowflake; client_secret: string }
-	| { client_id?: undefined; client_secret?: undefined };
+	| { client_id?: never; client_secret?: never };
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-access-token-response}

--- a/deno/rest/v10/oauth2.ts
+++ b/deno/rest/v10/oauth2.ts
@@ -82,7 +82,7 @@ export type RESTPostOAuth2AccessTokenURLEncodedData = RESTOAuth2TokenOptionalCli
 
 export type RESTOAuth2TokenOptionalClientCredentials =
 	| { client_id: Snowflake; client_secret: string }
-	| { client_id?: void; client_secret?: void };
+	| { client_id?: undefined; client_secret?: undefined };
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-access-token-response}

--- a/deno/rest/v10/soundboard.ts
+++ b/deno/rest/v10/soundboard.ts
@@ -104,4 +104,4 @@ export type RESTPatchAPIGuildSoundboardSoundResult = APISoundboardSound;
 /**
  * @see {@link https://discord.com/developers/docs/resources/soundboard#delete-guild-soundboard-sound}
  */
-export type RESTDeleteAPIGuildSoundboardSoundResult = never;
+export type RESTDeleteAPIGuildSoundboardSoundResult = void;

--- a/deno/rest/v10/soundboard.ts
+++ b/deno/rest/v10/soundboard.ts
@@ -104,4 +104,4 @@ export type RESTPatchAPIGuildSoundboardSoundResult = APISoundboardSound;
 /**
  * @see {@link https://discord.com/developers/docs/resources/soundboard#delete-guild-soundboard-sound}
  */
-export type RESTDeleteAPIGuildSoundboardSoundResult = void;
+export type RESTDeleteAPIGuildSoundboardSoundResult = undefined;

--- a/deno/rest/v10/soundboard.ts
+++ b/deno/rest/v10/soundboard.ts
@@ -4,7 +4,7 @@ import type { APISoundboardSound } from '../../payloads/v10/mod.ts';
 /**
  * @see {@link https://discord.com/developers/docs/resources/soundboard#send-soundboard-sound}
  */
-export type RESTPostAPISendSoundboardSoundResult = never;
+export type RESTPostAPISendSoundboardSoundResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/soundboard#send-soundboard-sound-json-params}

--- a/deno/rest/v10/stageInstance.ts
+++ b/deno/rest/v10/stageInstance.ts
@@ -61,4 +61,4 @@ export type RESTPatchAPIStageInstanceResult = APIStageInstance;
 /**
  * @see {@link https://discord.com/developers/docs/resources/stage-instance#delete-stage-instance}
  */
-export type RESTDeleteAPIStageInstanceResult = void;
+export type RESTDeleteAPIStageInstanceResult = undefined;

--- a/deno/rest/v10/stageInstance.ts
+++ b/deno/rest/v10/stageInstance.ts
@@ -61,4 +61,4 @@ export type RESTPatchAPIStageInstanceResult = APIStageInstance;
 /**
  * @see {@link https://discord.com/developers/docs/resources/stage-instance#delete-stage-instance}
  */
-export type RESTDeleteAPIStageInstanceResult = never;
+export type RESTDeleteAPIStageInstanceResult = void;

--- a/deno/rest/v10/sticker.ts
+++ b/deno/rest/v10/sticker.ts
@@ -93,4 +93,4 @@ export type RESTPatchAPIGuildStickerResult = APISticker;
 /**
  * @see {@link https://discord.com/developers/docs/resources/sticker#delete-guild-sticker}
  */
-export type RESTDeleteAPIGuildStickerResult = never;
+export type RESTDeleteAPIGuildStickerResult = void;

--- a/deno/rest/v10/sticker.ts
+++ b/deno/rest/v10/sticker.ts
@@ -93,4 +93,4 @@ export type RESTPatchAPIGuildStickerResult = APISticker;
 /**
  * @see {@link https://discord.com/developers/docs/resources/sticker#delete-guild-sticker}
  */
-export type RESTDeleteAPIGuildStickerResult = void;
+export type RESTDeleteAPIGuildStickerResult = undefined;

--- a/deno/rest/v10/user.ts
+++ b/deno/rest/v10/user.ts
@@ -92,7 +92,7 @@ export type RESTGetAPICurrentUserGuildsResult = RESTAPIPartialCurrentUserGuild[]
 /**
  * @see {@link https://discord.com/developers/docs/resources/user#leave-guild}
  */
-export type RESTDeleteAPICurrentUserGuildResult = void;
+export type RESTDeleteAPICurrentUserGuildResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/user#create-dm}

--- a/deno/rest/v10/user.ts
+++ b/deno/rest/v10/user.ts
@@ -92,7 +92,7 @@ export type RESTGetAPICurrentUserGuildsResult = RESTAPIPartialCurrentUserGuild[]
 /**
  * @see {@link https://discord.com/developers/docs/resources/user#leave-guild}
  */
-export type RESTDeleteAPICurrentUserGuildResult = never;
+export type RESTDeleteAPICurrentUserGuildResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/user#create-dm}

--- a/deno/rest/v10/voice.ts
+++ b/deno/rest/v10/voice.ts
@@ -42,7 +42,7 @@ export interface RESTPatchAPIGuildVoiceStateCurrentMemberJSONBody {
 /**
  * @see {@link https://discord.com/developers/docs/resources/voice#modify-current-user-voice-state}
  */
-export type RESTPatchAPIGuildVoiceStateCurrentMemberResult = void;
+export type RESTPatchAPIGuildVoiceStateCurrentMemberResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/voice#modify-user-voice-state}
@@ -61,4 +61,4 @@ export interface RESTPatchAPIGuildVoiceStateUserJSONBody {
 /**
  * @see {@link https://discord.com/developers/docs/resources/voice#modify-user-voice-state}
  */
-export type RESTPatchAPIGuildVoiceStateUserResult = void;
+export type RESTPatchAPIGuildVoiceStateUserResult = undefined;

--- a/deno/rest/v10/voice.ts
+++ b/deno/rest/v10/voice.ts
@@ -42,7 +42,7 @@ export interface RESTPatchAPIGuildVoiceStateCurrentMemberJSONBody {
 /**
  * @see {@link https://discord.com/developers/docs/resources/voice#modify-current-user-voice-state}
  */
-export type RESTPatchAPIGuildVoiceStateCurrentMemberResult = never;
+export type RESTPatchAPIGuildVoiceStateCurrentMemberResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/voice#modify-user-voice-state}
@@ -61,4 +61,4 @@ export interface RESTPatchAPIGuildVoiceStateUserJSONBody {
 /**
  * @see {@link https://discord.com/developers/docs/resources/voice#modify-user-voice-state}
  */
-export type RESTPatchAPIGuildVoiceStateUserResult = never;
+export type RESTPatchAPIGuildVoiceStateUserResult = void;

--- a/deno/rest/v10/webhook.ts
+++ b/deno/rest/v10/webhook.ts
@@ -89,12 +89,12 @@ export type RESTPatchAPIWebhookWithTokenResult = RESTGetAPIWebhookWithTokenResul
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#delete-webhook}
  */
-export type RESTDeleteAPIWebhookResult = never;
+export type RESTDeleteAPIWebhookResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#delete-webhook-with-token}
  */
-export type RESTDeleteAPIWebhookWithTokenResult = never;
+export type RESTDeleteAPIWebhookWithTokenResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#execute-webhook}
@@ -201,7 +201,7 @@ export interface RESTPostAPIWebhookWithTokenQuery {
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#execute-webhook}
  */
-export type RESTPostAPIWebhookWithTokenResult = never;
+export type RESTPostAPIWebhookWithTokenResult = void;
 
 /**
  * Received when a call to https://discord.com/developers/docs/resources/webhook#execute-webhook receives
@@ -219,7 +219,7 @@ export type RESTPostAPIWebhookWithTokenSlackQuery = Pick<RESTPostAPIWebhookWithT
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#execute-slackcompatible-webhook}
  */
-export type RESTPostAPIWebhookWithTokenSlackResult = never;
+export type RESTPostAPIWebhookWithTokenSlackResult = void;
 
 /**
  * Received when a call to https://discord.com/developers/docs/resources/webhook#execute-webhook receives
@@ -237,7 +237,7 @@ export type RESTPostAPIWebhookWithTokenGitHubQuery = Pick<RESTPostAPIWebhookWith
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#execute-githubcompatible-webhook}
  */
-export type RESTPostAPIWebhookWithTokenGitHubResult = never;
+export type RESTPostAPIWebhookWithTokenGitHubResult = void;
 
 /**
  * Received when a call to https://discord.com/developers/docs/resources/webhook#execute-webhook receives
@@ -319,4 +319,4 @@ export interface RESTDeleteAPIWebhookWithTokenMessageQuery {
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#delete-webhook-message}
  */
-export type RESTDeleteAPIWebhookWithTokenMessageResult = never;
+export type RESTDeleteAPIWebhookWithTokenMessageResult = void;

--- a/deno/rest/v10/webhook.ts
+++ b/deno/rest/v10/webhook.ts
@@ -89,12 +89,12 @@ export type RESTPatchAPIWebhookWithTokenResult = RESTGetAPIWebhookWithTokenResul
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#delete-webhook}
  */
-export type RESTDeleteAPIWebhookResult = void;
+export type RESTDeleteAPIWebhookResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#delete-webhook-with-token}
  */
-export type RESTDeleteAPIWebhookWithTokenResult = void;
+export type RESTDeleteAPIWebhookWithTokenResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#execute-webhook}
@@ -201,7 +201,7 @@ export interface RESTPostAPIWebhookWithTokenQuery {
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#execute-webhook}
  */
-export type RESTPostAPIWebhookWithTokenResult = void;
+export type RESTPostAPIWebhookWithTokenResult = undefined;
 
 /**
  * Received when a call to https://discord.com/developers/docs/resources/webhook#execute-webhook receives
@@ -219,7 +219,7 @@ export type RESTPostAPIWebhookWithTokenSlackQuery = Pick<RESTPostAPIWebhookWithT
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#execute-slackcompatible-webhook}
  */
-export type RESTPostAPIWebhookWithTokenSlackResult = void;
+export type RESTPostAPIWebhookWithTokenSlackResult = undefined;
 
 /**
  * Received when a call to https://discord.com/developers/docs/resources/webhook#execute-webhook receives
@@ -237,7 +237,7 @@ export type RESTPostAPIWebhookWithTokenGitHubQuery = Pick<RESTPostAPIWebhookWith
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#execute-githubcompatible-webhook}
  */
-export type RESTPostAPIWebhookWithTokenGitHubResult = void;
+export type RESTPostAPIWebhookWithTokenGitHubResult = undefined;
 
 /**
  * Received when a call to https://discord.com/developers/docs/resources/webhook#execute-webhook receives
@@ -319,4 +319,4 @@ export interface RESTDeleteAPIWebhookWithTokenMessageQuery {
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#delete-webhook-message}
  */
-export type RESTDeleteAPIWebhookWithTokenMessageResult = void;
+export type RESTDeleteAPIWebhookWithTokenMessageResult = undefined;

--- a/deno/rest/v9/autoModeration.ts
+++ b/deno/rest/v9/autoModeration.ts
@@ -80,4 +80,4 @@ export type RESTPatchAPIAutoModerationRuleResult = APIAutoModerationRule;
 /**
  * @see {@link https://discord.com/developers/docs/resources/auto-moderation#delete-auto-moderation-rule}
  */
-export type RESTDeleteAPIAutoModerationRuleResult = void;
+export type RESTDeleteAPIAutoModerationRuleResult = undefined;

--- a/deno/rest/v9/autoModeration.ts
+++ b/deno/rest/v9/autoModeration.ts
@@ -80,4 +80,4 @@ export type RESTPatchAPIAutoModerationRuleResult = APIAutoModerationRule;
 /**
  * @see {@link https://discord.com/developers/docs/resources/auto-moderation#delete-auto-moderation-rule}
  */
-export type RESTDeleteAPIAutoModerationRuleResult = never;
+export type RESTDeleteAPIAutoModerationRuleResult = void;

--- a/deno/rest/v9/channel.ts
+++ b/deno/rest/v9/channel.ts
@@ -376,12 +376,12 @@ export type RESTPostAPIChannelMessageCrosspostResult = APIMessage;
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#create-reaction}
  */
-export type RESTPutAPIChannelMessageReactionResult = never;
+export type RESTPutAPIChannelMessageReactionResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#delete-own-reaction}
  */
-export type RESTDeleteAPIChannelMessageOwnReactionResult = never;
+export type RESTDeleteAPIChannelMessageOwnReactionResult = void;
 
 /**
  * @deprecated Use {@link RESTDeleteAPIChannelMessageOwnReactionResult} instead
@@ -391,7 +391,7 @@ export type RESTDeleteAPIChannelMessageOwnReaction = RESTDeleteAPIChannelMessage
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#delete-user-reaction}
  */
-export type RESTDeleteAPIChannelMessageUserReactionResult = never;
+export type RESTDeleteAPIChannelMessageUserReactionResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#get-reactions}
@@ -435,12 +435,12 @@ export type RESTGetAPIChannelMessageReactionUsersResult = APIUser[];
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#delete-all-reactions}
  */
-export type RESTDeleteAPIChannelAllMessageReactionsResult = never;
+export type RESTDeleteAPIChannelAllMessageReactionsResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#delete-all-reactions-for-emoji}
  */
-export type RESTDeleteAPIChannelMessageReactionResult = never;
+export type RESTDeleteAPIChannelMessageReactionResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#edit-message}
@@ -514,7 +514,7 @@ export type RESTPatchAPIChannelMessageResult = APIMessage;
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#delete-message}
  */
-export type RESTDeleteAPIChannelMessageResult = never;
+export type RESTDeleteAPIChannelMessageResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#bulk-delete-messages}
@@ -529,7 +529,7 @@ export interface RESTPostAPIChannelMessagesBulkDeleteJSONBody {
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#bulk-delete-messages}
  */
-export type RESTPostAPIChannelMessagesBulkDeleteResult = never;
+export type RESTPostAPIChannelMessagesBulkDeleteResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#edit-channel-permissions}
@@ -558,7 +558,7 @@ export interface RESTPutAPIChannelPermissionJSONBody {
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#edit-channel-permissions}
  */
-export type RESTPutAPIChannelPermissionResult = never;
+export type RESTPutAPIChannelPermissionResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#get-channel-invites}
@@ -646,7 +646,7 @@ export type RESTPostAPIChannelInviteResult = APIExtendedInvite;
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#delete-channel-permission}
  */
-export type RESTDeleteAPIChannelPermissionResult = never;
+export type RESTDeleteAPIChannelPermissionResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#follow-news-channel}
@@ -666,7 +666,7 @@ export type RESTPostAPIChannelFollowersResult = APIFollowedChannel;
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#trigger-typing-indicator}
  */
-export type RESTPostAPIChannelTypingResult = never;
+export type RESTPostAPIChannelTypingResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/message#get-channel-pins}
@@ -701,12 +701,12 @@ export interface RESTGetAPIChannelMessagesPinsResult {
 /**
  * @see {@link https://discord.com/developers/docs/resources/message#pin-message}
  */
-export type RESTPutAPIChannelMessagesPinResult = never;
+export type RESTPutAPIChannelMessagesPinResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/message#unpin-message}
  */
-export type RESTDeleteAPIChannelMessagesPinResult = never;
+export type RESTDeleteAPIChannelMessagesPinResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/message#get-pinned-messages-deprecated}
@@ -718,12 +718,12 @@ export type RESTGetAPIChannelPinsResult = APIMessage[];
  * @see {@link https://discord.com/developers/docs/resources/message#pin-message-deprecated}
  * @deprecated
  */
-export type RESTPutAPIChannelPinResult = never;
+export type RESTPutAPIChannelPinResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#unpin-message}
  */
-export type RESTDeleteAPIChannelPinResult = never;
+export type RESTDeleteAPIChannelPinResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#group-dm-add-recipient}
@@ -829,12 +829,12 @@ export type RESTPostAPIChannelThreadsResult =
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#join-thread}
  */
-export type RESTPutAPIChannelThreadMembersResult = never;
+export type RESTPutAPIChannelThreadMembersResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#leave-thread}
  */
-export type RESTDeleteAPIChannelThreadMembersResult = never;
+export type RESTDeleteAPIChannelThreadMembersResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#get-thread-member}

--- a/deno/rest/v9/channel.ts
+++ b/deno/rest/v9/channel.ts
@@ -376,12 +376,12 @@ export type RESTPostAPIChannelMessageCrosspostResult = APIMessage;
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#create-reaction}
  */
-export type RESTPutAPIChannelMessageReactionResult = void;
+export type RESTPutAPIChannelMessageReactionResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#delete-own-reaction}
  */
-export type RESTDeleteAPIChannelMessageOwnReactionResult = void;
+export type RESTDeleteAPIChannelMessageOwnReactionResult = undefined;
 
 /**
  * @deprecated Use {@link RESTDeleteAPIChannelMessageOwnReactionResult} instead
@@ -391,7 +391,7 @@ export type RESTDeleteAPIChannelMessageOwnReaction = RESTDeleteAPIChannelMessage
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#delete-user-reaction}
  */
-export type RESTDeleteAPIChannelMessageUserReactionResult = void;
+export type RESTDeleteAPIChannelMessageUserReactionResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#get-reactions}
@@ -435,12 +435,12 @@ export type RESTGetAPIChannelMessageReactionUsersResult = APIUser[];
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#delete-all-reactions}
  */
-export type RESTDeleteAPIChannelAllMessageReactionsResult = void;
+export type RESTDeleteAPIChannelAllMessageReactionsResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#delete-all-reactions-for-emoji}
  */
-export type RESTDeleteAPIChannelMessageReactionResult = void;
+export type RESTDeleteAPIChannelMessageReactionResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#edit-message}
@@ -514,7 +514,7 @@ export type RESTPatchAPIChannelMessageResult = APIMessage;
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#delete-message}
  */
-export type RESTDeleteAPIChannelMessageResult = void;
+export type RESTDeleteAPIChannelMessageResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#bulk-delete-messages}
@@ -529,7 +529,7 @@ export interface RESTPostAPIChannelMessagesBulkDeleteJSONBody {
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#bulk-delete-messages}
  */
-export type RESTPostAPIChannelMessagesBulkDeleteResult = void;
+export type RESTPostAPIChannelMessagesBulkDeleteResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#edit-channel-permissions}
@@ -558,7 +558,7 @@ export interface RESTPutAPIChannelPermissionJSONBody {
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#edit-channel-permissions}
  */
-export type RESTPutAPIChannelPermissionResult = void;
+export type RESTPutAPIChannelPermissionResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#get-channel-invites}
@@ -646,7 +646,7 @@ export type RESTPostAPIChannelInviteResult = APIExtendedInvite;
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#delete-channel-permission}
  */
-export type RESTDeleteAPIChannelPermissionResult = void;
+export type RESTDeleteAPIChannelPermissionResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#follow-news-channel}
@@ -666,7 +666,7 @@ export type RESTPostAPIChannelFollowersResult = APIFollowedChannel;
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#trigger-typing-indicator}
  */
-export type RESTPostAPIChannelTypingResult = void;
+export type RESTPostAPIChannelTypingResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/message#get-channel-pins}
@@ -701,12 +701,12 @@ export interface RESTGetAPIChannelMessagesPinsResult {
 /**
  * @see {@link https://discord.com/developers/docs/resources/message#pin-message}
  */
-export type RESTPutAPIChannelMessagesPinResult = void;
+export type RESTPutAPIChannelMessagesPinResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/message#unpin-message}
  */
-export type RESTDeleteAPIChannelMessagesPinResult = void;
+export type RESTDeleteAPIChannelMessagesPinResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/message#get-pinned-messages-deprecated}
@@ -718,12 +718,12 @@ export type RESTGetAPIChannelPinsResult = APIMessage[];
  * @see {@link https://discord.com/developers/docs/resources/message#pin-message-deprecated}
  * @deprecated
  */
-export type RESTPutAPIChannelPinResult = void;
+export type RESTPutAPIChannelPinResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#unpin-message}
  */
-export type RESTDeleteAPIChannelPinResult = void;
+export type RESTDeleteAPIChannelPinResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#group-dm-add-recipient}
@@ -829,12 +829,12 @@ export type RESTPostAPIChannelThreadsResult =
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#join-thread}
  */
-export type RESTPutAPIChannelThreadMembersResult = void;
+export type RESTPutAPIChannelThreadMembersResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#leave-thread}
  */
-export type RESTDeleteAPIChannelThreadMembersResult = void;
+export type RESTDeleteAPIChannelThreadMembersResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#get-thread-member}

--- a/deno/rest/v9/emoji.ts
+++ b/deno/rest/v9/emoji.ts
@@ -58,7 +58,7 @@ export type RESTPatchAPIGuildEmojiResult = APIEmoji;
 /**
  * @see {@link https://discord.com/developers/docs/resources/emoji#delete-guild-emoji}
  */
-export type RESTDeleteAPIGuildEmojiResult = void;
+export type RESTDeleteAPIGuildEmojiResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/emoji#list-application-emojis}
@@ -95,4 +95,4 @@ export type RESTPatchAPIApplicationEmojiResult = APIApplicationEmoji;
 /**
  * @see {@link https://discord.com/developers/docs/resources/emoji#delete-application-emoji}
  */
-export type RESTDeleteAPIApplicationEmojiResult = void;
+export type RESTDeleteAPIApplicationEmojiResult = undefined;

--- a/deno/rest/v9/emoji.ts
+++ b/deno/rest/v9/emoji.ts
@@ -58,7 +58,7 @@ export type RESTPatchAPIGuildEmojiResult = APIEmoji;
 /**
  * @see {@link https://discord.com/developers/docs/resources/emoji#delete-guild-emoji}
  */
-export type RESTDeleteAPIGuildEmojiResult = never;
+export type RESTDeleteAPIGuildEmojiResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/emoji#list-application-emojis}
@@ -95,4 +95,4 @@ export type RESTPatchAPIApplicationEmojiResult = APIApplicationEmoji;
 /**
  * @see {@link https://discord.com/developers/docs/resources/emoji#delete-application-emoji}
  */
-export type RESTDeleteAPIApplicationEmojiResult = never;
+export type RESTDeleteAPIApplicationEmojiResult = void;

--- a/deno/rest/v9/guild.ts
+++ b/deno/rest/v9/guild.ts
@@ -360,7 +360,7 @@ export type RESTPatchAPIGuildResult = APIGuild;
  * @see {@link https://discord.com/developers/docs/change-log#guild-create-deprecation}
  * @deprecated
  */
-export type RESTDeleteAPIGuildResult = never;
+export type RESTDeleteAPIGuildResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#get-guild-channels}
@@ -402,7 +402,7 @@ export type RESTPatchAPIGuildChannelPositionsJSONBody = {
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#modify-guild-channel-positions}
  */
-export type RESTPatchAPIGuildChannelPositionsResult = never;
+export type RESTPatchAPIGuildChannelPositionsResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#list-active-guild-threads}
@@ -739,17 +739,17 @@ export type RESTPatchAPICurrentGuildMemberResult = APIGuildMember;
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#add-guild-member-role}
  */
-export type RESTPutAPIGuildMemberRoleResult = never;
+export type RESTPutAPIGuildMemberRoleResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#remove-guild-member-role}
  */
-export type RESTDeleteAPIGuildMemberRoleResult = never;
+export type RESTDeleteAPIGuildMemberRoleResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#remove-guild-member}
  */
-export type RESTDeleteAPIGuildMemberResult = never;
+export type RESTDeleteAPIGuildMemberResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#get-guild-bans}
@@ -806,12 +806,12 @@ export interface RESTPutAPIGuildBanJSONBody {
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#create-guild-ban}
  */
-export type RESTPutAPIGuildBanResult = never;
+export type RESTPutAPIGuildBanResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#remove-guild-ban}
  */
-export type RESTDeleteAPIGuildBanResult = never;
+export type RESTDeleteAPIGuildBanResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#bulk-guild-ban}
@@ -975,7 +975,7 @@ export type RESTPatchAPIGuildRoleResult = APIRole;
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#delete-guild-role}
  */
-export type RESTDeleteAPIGuildRoleResult = never;
+export type RESTDeleteAPIGuildRoleResult = void;
 
 /**
  * A record mapping role IDs to the number of members that have that role.
@@ -1060,7 +1060,7 @@ export type RESTGetAPIGuildIntegrationsResult = APIGuildIntegration[];
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#delete-guild-integration}
  */
-export type RESTDeleteAPIGuildIntegrationResult = never;
+export type RESTDeleteAPIGuildIntegrationResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#get-guild-widget-settings}

--- a/deno/rest/v9/guild.ts
+++ b/deno/rest/v9/guild.ts
@@ -360,7 +360,7 @@ export type RESTPatchAPIGuildResult = APIGuild;
  * @see {@link https://discord.com/developers/docs/change-log#guild-create-deprecation}
  * @deprecated
  */
-export type RESTDeleteAPIGuildResult = void;
+export type RESTDeleteAPIGuildResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#get-guild-channels}
@@ -402,7 +402,7 @@ export type RESTPatchAPIGuildChannelPositionsJSONBody = {
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#modify-guild-channel-positions}
  */
-export type RESTPatchAPIGuildChannelPositionsResult = void;
+export type RESTPatchAPIGuildChannelPositionsResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#list-active-guild-threads}
@@ -739,17 +739,17 @@ export type RESTPatchAPICurrentGuildMemberResult = APIGuildMember;
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#add-guild-member-role}
  */
-export type RESTPutAPIGuildMemberRoleResult = void;
+export type RESTPutAPIGuildMemberRoleResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#remove-guild-member-role}
  */
-export type RESTDeleteAPIGuildMemberRoleResult = void;
+export type RESTDeleteAPIGuildMemberRoleResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#remove-guild-member}
  */
-export type RESTDeleteAPIGuildMemberResult = void;
+export type RESTDeleteAPIGuildMemberResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#get-guild-bans}
@@ -806,12 +806,12 @@ export interface RESTPutAPIGuildBanJSONBody {
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#create-guild-ban}
  */
-export type RESTPutAPIGuildBanResult = void;
+export type RESTPutAPIGuildBanResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#remove-guild-ban}
  */
-export type RESTDeleteAPIGuildBanResult = void;
+export type RESTDeleteAPIGuildBanResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#bulk-guild-ban}
@@ -975,7 +975,7 @@ export type RESTPatchAPIGuildRoleResult = APIRole;
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#delete-guild-role}
  */
-export type RESTDeleteAPIGuildRoleResult = void;
+export type RESTDeleteAPIGuildRoleResult = undefined;
 
 /**
  * A record mapping role IDs to the number of members that have that role.
@@ -1060,7 +1060,7 @@ export type RESTGetAPIGuildIntegrationsResult = APIGuildIntegration[];
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#delete-guild-integration}
  */
-export type RESTDeleteAPIGuildIntegrationResult = void;
+export type RESTDeleteAPIGuildIntegrationResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#get-guild-widget-settings}

--- a/deno/rest/v9/guildScheduledEvent.ts
+++ b/deno/rest/v9/guildScheduledEvent.ts
@@ -118,7 +118,7 @@ export type RESTPatchAPIGuildScheduledEventResult = APIGuildScheduledEvent;
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild-scheduled-event#delete-guild-scheduled-event}
  */
-export type RESTDeleteAPIGuildScheduledEventResult = void;
+export type RESTDeleteAPIGuildScheduledEventResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild-scheduled-event#get-guild-scheduled-event-users}

--- a/deno/rest/v9/guildScheduledEvent.ts
+++ b/deno/rest/v9/guildScheduledEvent.ts
@@ -118,7 +118,7 @@ export type RESTPatchAPIGuildScheduledEventResult = APIGuildScheduledEvent;
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild-scheduled-event#delete-guild-scheduled-event}
  */
-export type RESTDeleteAPIGuildScheduledEventResult = never;
+export type RESTDeleteAPIGuildScheduledEventResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild-scheduled-event#get-guild-scheduled-event-users}

--- a/deno/rest/v9/interactions.ts
+++ b/deno/rest/v9/interactions.ts
@@ -212,7 +212,7 @@ export type RESTPostAPIInteractionCallbackFormDataBody =
 /**
  * @see {@link https://discord.com/developers/docs/interactions/receiving-and-responding#create-interaction-response}
  */
-export type RESTPostAPIInteractionCallbackResult = void;
+export type RESTPostAPIInteractionCallbackResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-callback-interaction-callback-response-object}

--- a/deno/rest/v9/interactions.ts
+++ b/deno/rest/v9/interactions.ts
@@ -212,7 +212,7 @@ export type RESTPostAPIInteractionCallbackFormDataBody =
 /**
  * @see {@link https://discord.com/developers/docs/interactions/receiving-and-responding#create-interaction-response}
  */
-export type RESTPostAPIInteractionCallbackResult = never;
+export type RESTPostAPIInteractionCallbackResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-callback-interaction-callback-response-object}

--- a/deno/rest/v9/monetization.ts
+++ b/deno/rest/v9/monetization.ts
@@ -95,7 +95,7 @@ export enum EntitlementOwnerType {
 /**
  * @see {@link https://discord.com/developers/docs/resources/entitlement#delete-test-entitlement}
  */
-export type RESTDeleteAPIEntitlementResult = void;
+export type RESTDeleteAPIEntitlementResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/sku#list-skus}
@@ -105,7 +105,7 @@ export type RESTGetAPISKUsResult = APISKU[];
 /**
  * @see {@link https://discord.com/developers/docs/resources/entitlement#consume-an-entitlement}
  */
-export type RESTPostAPIEntitlementConsumeResult = void;
+export type RESTPostAPIEntitlementConsumeResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/subscription#query-string-params}

--- a/deno/rest/v9/monetization.ts
+++ b/deno/rest/v9/monetization.ts
@@ -95,7 +95,7 @@ export enum EntitlementOwnerType {
 /**
  * @see {@link https://discord.com/developers/docs/resources/entitlement#delete-test-entitlement}
  */
-export type RESTDeleteAPIEntitlementResult = never;
+export type RESTDeleteAPIEntitlementResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/sku#list-skus}
@@ -105,7 +105,7 @@ export type RESTGetAPISKUsResult = APISKU[];
 /**
  * @see {@link https://discord.com/developers/docs/resources/entitlement#consume-an-entitlement}
  */
-export type RESTPostAPIEntitlementConsumeResult = never;
+export type RESTPostAPIEntitlementConsumeResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/subscription#query-string-params}

--- a/deno/rest/v9/oauth2.ts
+++ b/deno/rest/v9/oauth2.ts
@@ -82,7 +82,7 @@ export type RESTPostOAuth2AccessTokenURLEncodedData = RESTOAuth2TokenOptionalCli
 
 export type RESTOAuth2TokenOptionalClientCredentials =
 	| { client_id: Snowflake; client_secret: string }
-	| { client_id?: never; client_secret?: never };
+	| { client_id?: void; client_secret?: void };
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-access-token-response}

--- a/deno/rest/v9/oauth2.ts
+++ b/deno/rest/v9/oauth2.ts
@@ -82,7 +82,7 @@ export type RESTPostOAuth2AccessTokenURLEncodedData = RESTOAuth2TokenOptionalCli
 
 export type RESTOAuth2TokenOptionalClientCredentials =
 	| { client_id: Snowflake; client_secret: string }
-	| { client_id?: undefined; client_secret?: undefined };
+	| { client_id?: never; client_secret?: never };
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-access-token-response}

--- a/deno/rest/v9/oauth2.ts
+++ b/deno/rest/v9/oauth2.ts
@@ -82,7 +82,7 @@ export type RESTPostOAuth2AccessTokenURLEncodedData = RESTOAuth2TokenOptionalCli
 
 export type RESTOAuth2TokenOptionalClientCredentials =
 	| { client_id: Snowflake; client_secret: string }
-	| { client_id?: void; client_secret?: void };
+	| { client_id?: undefined; client_secret?: undefined };
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-access-token-response}

--- a/deno/rest/v9/soundboard.ts
+++ b/deno/rest/v9/soundboard.ts
@@ -104,4 +104,4 @@ export type RESTPatchAPIGuildSoundboardSoundResult = APISoundboardSound;
 /**
  * @see {@link https://discord.com/developers/docs/resources/soundboard#delete-guild-soundboard-sound}
  */
-export type RESTDeleteAPIGuildSoundboardSoundResult = never;
+export type RESTDeleteAPIGuildSoundboardSoundResult = void;

--- a/deno/rest/v9/soundboard.ts
+++ b/deno/rest/v9/soundboard.ts
@@ -104,4 +104,4 @@ export type RESTPatchAPIGuildSoundboardSoundResult = APISoundboardSound;
 /**
  * @see {@link https://discord.com/developers/docs/resources/soundboard#delete-guild-soundboard-sound}
  */
-export type RESTDeleteAPIGuildSoundboardSoundResult = void;
+export type RESTDeleteAPIGuildSoundboardSoundResult = undefined;

--- a/deno/rest/v9/soundboard.ts
+++ b/deno/rest/v9/soundboard.ts
@@ -4,7 +4,7 @@ import type { APISoundboardSound } from '../../payloads/v9/mod.ts';
 /**
  * @see {@link https://discord.com/developers/docs/resources/soundboard#send-soundboard-sound}
  */
-export type RESTPostAPISendSoundboardSoundResult = never;
+export type RESTPostAPISendSoundboardSoundResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/soundboard#send-soundboard-sound-json-params}

--- a/deno/rest/v9/stageInstance.ts
+++ b/deno/rest/v9/stageInstance.ts
@@ -61,4 +61,4 @@ export type RESTPatchAPIStageInstanceResult = APIStageInstance;
 /**
  * @see {@link https://discord.com/developers/docs/resources/stage-instance#delete-stage-instance}
  */
-export type RESTDeleteAPIStageInstanceResult = void;
+export type RESTDeleteAPIStageInstanceResult = undefined;

--- a/deno/rest/v9/stageInstance.ts
+++ b/deno/rest/v9/stageInstance.ts
@@ -61,4 +61,4 @@ export type RESTPatchAPIStageInstanceResult = APIStageInstance;
 /**
  * @see {@link https://discord.com/developers/docs/resources/stage-instance#delete-stage-instance}
  */
-export type RESTDeleteAPIStageInstanceResult = never;
+export type RESTDeleteAPIStageInstanceResult = void;

--- a/deno/rest/v9/sticker.ts
+++ b/deno/rest/v9/sticker.ts
@@ -93,4 +93,4 @@ export type RESTPatchAPIGuildStickerResult = APISticker;
 /**
  * @see {@link https://discord.com/developers/docs/resources/sticker#delete-guild-sticker}
  */
-export type RESTDeleteAPIGuildStickerResult = never;
+export type RESTDeleteAPIGuildStickerResult = void;

--- a/deno/rest/v9/sticker.ts
+++ b/deno/rest/v9/sticker.ts
@@ -93,4 +93,4 @@ export type RESTPatchAPIGuildStickerResult = APISticker;
 /**
  * @see {@link https://discord.com/developers/docs/resources/sticker#delete-guild-sticker}
  */
-export type RESTDeleteAPIGuildStickerResult = void;
+export type RESTDeleteAPIGuildStickerResult = undefined;

--- a/deno/rest/v9/user.ts
+++ b/deno/rest/v9/user.ts
@@ -92,7 +92,7 @@ export type RESTGetAPICurrentUserGuildsResult = RESTAPIPartialCurrentUserGuild[]
 /**
  * @see {@link https://discord.com/developers/docs/resources/user#leave-guild}
  */
-export type RESTDeleteAPICurrentUserGuildResult = void;
+export type RESTDeleteAPICurrentUserGuildResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/user#create-dm}

--- a/deno/rest/v9/user.ts
+++ b/deno/rest/v9/user.ts
@@ -92,7 +92,7 @@ export type RESTGetAPICurrentUserGuildsResult = RESTAPIPartialCurrentUserGuild[]
 /**
  * @see {@link https://discord.com/developers/docs/resources/user#leave-guild}
  */
-export type RESTDeleteAPICurrentUserGuildResult = never;
+export type RESTDeleteAPICurrentUserGuildResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/user#create-dm}

--- a/deno/rest/v9/voice.ts
+++ b/deno/rest/v9/voice.ts
@@ -42,7 +42,7 @@ export interface RESTPatchAPIGuildVoiceStateCurrentMemberJSONBody {
 /**
  * @see {@link https://discord.com/developers/docs/resources/voice#modify-current-user-voice-state}
  */
-export type RESTPatchAPIGuildVoiceStateCurrentMemberResult = void;
+export type RESTPatchAPIGuildVoiceStateCurrentMemberResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/voice#modify-user-voice-state}
@@ -61,4 +61,4 @@ export interface RESTPatchAPIGuildVoiceStateUserJSONBody {
 /**
  * @see {@link https://discord.com/developers/docs/resources/voice#modify-user-voice-state}
  */
-export type RESTPatchAPIGuildVoiceStateUserResult = void;
+export type RESTPatchAPIGuildVoiceStateUserResult = undefined;

--- a/deno/rest/v9/voice.ts
+++ b/deno/rest/v9/voice.ts
@@ -42,7 +42,7 @@ export interface RESTPatchAPIGuildVoiceStateCurrentMemberJSONBody {
 /**
  * @see {@link https://discord.com/developers/docs/resources/voice#modify-current-user-voice-state}
  */
-export type RESTPatchAPIGuildVoiceStateCurrentMemberResult = never;
+export type RESTPatchAPIGuildVoiceStateCurrentMemberResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/voice#modify-user-voice-state}
@@ -61,4 +61,4 @@ export interface RESTPatchAPIGuildVoiceStateUserJSONBody {
 /**
  * @see {@link https://discord.com/developers/docs/resources/voice#modify-user-voice-state}
  */
-export type RESTPatchAPIGuildVoiceStateUserResult = never;
+export type RESTPatchAPIGuildVoiceStateUserResult = void;

--- a/deno/rest/v9/webhook.ts
+++ b/deno/rest/v9/webhook.ts
@@ -89,12 +89,12 @@ export type RESTPatchAPIWebhookWithTokenResult = RESTGetAPIWebhookWithTokenResul
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#delete-webhook}
  */
-export type RESTDeleteAPIWebhookResult = never;
+export type RESTDeleteAPIWebhookResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#delete-webhook-with-token}
  */
-export type RESTDeleteAPIWebhookWithTokenResult = never;
+export type RESTDeleteAPIWebhookWithTokenResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#execute-webhook}
@@ -201,7 +201,7 @@ export interface RESTPostAPIWebhookWithTokenQuery {
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#execute-webhook}
  */
-export type RESTPostAPIWebhookWithTokenResult = never;
+export type RESTPostAPIWebhookWithTokenResult = void;
 
 /**
  * Received when a call to https://discord.com/developers/docs/resources/webhook#execute-webhook receives
@@ -219,7 +219,7 @@ export type RESTPostAPIWebhookWithTokenSlackQuery = Pick<RESTPostAPIWebhookWithT
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#execute-slackcompatible-webhook}
  */
-export type RESTPostAPIWebhookWithTokenSlackResult = never;
+export type RESTPostAPIWebhookWithTokenSlackResult = void;
 
 /**
  * Received when a call to https://discord.com/developers/docs/resources/webhook#execute-webhook receives
@@ -237,7 +237,7 @@ export type RESTPostAPIWebhookWithTokenGitHubQuery = Pick<RESTPostAPIWebhookWith
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#execute-githubcompatible-webhook}
  */
-export type RESTPostAPIWebhookWithTokenGitHubResult = never;
+export type RESTPostAPIWebhookWithTokenGitHubResult = void;
 
 /**
  * Received when a call to https://discord.com/developers/docs/resources/webhook#execute-webhook receives
@@ -319,4 +319,4 @@ export interface RESTDeleteAPIWebhookWithTokenMessageQuery {
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#delete-webhook-message}
  */
-export type RESTDeleteAPIWebhookWithTokenMessageResult = never;
+export type RESTDeleteAPIWebhookWithTokenMessageResult = void;

--- a/deno/rest/v9/webhook.ts
+++ b/deno/rest/v9/webhook.ts
@@ -89,12 +89,12 @@ export type RESTPatchAPIWebhookWithTokenResult = RESTGetAPIWebhookWithTokenResul
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#delete-webhook}
  */
-export type RESTDeleteAPIWebhookResult = void;
+export type RESTDeleteAPIWebhookResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#delete-webhook-with-token}
  */
-export type RESTDeleteAPIWebhookWithTokenResult = void;
+export type RESTDeleteAPIWebhookWithTokenResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#execute-webhook}
@@ -201,7 +201,7 @@ export interface RESTPostAPIWebhookWithTokenQuery {
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#execute-webhook}
  */
-export type RESTPostAPIWebhookWithTokenResult = void;
+export type RESTPostAPIWebhookWithTokenResult = undefined;
 
 /**
  * Received when a call to https://discord.com/developers/docs/resources/webhook#execute-webhook receives
@@ -219,7 +219,7 @@ export type RESTPostAPIWebhookWithTokenSlackQuery = Pick<RESTPostAPIWebhookWithT
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#execute-slackcompatible-webhook}
  */
-export type RESTPostAPIWebhookWithTokenSlackResult = void;
+export type RESTPostAPIWebhookWithTokenSlackResult = undefined;
 
 /**
  * Received when a call to https://discord.com/developers/docs/resources/webhook#execute-webhook receives
@@ -237,7 +237,7 @@ export type RESTPostAPIWebhookWithTokenGitHubQuery = Pick<RESTPostAPIWebhookWith
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#execute-githubcompatible-webhook}
  */
-export type RESTPostAPIWebhookWithTokenGitHubResult = void;
+export type RESTPostAPIWebhookWithTokenGitHubResult = undefined;
 
 /**
  * Received when a call to https://discord.com/developers/docs/resources/webhook#execute-webhook receives
@@ -319,4 +319,4 @@ export interface RESTDeleteAPIWebhookWithTokenMessageQuery {
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#delete-webhook-message}
  */
-export type RESTDeleteAPIWebhookWithTokenMessageResult = void;
+export type RESTDeleteAPIWebhookWithTokenMessageResult = undefined;

--- a/deno/rpc/v10.ts
+++ b/deno/rpc/v10.ts
@@ -1233,42 +1233,42 @@ export enum RPCEvents {
 /**
  * @unstable
  */
-export type RPCSubscribeActivityInviteArgs = Record<string, void>;
+export type RPCSubscribeActivityInviteArgs = Record<string, undefined>;
 
-export type RPCSubscribeActivityJoinArgs = Record<string, void>;
+export type RPCSubscribeActivityJoinArgs = Record<string, undefined>;
 
-export type RPCSubscribeActivityJoinRequestArgs = Record<string, void>;
+export type RPCSubscribeActivityJoinRequestArgs = Record<string, undefined>;
 
-export type RPCSubscribeActivitySpectateArgs = Record<string, void>;
+export type RPCSubscribeActivitySpectateArgs = Record<string, undefined>;
 
-export type RPCSubscribeChannelCreateArgs = Record<string, void>;
-
-/**
- * @unstable
- */
-export type RPCSubscribeCurrentUserUpdateArgs = Record<string, void>;
+export type RPCSubscribeChannelCreateArgs = Record<string, undefined>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeEntitlementCreateArgs = Record<string, void>;
+export type RPCSubscribeCurrentUserUpdateArgs = Record<string, undefined>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeEntitlementDeleteArgs = Record<string, void>;
+export type RPCSubscribeEntitlementCreateArgs = Record<string, undefined>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeGameJoinArgs = Record<string, void>;
+export type RPCSubscribeEntitlementDeleteArgs = Record<string, undefined>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeGameSpectateArgs = Record<string, void>;
+export type RPCSubscribeGameJoinArgs = Record<string, undefined>;
 
-export type RPCSubscribeGuildCreateArgs = Record<string, void>;
+/**
+ * @unstable
+ */
+export type RPCSubscribeGameSpectateArgs = Record<string, undefined>;
+
+export type RPCSubscribeGuildCreateArgs = Record<string, undefined>;
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/rpc#guildstatus-guild-status-argument-structure}
@@ -1310,22 +1310,22 @@ export interface RPCSubscribeMessageUpdateArgs {
 	channel_id: Snowflake;
 }
 
-export type RPCSubscribeNotificationCreateArgs = Record<string, void>;
+export type RPCSubscribeNotificationCreateArgs = Record<string, undefined>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeOverlayArgs = Record<string, void>;
+export type RPCSubscribeOverlayArgs = Record<string, undefined>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeOverlayUpdateArgs = Record<string, void>;
+export type RPCSubscribeOverlayUpdateArgs = Record<string, undefined>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeRelationshipUpdateArgs = Record<string, void>;
+export type RPCSubscribeRelationshipUpdateArgs = Record<string, undefined>;
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/rpc#speakingstartspeakingstop-speaking-argument-structure}
@@ -1347,19 +1347,19 @@ export interface RPCSubscribeSpeakingStopArgs {
 	channel_id: Snowflake;
 }
 
-export type RPCSubscribeVoiceChannelSelectArgs = Record<string, void>;
+export type RPCSubscribeVoiceChannelSelectArgs = Record<string, undefined>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeVoiceConnectionStatusArgs = Record<string, void>;
+export type RPCSubscribeVoiceConnectionStatusArgs = Record<string, undefined>;
 
-export type RPCSubscribeVoiceSettingsUpdateArgs = Record<string, void>;
+export type RPCSubscribeVoiceSettingsUpdateArgs = Record<string, undefined>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeVoiceSettingsUpdate2Args = Record<string, void>;
+export type RPCSubscribeVoiceSettingsUpdate2Args = Record<string, undefined>;
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/rpc#voicestatecreatevoicestateupdatevoicestatedelete-voice-state-argument-structure}

--- a/deno/rpc/v10.ts
+++ b/deno/rpc/v10.ts
@@ -1233,42 +1233,42 @@ export enum RPCEvents {
 /**
  * @unstable
  */
-export type RPCSubscribeActivityInviteArgs = Record<string, never>;
+export type RPCSubscribeActivityInviteArgs = Record<string, void>;
 
-export type RPCSubscribeActivityJoinArgs = Record<string, never>;
+export type RPCSubscribeActivityJoinArgs = Record<string, void>;
 
-export type RPCSubscribeActivityJoinRequestArgs = Record<string, never>;
+export type RPCSubscribeActivityJoinRequestArgs = Record<string, void>;
 
-export type RPCSubscribeActivitySpectateArgs = Record<string, never>;
+export type RPCSubscribeActivitySpectateArgs = Record<string, void>;
 
-export type RPCSubscribeChannelCreateArgs = Record<string, never>;
-
-/**
- * @unstable
- */
-export type RPCSubscribeCurrentUserUpdateArgs = Record<string, never>;
+export type RPCSubscribeChannelCreateArgs = Record<string, void>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeEntitlementCreateArgs = Record<string, never>;
+export type RPCSubscribeCurrentUserUpdateArgs = Record<string, void>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeEntitlementDeleteArgs = Record<string, never>;
+export type RPCSubscribeEntitlementCreateArgs = Record<string, void>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeGameJoinArgs = Record<string, never>;
+export type RPCSubscribeEntitlementDeleteArgs = Record<string, void>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeGameSpectateArgs = Record<string, never>;
+export type RPCSubscribeGameJoinArgs = Record<string, void>;
 
-export type RPCSubscribeGuildCreateArgs = Record<string, never>;
+/**
+ * @unstable
+ */
+export type RPCSubscribeGameSpectateArgs = Record<string, void>;
+
+export type RPCSubscribeGuildCreateArgs = Record<string, void>;
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/rpc#guildstatus-guild-status-argument-structure}
@@ -1310,22 +1310,22 @@ export interface RPCSubscribeMessageUpdateArgs {
 	channel_id: Snowflake;
 }
 
-export type RPCSubscribeNotificationCreateArgs = Record<string, never>;
+export type RPCSubscribeNotificationCreateArgs = Record<string, void>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeOverlayArgs = Record<string, never>;
+export type RPCSubscribeOverlayArgs = Record<string, void>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeOverlayUpdateArgs = Record<string, never>;
+export type RPCSubscribeOverlayUpdateArgs = Record<string, void>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeRelationshipUpdateArgs = Record<string, never>;
+export type RPCSubscribeRelationshipUpdateArgs = Record<string, void>;
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/rpc#speakingstartspeakingstop-speaking-argument-structure}
@@ -1347,19 +1347,19 @@ export interface RPCSubscribeSpeakingStopArgs {
 	channel_id: Snowflake;
 }
 
-export type RPCSubscribeVoiceChannelSelectArgs = Record<string, never>;
+export type RPCSubscribeVoiceChannelSelectArgs = Record<string, void>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeVoiceConnectionStatusArgs = Record<string, never>;
+export type RPCSubscribeVoiceConnectionStatusArgs = Record<string, void>;
 
-export type RPCSubscribeVoiceSettingsUpdateArgs = Record<string, never>;
+export type RPCSubscribeVoiceSettingsUpdateArgs = Record<string, void>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeVoiceSettingsUpdate2Args = Record<string, never>;
+export type RPCSubscribeVoiceSettingsUpdate2Args = Record<string, void>;
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/rpc#voicestatecreatevoicestateupdatevoicestatedelete-voice-state-argument-structure}

--- a/deno/rpc/v10.ts
+++ b/deno/rpc/v10.ts
@@ -1233,42 +1233,42 @@ export enum RPCEvents {
 /**
  * @unstable
  */
-export type RPCSubscribeActivityInviteArgs = Record<string, undefined>;
+export type RPCSubscribeActivityInviteArgs = Record<string, unknown>;
 
-export type RPCSubscribeActivityJoinArgs = Record<string, undefined>;
+export type RPCSubscribeActivityJoinArgs = Record<string, unknown>;
 
-export type RPCSubscribeActivityJoinRequestArgs = Record<string, undefined>;
+export type RPCSubscribeActivityJoinRequestArgs = Record<string, unknown>;
 
-export type RPCSubscribeActivitySpectateArgs = Record<string, undefined>;
+export type RPCSubscribeActivitySpectateArgs = Record<string, unknown>;
 
-export type RPCSubscribeChannelCreateArgs = Record<string, undefined>;
-
-/**
- * @unstable
- */
-export type RPCSubscribeCurrentUserUpdateArgs = Record<string, undefined>;
+export type RPCSubscribeChannelCreateArgs = Record<string, unknown>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeEntitlementCreateArgs = Record<string, undefined>;
+export type RPCSubscribeCurrentUserUpdateArgs = Record<string, unknown>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeEntitlementDeleteArgs = Record<string, undefined>;
+export type RPCSubscribeEntitlementCreateArgs = Record<string, unknown>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeGameJoinArgs = Record<string, undefined>;
+export type RPCSubscribeEntitlementDeleteArgs = Record<string, unknown>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeGameSpectateArgs = Record<string, undefined>;
+export type RPCSubscribeGameJoinArgs = Record<string, unknown>;
 
-export type RPCSubscribeGuildCreateArgs = Record<string, undefined>;
+/**
+ * @unstable
+ */
+export type RPCSubscribeGameSpectateArgs = Record<string, unknown>;
+
+export type RPCSubscribeGuildCreateArgs = Record<string, unknown>;
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/rpc#guildstatus-guild-status-argument-structure}
@@ -1310,22 +1310,22 @@ export interface RPCSubscribeMessageUpdateArgs {
 	channel_id: Snowflake;
 }
 
-export type RPCSubscribeNotificationCreateArgs = Record<string, undefined>;
+export type RPCSubscribeNotificationCreateArgs = Record<string, unknown>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeOverlayArgs = Record<string, undefined>;
+export type RPCSubscribeOverlayArgs = Record<string, unknown>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeOverlayUpdateArgs = Record<string, undefined>;
+export type RPCSubscribeOverlayUpdateArgs = Record<string, unknown>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeRelationshipUpdateArgs = Record<string, undefined>;
+export type RPCSubscribeRelationshipUpdateArgs = Record<string, unknown>;
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/rpc#speakingstartspeakingstop-speaking-argument-structure}
@@ -1347,19 +1347,19 @@ export interface RPCSubscribeSpeakingStopArgs {
 	channel_id: Snowflake;
 }
 
-export type RPCSubscribeVoiceChannelSelectArgs = Record<string, undefined>;
+export type RPCSubscribeVoiceChannelSelectArgs = Record<string, unknown>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeVoiceConnectionStatusArgs = Record<string, undefined>;
+export type RPCSubscribeVoiceConnectionStatusArgs = Record<string, unknown>;
 
-export type RPCSubscribeVoiceSettingsUpdateArgs = Record<string, undefined>;
+export type RPCSubscribeVoiceSettingsUpdateArgs = Record<string, unknown>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeVoiceSettingsUpdate2Args = Record<string, undefined>;
+export type RPCSubscribeVoiceSettingsUpdate2Args = Record<string, unknown>;
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/rpc#voicestatecreatevoicestateupdatevoicestatedelete-voice-state-argument-structure}

--- a/gateway/v10.ts
+++ b/gateway/v10.ts
@@ -430,7 +430,7 @@ export interface GatewayHelloData {
  */
 export interface GatewayHeartbeatRequest extends _NonDispatchPayload {
 	op: GatewayOpcodes.Heartbeat;
-	d: never;
+	d: void;
 }
 
 /**
@@ -438,7 +438,7 @@ export interface GatewayHeartbeatRequest extends _NonDispatchPayload {
  */
 export interface GatewayHeartbeatAck extends _NonDispatchPayload {
 	op: GatewayOpcodes.HeartbeatAck;
-	d: never;
+	d: void;
 }
 
 /**
@@ -459,7 +459,7 @@ export type GatewayInvalidSessionData = boolean;
  */
 export interface GatewayReconnect extends _NonDispatchPayload {
 	op: GatewayOpcodes.Reconnect;
-	d: never;
+	d: void;
 }
 
 /**
@@ -514,7 +514,7 @@ export interface GatewayReadyDispatchData {
 /**
  * @see {@link https://discord.com/developers/docs/topics/gateway-events#resumed}
  */
-export type GatewayResumedDispatch = _DataPayload<GatewayDispatchEvents.Resumed, never>;
+export type GatewayResumedDispatch = _DataPayload<GatewayDispatchEvents.Resumed, void>;
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/gateway-events#auto-moderation-rule-create}
@@ -2657,7 +2657,7 @@ export interface _DataPayload<Event extends GatewayDispatchEvents, D = unknown> 
 }
 
 // This is not used internally anymore, just remains to be non-breaking
-export type GatewayMessageReactionData<E extends GatewayDispatchEvents, O extends string = never> = _DataPayload<
+export type GatewayMessageReactionData<E extends GatewayDispatchEvents, O extends string = void> = _DataPayload<
 	E,
 	Omit<GatewayMessageReactionAddDispatchData, O>
 >;

--- a/gateway/v10.ts
+++ b/gateway/v10.ts
@@ -430,7 +430,7 @@ export interface GatewayHelloData {
  */
 export interface GatewayHeartbeatRequest extends _NonDispatchPayload {
 	op: GatewayOpcodes.Heartbeat;
-	d: never;
+	d: undefined;
 }
 
 /**
@@ -438,7 +438,7 @@ export interface GatewayHeartbeatRequest extends _NonDispatchPayload {
  */
 export interface GatewayHeartbeatAck extends _NonDispatchPayload {
 	op: GatewayOpcodes.HeartbeatAck;
-	d: never;
+	d: undefined;
 }
 
 /**
@@ -459,7 +459,7 @@ export type GatewayInvalidSessionData = boolean;
  */
 export interface GatewayReconnect extends _NonDispatchPayload {
 	op: GatewayOpcodes.Reconnect;
-	d: never;
+	d: undefined;
 }
 
 /**
@@ -514,7 +514,7 @@ export interface GatewayReadyDispatchData {
 /**
  * @see {@link https://discord.com/developers/docs/topics/gateway-events#resumed}
  */
-export type GatewayResumedDispatch = _DataPayload<GatewayDispatchEvents.Resumed, void>;
+export type GatewayResumedDispatch = _DataPayload<GatewayDispatchEvents.Resumed, undefined>;
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/gateway-events#auto-moderation-rule-create}

--- a/gateway/v10.ts
+++ b/gateway/v10.ts
@@ -430,7 +430,7 @@ export interface GatewayHelloData {
  */
 export interface GatewayHeartbeatRequest extends _NonDispatchPayload {
 	op: GatewayOpcodes.Heartbeat;
-	d: void;
+	d: never;
 }
 
 /**
@@ -438,7 +438,7 @@ export interface GatewayHeartbeatRequest extends _NonDispatchPayload {
  */
 export interface GatewayHeartbeatAck extends _NonDispatchPayload {
 	op: GatewayOpcodes.HeartbeatAck;
-	d: void;
+	d: never;
 }
 
 /**
@@ -459,7 +459,7 @@ export type GatewayInvalidSessionData = boolean;
  */
 export interface GatewayReconnect extends _NonDispatchPayload {
 	op: GatewayOpcodes.Reconnect;
-	d: void;
+	d: never;
 }
 
 /**
@@ -2657,7 +2657,7 @@ export interface _DataPayload<Event extends GatewayDispatchEvents, D = unknown> 
 }
 
 // This is not used internally anymore, just remains to be non-breaking
-export type GatewayMessageReactionData<E extends GatewayDispatchEvents, O extends string = void> = _DataPayload<
+export type GatewayMessageReactionData<E extends GatewayDispatchEvents, O extends string = never> = _DataPayload<
 	E,
 	Omit<GatewayMessageReactionAddDispatchData, O>
 >;

--- a/gateway/v9.ts
+++ b/gateway/v9.ts
@@ -429,7 +429,7 @@ export interface GatewayHelloData {
  */
 export interface GatewayHeartbeatRequest extends _NonDispatchPayload {
 	op: GatewayOpcodes.Heartbeat;
-	d: never;
+	d: undefined;
 }
 
 /**
@@ -437,7 +437,7 @@ export interface GatewayHeartbeatRequest extends _NonDispatchPayload {
  */
 export interface GatewayHeartbeatAck extends _NonDispatchPayload {
 	op: GatewayOpcodes.HeartbeatAck;
-	d: never;
+	d: undefined;
 }
 
 /**
@@ -458,7 +458,7 @@ export type GatewayInvalidSessionData = boolean;
  */
 export interface GatewayReconnect extends _NonDispatchPayload {
 	op: GatewayOpcodes.Reconnect;
-	d: never;
+	d: undefined;
 }
 
 /**
@@ -513,7 +513,7 @@ export interface GatewayReadyDispatchData {
 /**
  * @see {@link https://discord.com/developers/docs/topics/gateway-events#resumed}
  */
-export type GatewayResumedDispatch = _DataPayload<GatewayDispatchEvents.Resumed, void>;
+export type GatewayResumedDispatch = _DataPayload<GatewayDispatchEvents.Resumed, undefined>;
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/gateway-events#auto-moderation-rule-create}

--- a/gateway/v9.ts
+++ b/gateway/v9.ts
@@ -429,7 +429,7 @@ export interface GatewayHelloData {
  */
 export interface GatewayHeartbeatRequest extends _NonDispatchPayload {
 	op: GatewayOpcodes.Heartbeat;
-	d: void;
+	d: never;
 }
 
 /**
@@ -437,7 +437,7 @@ export interface GatewayHeartbeatRequest extends _NonDispatchPayload {
  */
 export interface GatewayHeartbeatAck extends _NonDispatchPayload {
 	op: GatewayOpcodes.HeartbeatAck;
-	d: void;
+	d: never;
 }
 
 /**
@@ -458,7 +458,7 @@ export type GatewayInvalidSessionData = boolean;
  */
 export interface GatewayReconnect extends _NonDispatchPayload {
 	op: GatewayOpcodes.Reconnect;
-	d: void;
+	d: never;
 }
 
 /**
@@ -2656,7 +2656,7 @@ export interface _DataPayload<Event extends GatewayDispatchEvents, D = unknown> 
 }
 
 // This is not used internally anymore, just remains to be non-breaking
-export type GatewayMessageReactionData<E extends GatewayDispatchEvents, O extends string = void> = _DataPayload<
+export type GatewayMessageReactionData<E extends GatewayDispatchEvents, O extends string = never> = _DataPayload<
 	E,
 	Omit<GatewayMessageReactionAddDispatchData, O>
 >;

--- a/gateway/v9.ts
+++ b/gateway/v9.ts
@@ -429,7 +429,7 @@ export interface GatewayHelloData {
  */
 export interface GatewayHeartbeatRequest extends _NonDispatchPayload {
 	op: GatewayOpcodes.Heartbeat;
-	d: never;
+	d: void;
 }
 
 /**
@@ -437,7 +437,7 @@ export interface GatewayHeartbeatRequest extends _NonDispatchPayload {
  */
 export interface GatewayHeartbeatAck extends _NonDispatchPayload {
 	op: GatewayOpcodes.HeartbeatAck;
-	d: never;
+	d: void;
 }
 
 /**
@@ -458,7 +458,7 @@ export type GatewayInvalidSessionData = boolean;
  */
 export interface GatewayReconnect extends _NonDispatchPayload {
 	op: GatewayOpcodes.Reconnect;
-	d: never;
+	d: void;
 }
 
 /**
@@ -513,7 +513,7 @@ export interface GatewayReadyDispatchData {
 /**
  * @see {@link https://discord.com/developers/docs/topics/gateway-events#resumed}
  */
-export type GatewayResumedDispatch = _DataPayload<GatewayDispatchEvents.Resumed, never>;
+export type GatewayResumedDispatch = _DataPayload<GatewayDispatchEvents.Resumed, void>;
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/gateway-events#auto-moderation-rule-create}
@@ -2656,7 +2656,7 @@ export interface _DataPayload<Event extends GatewayDispatchEvents, D = unknown> 
 }
 
 // This is not used internally anymore, just remains to be non-breaking
-export type GatewayMessageReactionData<E extends GatewayDispatchEvents, O extends string = never> = _DataPayload<
+export type GatewayMessageReactionData<E extends GatewayDispatchEvents, O extends string = void> = _DataPayload<
 	E,
 	Omit<GatewayMessageReactionAddDispatchData, O>
 >;

--- a/payloads/v10/_interactions/ping.ts
+++ b/payloads/v10/_interactions/ping.ts
@@ -1,4 +1,4 @@
 import type { APIBaseInteraction } from './base';
 import type { InteractionType } from './responses';
 
-export type APIPingInteraction = Omit<APIBaseInteraction<InteractionType.Ping, never>, 'locale'>;
+export type APIPingInteraction = Omit<APIBaseInteraction<InteractionType.Ping, void>, 'locale'>;

--- a/payloads/v10/_interactions/ping.ts
+++ b/payloads/v10/_interactions/ping.ts
@@ -1,4 +1,4 @@
 import type { APIBaseInteraction } from './base';
 import type { InteractionType } from './responses';
 
-export type APIPingInteraction = Omit<APIBaseInteraction<InteractionType.Ping, void>, 'locale'>;
+export type APIPingInteraction = Omit<APIBaseInteraction<InteractionType.Ping, undefined>, 'locale'>;

--- a/payloads/v10/invite.ts
+++ b/payloads/v10/invite.ts
@@ -90,7 +90,7 @@ export interface APIInvite {
 	 * @deprecated This has been removed from the documentation.
 	 * {@link https://github.com/discord/discord-api-docs/pull/7779 | discord-api-docs#7779}
 	 */
-	stage_instance?: never;
+	stage_instance?: void;
 	/**
 	 * The guild scheduled event data, returned from the `GET /invites/<code>` endpoint when `guild_scheduled_event_id` is a valid guild scheduled event id
 	 */

--- a/payloads/v10/invite.ts
+++ b/payloads/v10/invite.ts
@@ -90,7 +90,7 @@ export interface APIInvite {
 	 * @deprecated This has been removed from the documentation.
 	 * {@link https://github.com/discord/discord-api-docs/pull/7779 | discord-api-docs#7779}
 	 */
-	stage_instance?: void;
+	stage_instance?: undefined;
 	/**
 	 * The guild scheduled event data, returned from the `GET /invites/<code>` endpoint when `guild_scheduled_event_id` is a valid guild scheduled event id
 	 */

--- a/payloads/v10/webhook.ts
+++ b/payloads/v10/webhook.ts
@@ -76,7 +76,7 @@ export interface APIWebhook {
  */
 export type APIWebhookEvent =
 	| APIWebhookEventBase<ApplicationWebhookType.Event, APIWebhookEventBody>
-	| APIWebhookEventBase<ApplicationWebhookType.Ping, never>;
+	| APIWebhookEventBase<ApplicationWebhookType.Ping, void>;
 
 /**
  * @see {@link https://discord.com/developers/docs/events/webhook-events#event-body-object}
@@ -127,7 +127,7 @@ export type APIWebhookEventEntitlementDeleteData = APIEntitlement;
 
 export type APIWebhookEventEntitlementUpdateData = APIEntitlement;
 
-export type APIWebhookEventQuestUserEnrollmentData = never;
+export type APIWebhookEventQuestUserEnrollmentData = void;
 
 export interface APIWebhookEventBase<Type extends ApplicationWebhookType, Event> {
 	/**

--- a/payloads/v10/webhook.ts
+++ b/payloads/v10/webhook.ts
@@ -76,7 +76,7 @@ export interface APIWebhook {
  */
 export type APIWebhookEvent =
 	| APIWebhookEventBase<ApplicationWebhookType.Event, APIWebhookEventBody>
-	| APIWebhookEventBase<ApplicationWebhookType.Ping, void>;
+	| APIWebhookEventBase<ApplicationWebhookType.Ping, undefined>;
 
 /**
  * @see {@link https://discord.com/developers/docs/events/webhook-events#event-body-object}
@@ -127,7 +127,7 @@ export type APIWebhookEventEntitlementDeleteData = APIEntitlement;
 
 export type APIWebhookEventEntitlementUpdateData = APIEntitlement;
 
-export type APIWebhookEventQuestUserEnrollmentData = void;
+export type APIWebhookEventQuestUserEnrollmentData = undefined;
 
 export interface APIWebhookEventBase<Type extends ApplicationWebhookType, Event> {
 	/**

--- a/payloads/v9/_interactions/ping.ts
+++ b/payloads/v9/_interactions/ping.ts
@@ -1,4 +1,4 @@
 import type { APIBaseInteraction } from './base';
 import type { InteractionType } from './responses';
 
-export type APIPingInteraction = Omit<APIBaseInteraction<InteractionType.Ping, never>, 'locale'>;
+export type APIPingInteraction = Omit<APIBaseInteraction<InteractionType.Ping, void>, 'locale'>;

--- a/payloads/v9/_interactions/ping.ts
+++ b/payloads/v9/_interactions/ping.ts
@@ -1,4 +1,4 @@
 import type { APIBaseInteraction } from './base';
 import type { InteractionType } from './responses';
 
-export type APIPingInteraction = Omit<APIBaseInteraction<InteractionType.Ping, void>, 'locale'>;
+export type APIPingInteraction = Omit<APIBaseInteraction<InteractionType.Ping, undefined>, 'locale'>;

--- a/payloads/v9/invite.ts
+++ b/payloads/v9/invite.ts
@@ -90,7 +90,7 @@ export interface APIInvite {
 	 * @deprecated This has been removed from the documentation.
 	 * {@link https://github.com/discord/discord-api-docs/pull/7779 | discord-api-docs#7779}
 	 */
-	stage_instance?: never;
+	stage_instance?: void;
 	/**
 	 * The guild scheduled event data, returned from the `GET /invites/<code>` endpoint when `guild_scheduled_event_id` is a valid guild scheduled event id
 	 */

--- a/payloads/v9/invite.ts
+++ b/payloads/v9/invite.ts
@@ -90,7 +90,7 @@ export interface APIInvite {
 	 * @deprecated This has been removed from the documentation.
 	 * {@link https://github.com/discord/discord-api-docs/pull/7779 | discord-api-docs#7779}
 	 */
-	stage_instance?: void;
+	stage_instance?: undefined;
 	/**
 	 * The guild scheduled event data, returned from the `GET /invites/<code>` endpoint when `guild_scheduled_event_id` is a valid guild scheduled event id
 	 */

--- a/payloads/v9/webhook.ts
+++ b/payloads/v9/webhook.ts
@@ -76,7 +76,7 @@ export interface APIWebhook {
  */
 export type APIWebhookEvent =
 	| APIWebhookEventBase<ApplicationWebhookType.Event, APIWebhookEventBody>
-	| APIWebhookEventBase<ApplicationWebhookType.Ping, never>;
+	| APIWebhookEventBase<ApplicationWebhookType.Ping, void>;
 
 /**
  * @see {@link https://discord.com/developers/docs/events/webhook-events#event-body-object}
@@ -127,7 +127,7 @@ export type APIWebhookEventEntitlementDeleteData = APIEntitlement;
 
 export type APIWebhookEventEntitlementUpdateData = APIEntitlement;
 
-export type APIWebhookEventQuestUserEnrollmentData = never;
+export type APIWebhookEventQuestUserEnrollmentData = void;
 
 export interface APIWebhookEventBase<Type extends ApplicationWebhookType, Event> {
 	/**

--- a/payloads/v9/webhook.ts
+++ b/payloads/v9/webhook.ts
@@ -76,7 +76,7 @@ export interface APIWebhook {
  */
 export type APIWebhookEvent =
 	| APIWebhookEventBase<ApplicationWebhookType.Event, APIWebhookEventBody>
-	| APIWebhookEventBase<ApplicationWebhookType.Ping, void>;
+	| APIWebhookEventBase<ApplicationWebhookType.Ping, undefined>;
 
 /**
  * @see {@link https://discord.com/developers/docs/events/webhook-events#event-body-object}
@@ -127,7 +127,7 @@ export type APIWebhookEventEntitlementDeleteData = APIEntitlement;
 
 export type APIWebhookEventEntitlementUpdateData = APIEntitlement;
 
-export type APIWebhookEventQuestUserEnrollmentData = void;
+export type APIWebhookEventQuestUserEnrollmentData = undefined;
 
 export interface APIWebhookEventBase<Type extends ApplicationWebhookType, Event> {
 	/**

--- a/rest/v10/autoModeration.ts
+++ b/rest/v10/autoModeration.ts
@@ -80,4 +80,4 @@ export type RESTPatchAPIAutoModerationRuleResult = APIAutoModerationRule;
 /**
  * @see {@link https://discord.com/developers/docs/resources/auto-moderation#delete-auto-moderation-rule}
  */
-export type RESTDeleteAPIAutoModerationRuleResult = void;
+export type RESTDeleteAPIAutoModerationRuleResult = undefined;

--- a/rest/v10/autoModeration.ts
+++ b/rest/v10/autoModeration.ts
@@ -80,4 +80,4 @@ export type RESTPatchAPIAutoModerationRuleResult = APIAutoModerationRule;
 /**
  * @see {@link https://discord.com/developers/docs/resources/auto-moderation#delete-auto-moderation-rule}
  */
-export type RESTDeleteAPIAutoModerationRuleResult = never;
+export type RESTDeleteAPIAutoModerationRuleResult = void;

--- a/rest/v10/channel.ts
+++ b/rest/v10/channel.ts
@@ -369,12 +369,12 @@ export type RESTPostAPIChannelMessageCrosspostResult = APIMessage;
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#create-reaction}
  */
-export type RESTPutAPIChannelMessageReactionResult = never;
+export type RESTPutAPIChannelMessageReactionResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#delete-own-reaction}
  */
-export type RESTDeleteAPIChannelMessageOwnReactionResult = never;
+export type RESTDeleteAPIChannelMessageOwnReactionResult = void;
 
 /**
  * @deprecated Use {@link RESTDeleteAPIChannelMessageOwnReactionResult} instead
@@ -384,7 +384,7 @@ export type RESTDeleteAPIChannelMessageOwnReaction = RESTDeleteAPIChannelMessage
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#delete-user-reaction}
  */
-export type RESTDeleteAPIChannelMessageUserReactionResult = never;
+export type RESTDeleteAPIChannelMessageUserReactionResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#get-reactions}
@@ -428,12 +428,12 @@ export type RESTGetAPIChannelMessageReactionUsersResult = APIUser[];
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#delete-all-reactions}
  */
-export type RESTDeleteAPIChannelAllMessageReactionsResult = never;
+export type RESTDeleteAPIChannelAllMessageReactionsResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#delete-all-reactions-for-emoji}
  */
-export type RESTDeleteAPIChannelMessageReactionResult = never;
+export type RESTDeleteAPIChannelMessageReactionResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#edit-message}
@@ -500,7 +500,7 @@ export type RESTPatchAPIChannelMessageResult = APIMessage;
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#delete-message}
  */
-export type RESTDeleteAPIChannelMessageResult = never;
+export type RESTDeleteAPIChannelMessageResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#bulk-delete-messages}
@@ -515,7 +515,7 @@ export interface RESTPostAPIChannelMessagesBulkDeleteJSONBody {
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#bulk-delete-messages}
  */
-export type RESTPostAPIChannelMessagesBulkDeleteResult = never;
+export type RESTPostAPIChannelMessagesBulkDeleteResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#edit-channel-permissions}
@@ -544,7 +544,7 @@ export interface RESTPutAPIChannelPermissionJSONBody {
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#edit-channel-permissions}
  */
-export type RESTPutAPIChannelPermissionResult = never;
+export type RESTPutAPIChannelPermissionResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#get-channel-invites}
@@ -632,7 +632,7 @@ export type RESTPostAPIChannelInviteResult = APIExtendedInvite;
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#delete-channel-permission}
  */
-export type RESTDeleteAPIChannelPermissionResult = never;
+export type RESTDeleteAPIChannelPermissionResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#follow-news-channel}
@@ -652,7 +652,7 @@ export type RESTPostAPIChannelFollowersResult = APIFollowedChannel;
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#trigger-typing-indicator}
  */
-export type RESTPostAPIChannelTypingResult = never;
+export type RESTPostAPIChannelTypingResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/message#get-channel-pins}
@@ -687,12 +687,12 @@ export interface RESTGetAPIChannelMessagesPinsResult {
 /**
  * @see {@link https://discord.com/developers/docs/resources/message#pin-message}
  */
-export type RESTPutAPIChannelMessagesPinResult = never;
+export type RESTPutAPIChannelMessagesPinResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/message#unpin-message}
  */
-export type RESTDeleteAPIChannelMessagesPinResult = never;
+export type RESTDeleteAPIChannelMessagesPinResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/message#get-pinned-messages-deprecated}
@@ -704,13 +704,13 @@ export type RESTGetAPIChannelPinsResult = APIMessage[];
  * @see {@link https://discord.com/developers/docs/resources/message#pin-message-deprecated}
  * @deprecated
  */
-export type RESTPutAPIChannelPinResult = never;
+export type RESTPutAPIChannelPinResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/message#unpin-message-deprecated}
  * @deprecated
  */
-export type RESTDeleteAPIChannelPinResult = never;
+export type RESTDeleteAPIChannelPinResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#group-dm-add-recipient}
@@ -816,12 +816,12 @@ export type RESTPostAPIChannelThreadsResult =
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#join-thread}
  */
-export type RESTPutAPIChannelThreadMembersResult = never;
+export type RESTPutAPIChannelThreadMembersResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#leave-thread}
  */
-export type RESTDeleteAPIChannelThreadMembersResult = never;
+export type RESTDeleteAPIChannelThreadMembersResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#get-thread-member}

--- a/rest/v10/channel.ts
+++ b/rest/v10/channel.ts
@@ -369,12 +369,12 @@ export type RESTPostAPIChannelMessageCrosspostResult = APIMessage;
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#create-reaction}
  */
-export type RESTPutAPIChannelMessageReactionResult = void;
+export type RESTPutAPIChannelMessageReactionResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#delete-own-reaction}
  */
-export type RESTDeleteAPIChannelMessageOwnReactionResult = void;
+export type RESTDeleteAPIChannelMessageOwnReactionResult = undefined;
 
 /**
  * @deprecated Use {@link RESTDeleteAPIChannelMessageOwnReactionResult} instead
@@ -384,7 +384,7 @@ export type RESTDeleteAPIChannelMessageOwnReaction = RESTDeleteAPIChannelMessage
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#delete-user-reaction}
  */
-export type RESTDeleteAPIChannelMessageUserReactionResult = void;
+export type RESTDeleteAPIChannelMessageUserReactionResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#get-reactions}
@@ -428,12 +428,12 @@ export type RESTGetAPIChannelMessageReactionUsersResult = APIUser[];
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#delete-all-reactions}
  */
-export type RESTDeleteAPIChannelAllMessageReactionsResult = void;
+export type RESTDeleteAPIChannelAllMessageReactionsResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#delete-all-reactions-for-emoji}
  */
-export type RESTDeleteAPIChannelMessageReactionResult = void;
+export type RESTDeleteAPIChannelMessageReactionResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#edit-message}
@@ -500,7 +500,7 @@ export type RESTPatchAPIChannelMessageResult = APIMessage;
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#delete-message}
  */
-export type RESTDeleteAPIChannelMessageResult = void;
+export type RESTDeleteAPIChannelMessageResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#bulk-delete-messages}
@@ -515,7 +515,7 @@ export interface RESTPostAPIChannelMessagesBulkDeleteJSONBody {
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#bulk-delete-messages}
  */
-export type RESTPostAPIChannelMessagesBulkDeleteResult = void;
+export type RESTPostAPIChannelMessagesBulkDeleteResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#edit-channel-permissions}
@@ -544,7 +544,7 @@ export interface RESTPutAPIChannelPermissionJSONBody {
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#edit-channel-permissions}
  */
-export type RESTPutAPIChannelPermissionResult = void;
+export type RESTPutAPIChannelPermissionResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#get-channel-invites}
@@ -632,7 +632,7 @@ export type RESTPostAPIChannelInviteResult = APIExtendedInvite;
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#delete-channel-permission}
  */
-export type RESTDeleteAPIChannelPermissionResult = void;
+export type RESTDeleteAPIChannelPermissionResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#follow-news-channel}
@@ -652,7 +652,7 @@ export type RESTPostAPIChannelFollowersResult = APIFollowedChannel;
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#trigger-typing-indicator}
  */
-export type RESTPostAPIChannelTypingResult = void;
+export type RESTPostAPIChannelTypingResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/message#get-channel-pins}
@@ -687,12 +687,12 @@ export interface RESTGetAPIChannelMessagesPinsResult {
 /**
  * @see {@link https://discord.com/developers/docs/resources/message#pin-message}
  */
-export type RESTPutAPIChannelMessagesPinResult = void;
+export type RESTPutAPIChannelMessagesPinResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/message#unpin-message}
  */
-export type RESTDeleteAPIChannelMessagesPinResult = void;
+export type RESTDeleteAPIChannelMessagesPinResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/message#get-pinned-messages-deprecated}
@@ -704,13 +704,13 @@ export type RESTGetAPIChannelPinsResult = APIMessage[];
  * @see {@link https://discord.com/developers/docs/resources/message#pin-message-deprecated}
  * @deprecated
  */
-export type RESTPutAPIChannelPinResult = void;
+export type RESTPutAPIChannelPinResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/message#unpin-message-deprecated}
  * @deprecated
  */
-export type RESTDeleteAPIChannelPinResult = void;
+export type RESTDeleteAPIChannelPinResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#group-dm-add-recipient}
@@ -816,12 +816,12 @@ export type RESTPostAPIChannelThreadsResult =
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#join-thread}
  */
-export type RESTPutAPIChannelThreadMembersResult = void;
+export type RESTPutAPIChannelThreadMembersResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#leave-thread}
  */
-export type RESTDeleteAPIChannelThreadMembersResult = void;
+export type RESTDeleteAPIChannelThreadMembersResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#get-thread-member}

--- a/rest/v10/emoji.ts
+++ b/rest/v10/emoji.ts
@@ -58,7 +58,7 @@ export type RESTPatchAPIGuildEmojiResult = APIEmoji;
 /**
  * @see {@link https://discord.com/developers/docs/resources/emoji#delete-guild-emoji}
  */
-export type RESTDeleteAPIGuildEmojiResult = void;
+export type RESTDeleteAPIGuildEmojiResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/emoji#list-application-emojis}
@@ -95,4 +95,4 @@ export type RESTPatchAPIApplicationEmojiResult = APIApplicationEmoji;
 /**
  * @see {@link https://discord.com/developers/docs/resources/emoji#delete-application-emoji}
  */
-export type RESTDeleteAPIApplicationEmojiResult = void;
+export type RESTDeleteAPIApplicationEmojiResult = undefined;

--- a/rest/v10/emoji.ts
+++ b/rest/v10/emoji.ts
@@ -58,7 +58,7 @@ export type RESTPatchAPIGuildEmojiResult = APIEmoji;
 /**
  * @see {@link https://discord.com/developers/docs/resources/emoji#delete-guild-emoji}
  */
-export type RESTDeleteAPIGuildEmojiResult = never;
+export type RESTDeleteAPIGuildEmojiResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/emoji#list-application-emojis}
@@ -95,4 +95,4 @@ export type RESTPatchAPIApplicationEmojiResult = APIApplicationEmoji;
 /**
  * @see {@link https://discord.com/developers/docs/resources/emoji#delete-application-emoji}
  */
-export type RESTDeleteAPIApplicationEmojiResult = never;
+export type RESTDeleteAPIApplicationEmojiResult = void;

--- a/rest/v10/guild.ts
+++ b/rest/v10/guild.ts
@@ -360,7 +360,7 @@ export type RESTPatchAPIGuildResult = APIGuild;
  * @see {@link https://discord.com/developers/docs/change-log#guild-create-deprecation}
  * @deprecated
  */
-export type RESTDeleteAPIGuildResult = void;
+export type RESTDeleteAPIGuildResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#get-guild-channels}
@@ -402,7 +402,7 @@ export type RESTPatchAPIGuildChannelPositionsJSONBody = {
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#modify-guild-channel-positions}
  */
-export type RESTPatchAPIGuildChannelPositionsResult = void;
+export type RESTPatchAPIGuildChannelPositionsResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#list-active-guild-threads}
@@ -739,17 +739,17 @@ export type RESTPatchAPICurrentGuildMemberResult = APIGuildMember;
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#add-guild-member-role}
  */
-export type RESTPutAPIGuildMemberRoleResult = void;
+export type RESTPutAPIGuildMemberRoleResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#remove-guild-member-role}
  */
-export type RESTDeleteAPIGuildMemberRoleResult = void;
+export type RESTDeleteAPIGuildMemberRoleResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#remove-guild-member}
  */
-export type RESTDeleteAPIGuildMemberResult = void;
+export type RESTDeleteAPIGuildMemberResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#get-guild-bans}
@@ -800,12 +800,12 @@ export interface RESTPutAPIGuildBanJSONBody {
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#create-guild-ban}
  */
-export type RESTPutAPIGuildBanResult = void;
+export type RESTPutAPIGuildBanResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#remove-guild-ban}
  */
-export type RESTDeleteAPIGuildBanResult = void;
+export type RESTDeleteAPIGuildBanResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#bulk-guild-ban}
@@ -969,7 +969,7 @@ export type RESTPatchAPIGuildRoleResult = APIRole;
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#delete-guild-role}
  */
-export type RESTDeleteAPIGuildRoleResult = void;
+export type RESTDeleteAPIGuildRoleResult = undefined;
 
 /**
  * A record mapping role IDs to the number of members that have that role.
@@ -1054,7 +1054,7 @@ export type RESTGetAPIGuildIntegrationsResult = APIGuildIntegration[];
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#delete-guild-integration}
  */
-export type RESTDeleteAPIGuildIntegrationResult = void;
+export type RESTDeleteAPIGuildIntegrationResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#get-guild-widget-settings}

--- a/rest/v10/guild.ts
+++ b/rest/v10/guild.ts
@@ -360,7 +360,7 @@ export type RESTPatchAPIGuildResult = APIGuild;
  * @see {@link https://discord.com/developers/docs/change-log#guild-create-deprecation}
  * @deprecated
  */
-export type RESTDeleteAPIGuildResult = never;
+export type RESTDeleteAPIGuildResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#get-guild-channels}
@@ -402,7 +402,7 @@ export type RESTPatchAPIGuildChannelPositionsJSONBody = {
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#modify-guild-channel-positions}
  */
-export type RESTPatchAPIGuildChannelPositionsResult = never;
+export type RESTPatchAPIGuildChannelPositionsResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#list-active-guild-threads}
@@ -739,17 +739,17 @@ export type RESTPatchAPICurrentGuildMemberResult = APIGuildMember;
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#add-guild-member-role}
  */
-export type RESTPutAPIGuildMemberRoleResult = never;
+export type RESTPutAPIGuildMemberRoleResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#remove-guild-member-role}
  */
-export type RESTDeleteAPIGuildMemberRoleResult = never;
+export type RESTDeleteAPIGuildMemberRoleResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#remove-guild-member}
  */
-export type RESTDeleteAPIGuildMemberResult = never;
+export type RESTDeleteAPIGuildMemberResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#get-guild-bans}
@@ -800,12 +800,12 @@ export interface RESTPutAPIGuildBanJSONBody {
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#create-guild-ban}
  */
-export type RESTPutAPIGuildBanResult = never;
+export type RESTPutAPIGuildBanResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#remove-guild-ban}
  */
-export type RESTDeleteAPIGuildBanResult = never;
+export type RESTDeleteAPIGuildBanResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#bulk-guild-ban}
@@ -969,7 +969,7 @@ export type RESTPatchAPIGuildRoleResult = APIRole;
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#delete-guild-role}
  */
-export type RESTDeleteAPIGuildRoleResult = never;
+export type RESTDeleteAPIGuildRoleResult = void;
 
 /**
  * A record mapping role IDs to the number of members that have that role.
@@ -1054,7 +1054,7 @@ export type RESTGetAPIGuildIntegrationsResult = APIGuildIntegration[];
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#delete-guild-integration}
  */
-export type RESTDeleteAPIGuildIntegrationResult = never;
+export type RESTDeleteAPIGuildIntegrationResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#get-guild-widget-settings}

--- a/rest/v10/guildScheduledEvent.ts
+++ b/rest/v10/guildScheduledEvent.ts
@@ -118,7 +118,7 @@ export type RESTPatchAPIGuildScheduledEventResult = APIGuildScheduledEvent;
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild-scheduled-event#delete-guild-scheduled-event}
  */
-export type RESTDeleteAPIGuildScheduledEventResult = void;
+export type RESTDeleteAPIGuildScheduledEventResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild-scheduled-event#get-guild-scheduled-event-users}

--- a/rest/v10/guildScheduledEvent.ts
+++ b/rest/v10/guildScheduledEvent.ts
@@ -118,7 +118,7 @@ export type RESTPatchAPIGuildScheduledEventResult = APIGuildScheduledEvent;
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild-scheduled-event#delete-guild-scheduled-event}
  */
-export type RESTDeleteAPIGuildScheduledEventResult = never;
+export type RESTDeleteAPIGuildScheduledEventResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild-scheduled-event#get-guild-scheduled-event-users}

--- a/rest/v10/interactions.ts
+++ b/rest/v10/interactions.ts
@@ -212,7 +212,7 @@ export type RESTPostAPIInteractionCallbackFormDataBody =
 /**
  * @see {@link https://discord.com/developers/docs/interactions/receiving-and-responding#create-interaction-response}
  */
-export type RESTPostAPIInteractionCallbackResult = void;
+export type RESTPostAPIInteractionCallbackResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-callback-interaction-callback-response-object}

--- a/rest/v10/interactions.ts
+++ b/rest/v10/interactions.ts
@@ -212,7 +212,7 @@ export type RESTPostAPIInteractionCallbackFormDataBody =
 /**
  * @see {@link https://discord.com/developers/docs/interactions/receiving-and-responding#create-interaction-response}
  */
-export type RESTPostAPIInteractionCallbackResult = never;
+export type RESTPostAPIInteractionCallbackResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-callback-interaction-callback-response-object}

--- a/rest/v10/monetization.ts
+++ b/rest/v10/monetization.ts
@@ -95,7 +95,7 @@ export enum EntitlementOwnerType {
 /**
  * @see {@link https://discord.com/developers/docs/resources/entitlement#delete-test-entitlement}
  */
-export type RESTDeleteAPIEntitlementResult = void;
+export type RESTDeleteAPIEntitlementResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/sku#list-skus}
@@ -105,7 +105,7 @@ export type RESTGetAPISKUsResult = APISKU[];
 /**
  * @see {@link https://discord.com/developers/docs/resources/entitlement#consume-an-entitlement}
  */
-export type RESTPostAPIEntitlementConsumeResult = void;
+export type RESTPostAPIEntitlementConsumeResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/subscription#query-string-params}

--- a/rest/v10/monetization.ts
+++ b/rest/v10/monetization.ts
@@ -95,7 +95,7 @@ export enum EntitlementOwnerType {
 /**
  * @see {@link https://discord.com/developers/docs/resources/entitlement#delete-test-entitlement}
  */
-export type RESTDeleteAPIEntitlementResult = never;
+export type RESTDeleteAPIEntitlementResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/sku#list-skus}
@@ -105,7 +105,7 @@ export type RESTGetAPISKUsResult = APISKU[];
 /**
  * @see {@link https://discord.com/developers/docs/resources/entitlement#consume-an-entitlement}
  */
-export type RESTPostAPIEntitlementConsumeResult = never;
+export type RESTPostAPIEntitlementConsumeResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/subscription#query-string-params}

--- a/rest/v10/oauth2.ts
+++ b/rest/v10/oauth2.ts
@@ -82,7 +82,7 @@ export type RESTPostOAuth2AccessTokenURLEncodedData = RESTOAuth2TokenOptionalCli
 
 export type RESTOAuth2TokenOptionalClientCredentials =
 	| { client_id: Snowflake; client_secret: string }
-	| { client_id?: never; client_secret?: never };
+	| { client_id?: void; client_secret?: void };
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-access-token-response}

--- a/rest/v10/oauth2.ts
+++ b/rest/v10/oauth2.ts
@@ -82,7 +82,7 @@ export type RESTPostOAuth2AccessTokenURLEncodedData = RESTOAuth2TokenOptionalCli
 
 export type RESTOAuth2TokenOptionalClientCredentials =
 	| { client_id: Snowflake; client_secret: string }
-	| { client_id?: undefined; client_secret?: undefined };
+	| { client_id?: never; client_secret?: never };
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-access-token-response}

--- a/rest/v10/oauth2.ts
+++ b/rest/v10/oauth2.ts
@@ -82,7 +82,7 @@ export type RESTPostOAuth2AccessTokenURLEncodedData = RESTOAuth2TokenOptionalCli
 
 export type RESTOAuth2TokenOptionalClientCredentials =
 	| { client_id: Snowflake; client_secret: string }
-	| { client_id?: void; client_secret?: void };
+	| { client_id?: undefined; client_secret?: undefined };
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-access-token-response}

--- a/rest/v10/soundboard.ts
+++ b/rest/v10/soundboard.ts
@@ -104,4 +104,4 @@ export type RESTPatchAPIGuildSoundboardSoundResult = APISoundboardSound;
 /**
  * @see {@link https://discord.com/developers/docs/resources/soundboard#delete-guild-soundboard-sound}
  */
-export type RESTDeleteAPIGuildSoundboardSoundResult = never;
+export type RESTDeleteAPIGuildSoundboardSoundResult = void;

--- a/rest/v10/soundboard.ts
+++ b/rest/v10/soundboard.ts
@@ -104,4 +104,4 @@ export type RESTPatchAPIGuildSoundboardSoundResult = APISoundboardSound;
 /**
  * @see {@link https://discord.com/developers/docs/resources/soundboard#delete-guild-soundboard-sound}
  */
-export type RESTDeleteAPIGuildSoundboardSoundResult = void;
+export type RESTDeleteAPIGuildSoundboardSoundResult = undefined;

--- a/rest/v10/soundboard.ts
+++ b/rest/v10/soundboard.ts
@@ -4,7 +4,7 @@ import type { APISoundboardSound } from '../../payloads/v10/index';
 /**
  * @see {@link https://discord.com/developers/docs/resources/soundboard#send-soundboard-sound}
  */
-export type RESTPostAPISendSoundboardSoundResult = never;
+export type RESTPostAPISendSoundboardSoundResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/soundboard#send-soundboard-sound-json-params}

--- a/rest/v10/stageInstance.ts
+++ b/rest/v10/stageInstance.ts
@@ -61,4 +61,4 @@ export type RESTPatchAPIStageInstanceResult = APIStageInstance;
 /**
  * @see {@link https://discord.com/developers/docs/resources/stage-instance#delete-stage-instance}
  */
-export type RESTDeleteAPIStageInstanceResult = void;
+export type RESTDeleteAPIStageInstanceResult = undefined;

--- a/rest/v10/stageInstance.ts
+++ b/rest/v10/stageInstance.ts
@@ -61,4 +61,4 @@ export type RESTPatchAPIStageInstanceResult = APIStageInstance;
 /**
  * @see {@link https://discord.com/developers/docs/resources/stage-instance#delete-stage-instance}
  */
-export type RESTDeleteAPIStageInstanceResult = never;
+export type RESTDeleteAPIStageInstanceResult = void;

--- a/rest/v10/sticker.ts
+++ b/rest/v10/sticker.ts
@@ -93,4 +93,4 @@ export type RESTPatchAPIGuildStickerResult = APISticker;
 /**
  * @see {@link https://discord.com/developers/docs/resources/sticker#delete-guild-sticker}
  */
-export type RESTDeleteAPIGuildStickerResult = never;
+export type RESTDeleteAPIGuildStickerResult = void;

--- a/rest/v10/sticker.ts
+++ b/rest/v10/sticker.ts
@@ -93,4 +93,4 @@ export type RESTPatchAPIGuildStickerResult = APISticker;
 /**
  * @see {@link https://discord.com/developers/docs/resources/sticker#delete-guild-sticker}
  */
-export type RESTDeleteAPIGuildStickerResult = void;
+export type RESTDeleteAPIGuildStickerResult = undefined;

--- a/rest/v10/user.ts
+++ b/rest/v10/user.ts
@@ -92,7 +92,7 @@ export type RESTGetAPICurrentUserGuildsResult = RESTAPIPartialCurrentUserGuild[]
 /**
  * @see {@link https://discord.com/developers/docs/resources/user#leave-guild}
  */
-export type RESTDeleteAPICurrentUserGuildResult = void;
+export type RESTDeleteAPICurrentUserGuildResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/user#create-dm}

--- a/rest/v10/user.ts
+++ b/rest/v10/user.ts
@@ -92,7 +92,7 @@ export type RESTGetAPICurrentUserGuildsResult = RESTAPIPartialCurrentUserGuild[]
 /**
  * @see {@link https://discord.com/developers/docs/resources/user#leave-guild}
  */
-export type RESTDeleteAPICurrentUserGuildResult = never;
+export type RESTDeleteAPICurrentUserGuildResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/user#create-dm}

--- a/rest/v10/voice.ts
+++ b/rest/v10/voice.ts
@@ -42,7 +42,7 @@ export interface RESTPatchAPIGuildVoiceStateCurrentMemberJSONBody {
 /**
  * @see {@link https://discord.com/developers/docs/resources/voice#modify-current-user-voice-state}
  */
-export type RESTPatchAPIGuildVoiceStateCurrentMemberResult = void;
+export type RESTPatchAPIGuildVoiceStateCurrentMemberResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/voice#modify-user-voice-state}
@@ -61,4 +61,4 @@ export interface RESTPatchAPIGuildVoiceStateUserJSONBody {
 /**
  * @see {@link https://discord.com/developers/docs/resources/voice#modify-user-voice-state}
  */
-export type RESTPatchAPIGuildVoiceStateUserResult = void;
+export type RESTPatchAPIGuildVoiceStateUserResult = undefined;

--- a/rest/v10/voice.ts
+++ b/rest/v10/voice.ts
@@ -42,7 +42,7 @@ export interface RESTPatchAPIGuildVoiceStateCurrentMemberJSONBody {
 /**
  * @see {@link https://discord.com/developers/docs/resources/voice#modify-current-user-voice-state}
  */
-export type RESTPatchAPIGuildVoiceStateCurrentMemberResult = never;
+export type RESTPatchAPIGuildVoiceStateCurrentMemberResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/voice#modify-user-voice-state}
@@ -61,4 +61,4 @@ export interface RESTPatchAPIGuildVoiceStateUserJSONBody {
 /**
  * @see {@link https://discord.com/developers/docs/resources/voice#modify-user-voice-state}
  */
-export type RESTPatchAPIGuildVoiceStateUserResult = never;
+export type RESTPatchAPIGuildVoiceStateUserResult = void;

--- a/rest/v10/webhook.ts
+++ b/rest/v10/webhook.ts
@@ -89,12 +89,12 @@ export type RESTPatchAPIWebhookWithTokenResult = RESTGetAPIWebhookWithTokenResul
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#delete-webhook}
  */
-export type RESTDeleteAPIWebhookResult = never;
+export type RESTDeleteAPIWebhookResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#delete-webhook-with-token}
  */
-export type RESTDeleteAPIWebhookWithTokenResult = never;
+export type RESTDeleteAPIWebhookWithTokenResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#execute-webhook}
@@ -201,7 +201,7 @@ export interface RESTPostAPIWebhookWithTokenQuery {
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#execute-webhook}
  */
-export type RESTPostAPIWebhookWithTokenResult = never;
+export type RESTPostAPIWebhookWithTokenResult = void;
 
 /**
  * Received when a call to https://discord.com/developers/docs/resources/webhook#execute-webhook receives
@@ -219,7 +219,7 @@ export type RESTPostAPIWebhookWithTokenSlackQuery = Pick<RESTPostAPIWebhookWithT
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#execute-slackcompatible-webhook}
  */
-export type RESTPostAPIWebhookWithTokenSlackResult = never;
+export type RESTPostAPIWebhookWithTokenSlackResult = void;
 
 /**
  * Received when a call to https://discord.com/developers/docs/resources/webhook#execute-webhook receives
@@ -237,7 +237,7 @@ export type RESTPostAPIWebhookWithTokenGitHubQuery = Pick<RESTPostAPIWebhookWith
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#execute-githubcompatible-webhook}
  */
-export type RESTPostAPIWebhookWithTokenGitHubResult = never;
+export type RESTPostAPIWebhookWithTokenGitHubResult = void;
 
 /**
  * Received when a call to https://discord.com/developers/docs/resources/webhook#execute-webhook receives
@@ -319,4 +319,4 @@ export interface RESTDeleteAPIWebhookWithTokenMessageQuery {
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#delete-webhook-message}
  */
-export type RESTDeleteAPIWebhookWithTokenMessageResult = never;
+export type RESTDeleteAPIWebhookWithTokenMessageResult = void;

--- a/rest/v10/webhook.ts
+++ b/rest/v10/webhook.ts
@@ -89,12 +89,12 @@ export type RESTPatchAPIWebhookWithTokenResult = RESTGetAPIWebhookWithTokenResul
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#delete-webhook}
  */
-export type RESTDeleteAPIWebhookResult = void;
+export type RESTDeleteAPIWebhookResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#delete-webhook-with-token}
  */
-export type RESTDeleteAPIWebhookWithTokenResult = void;
+export type RESTDeleteAPIWebhookWithTokenResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#execute-webhook}
@@ -201,7 +201,7 @@ export interface RESTPostAPIWebhookWithTokenQuery {
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#execute-webhook}
  */
-export type RESTPostAPIWebhookWithTokenResult = void;
+export type RESTPostAPIWebhookWithTokenResult = undefined;
 
 /**
  * Received when a call to https://discord.com/developers/docs/resources/webhook#execute-webhook receives
@@ -219,7 +219,7 @@ export type RESTPostAPIWebhookWithTokenSlackQuery = Pick<RESTPostAPIWebhookWithT
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#execute-slackcompatible-webhook}
  */
-export type RESTPostAPIWebhookWithTokenSlackResult = void;
+export type RESTPostAPIWebhookWithTokenSlackResult = undefined;
 
 /**
  * Received when a call to https://discord.com/developers/docs/resources/webhook#execute-webhook receives
@@ -237,7 +237,7 @@ export type RESTPostAPIWebhookWithTokenGitHubQuery = Pick<RESTPostAPIWebhookWith
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#execute-githubcompatible-webhook}
  */
-export type RESTPostAPIWebhookWithTokenGitHubResult = void;
+export type RESTPostAPIWebhookWithTokenGitHubResult = undefined;
 
 /**
  * Received when a call to https://discord.com/developers/docs/resources/webhook#execute-webhook receives
@@ -319,4 +319,4 @@ export interface RESTDeleteAPIWebhookWithTokenMessageQuery {
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#delete-webhook-message}
  */
-export type RESTDeleteAPIWebhookWithTokenMessageResult = void;
+export type RESTDeleteAPIWebhookWithTokenMessageResult = undefined;

--- a/rest/v9/autoModeration.ts
+++ b/rest/v9/autoModeration.ts
@@ -80,4 +80,4 @@ export type RESTPatchAPIAutoModerationRuleResult = APIAutoModerationRule;
 /**
  * @see {@link https://discord.com/developers/docs/resources/auto-moderation#delete-auto-moderation-rule}
  */
-export type RESTDeleteAPIAutoModerationRuleResult = void;
+export type RESTDeleteAPIAutoModerationRuleResult = undefined;

--- a/rest/v9/autoModeration.ts
+++ b/rest/v9/autoModeration.ts
@@ -80,4 +80,4 @@ export type RESTPatchAPIAutoModerationRuleResult = APIAutoModerationRule;
 /**
  * @see {@link https://discord.com/developers/docs/resources/auto-moderation#delete-auto-moderation-rule}
  */
-export type RESTDeleteAPIAutoModerationRuleResult = never;
+export type RESTDeleteAPIAutoModerationRuleResult = void;

--- a/rest/v9/channel.ts
+++ b/rest/v9/channel.ts
@@ -376,12 +376,12 @@ export type RESTPostAPIChannelMessageCrosspostResult = APIMessage;
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#create-reaction}
  */
-export type RESTPutAPIChannelMessageReactionResult = never;
+export type RESTPutAPIChannelMessageReactionResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#delete-own-reaction}
  */
-export type RESTDeleteAPIChannelMessageOwnReactionResult = never;
+export type RESTDeleteAPIChannelMessageOwnReactionResult = void;
 
 /**
  * @deprecated Use {@link RESTDeleteAPIChannelMessageOwnReactionResult} instead
@@ -391,7 +391,7 @@ export type RESTDeleteAPIChannelMessageOwnReaction = RESTDeleteAPIChannelMessage
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#delete-user-reaction}
  */
-export type RESTDeleteAPIChannelMessageUserReactionResult = never;
+export type RESTDeleteAPIChannelMessageUserReactionResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#get-reactions}
@@ -435,12 +435,12 @@ export type RESTGetAPIChannelMessageReactionUsersResult = APIUser[];
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#delete-all-reactions}
  */
-export type RESTDeleteAPIChannelAllMessageReactionsResult = never;
+export type RESTDeleteAPIChannelAllMessageReactionsResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#delete-all-reactions-for-emoji}
  */
-export type RESTDeleteAPIChannelMessageReactionResult = never;
+export type RESTDeleteAPIChannelMessageReactionResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#edit-message}
@@ -514,7 +514,7 @@ export type RESTPatchAPIChannelMessageResult = APIMessage;
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#delete-message}
  */
-export type RESTDeleteAPIChannelMessageResult = never;
+export type RESTDeleteAPIChannelMessageResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#bulk-delete-messages}
@@ -529,7 +529,7 @@ export interface RESTPostAPIChannelMessagesBulkDeleteJSONBody {
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#bulk-delete-messages}
  */
-export type RESTPostAPIChannelMessagesBulkDeleteResult = never;
+export type RESTPostAPIChannelMessagesBulkDeleteResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#edit-channel-permissions}
@@ -558,7 +558,7 @@ export interface RESTPutAPIChannelPermissionJSONBody {
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#edit-channel-permissions}
  */
-export type RESTPutAPIChannelPermissionResult = never;
+export type RESTPutAPIChannelPermissionResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#get-channel-invites}
@@ -646,7 +646,7 @@ export type RESTPostAPIChannelInviteResult = APIExtendedInvite;
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#delete-channel-permission}
  */
-export type RESTDeleteAPIChannelPermissionResult = never;
+export type RESTDeleteAPIChannelPermissionResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#follow-news-channel}
@@ -666,7 +666,7 @@ export type RESTPostAPIChannelFollowersResult = APIFollowedChannel;
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#trigger-typing-indicator}
  */
-export type RESTPostAPIChannelTypingResult = never;
+export type RESTPostAPIChannelTypingResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/message#get-channel-pins}
@@ -701,12 +701,12 @@ export interface RESTGetAPIChannelMessagesPinsResult {
 /**
  * @see {@link https://discord.com/developers/docs/resources/message#pin-message}
  */
-export type RESTPutAPIChannelMessagesPinResult = never;
+export type RESTPutAPIChannelMessagesPinResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/message#unpin-message}
  */
-export type RESTDeleteAPIChannelMessagesPinResult = never;
+export type RESTDeleteAPIChannelMessagesPinResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/message#get-pinned-messages-deprecated}
@@ -718,12 +718,12 @@ export type RESTGetAPIChannelPinsResult = APIMessage[];
  * @see {@link https://discord.com/developers/docs/resources/message#pin-message-deprecated}
  * @deprecated
  */
-export type RESTPutAPIChannelPinResult = never;
+export type RESTPutAPIChannelPinResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#unpin-message}
  */
-export type RESTDeleteAPIChannelPinResult = never;
+export type RESTDeleteAPIChannelPinResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#group-dm-add-recipient}
@@ -829,12 +829,12 @@ export type RESTPostAPIChannelThreadsResult =
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#join-thread}
  */
-export type RESTPutAPIChannelThreadMembersResult = never;
+export type RESTPutAPIChannelThreadMembersResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#leave-thread}
  */
-export type RESTDeleteAPIChannelThreadMembersResult = never;
+export type RESTDeleteAPIChannelThreadMembersResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#get-thread-member}

--- a/rest/v9/channel.ts
+++ b/rest/v9/channel.ts
@@ -376,12 +376,12 @@ export type RESTPostAPIChannelMessageCrosspostResult = APIMessage;
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#create-reaction}
  */
-export type RESTPutAPIChannelMessageReactionResult = void;
+export type RESTPutAPIChannelMessageReactionResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#delete-own-reaction}
  */
-export type RESTDeleteAPIChannelMessageOwnReactionResult = void;
+export type RESTDeleteAPIChannelMessageOwnReactionResult = undefined;
 
 /**
  * @deprecated Use {@link RESTDeleteAPIChannelMessageOwnReactionResult} instead
@@ -391,7 +391,7 @@ export type RESTDeleteAPIChannelMessageOwnReaction = RESTDeleteAPIChannelMessage
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#delete-user-reaction}
  */
-export type RESTDeleteAPIChannelMessageUserReactionResult = void;
+export type RESTDeleteAPIChannelMessageUserReactionResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#get-reactions}
@@ -435,12 +435,12 @@ export type RESTGetAPIChannelMessageReactionUsersResult = APIUser[];
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#delete-all-reactions}
  */
-export type RESTDeleteAPIChannelAllMessageReactionsResult = void;
+export type RESTDeleteAPIChannelAllMessageReactionsResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#delete-all-reactions-for-emoji}
  */
-export type RESTDeleteAPIChannelMessageReactionResult = void;
+export type RESTDeleteAPIChannelMessageReactionResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#edit-message}
@@ -514,7 +514,7 @@ export type RESTPatchAPIChannelMessageResult = APIMessage;
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#delete-message}
  */
-export type RESTDeleteAPIChannelMessageResult = void;
+export type RESTDeleteAPIChannelMessageResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#bulk-delete-messages}
@@ -529,7 +529,7 @@ export interface RESTPostAPIChannelMessagesBulkDeleteJSONBody {
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#bulk-delete-messages}
  */
-export type RESTPostAPIChannelMessagesBulkDeleteResult = void;
+export type RESTPostAPIChannelMessagesBulkDeleteResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#edit-channel-permissions}
@@ -558,7 +558,7 @@ export interface RESTPutAPIChannelPermissionJSONBody {
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#edit-channel-permissions}
  */
-export type RESTPutAPIChannelPermissionResult = void;
+export type RESTPutAPIChannelPermissionResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#get-channel-invites}
@@ -646,7 +646,7 @@ export type RESTPostAPIChannelInviteResult = APIExtendedInvite;
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#delete-channel-permission}
  */
-export type RESTDeleteAPIChannelPermissionResult = void;
+export type RESTDeleteAPIChannelPermissionResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#follow-news-channel}
@@ -666,7 +666,7 @@ export type RESTPostAPIChannelFollowersResult = APIFollowedChannel;
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#trigger-typing-indicator}
  */
-export type RESTPostAPIChannelTypingResult = void;
+export type RESTPostAPIChannelTypingResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/message#get-channel-pins}
@@ -701,12 +701,12 @@ export interface RESTGetAPIChannelMessagesPinsResult {
 /**
  * @see {@link https://discord.com/developers/docs/resources/message#pin-message}
  */
-export type RESTPutAPIChannelMessagesPinResult = void;
+export type RESTPutAPIChannelMessagesPinResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/message#unpin-message}
  */
-export type RESTDeleteAPIChannelMessagesPinResult = void;
+export type RESTDeleteAPIChannelMessagesPinResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/message#get-pinned-messages-deprecated}
@@ -718,12 +718,12 @@ export type RESTGetAPIChannelPinsResult = APIMessage[];
  * @see {@link https://discord.com/developers/docs/resources/message#pin-message-deprecated}
  * @deprecated
  */
-export type RESTPutAPIChannelPinResult = void;
+export type RESTPutAPIChannelPinResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#unpin-message}
  */
-export type RESTDeleteAPIChannelPinResult = void;
+export type RESTDeleteAPIChannelPinResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#group-dm-add-recipient}
@@ -829,12 +829,12 @@ export type RESTPostAPIChannelThreadsResult =
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#join-thread}
  */
-export type RESTPutAPIChannelThreadMembersResult = void;
+export type RESTPutAPIChannelThreadMembersResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#leave-thread}
  */
-export type RESTDeleteAPIChannelThreadMembersResult = void;
+export type RESTDeleteAPIChannelThreadMembersResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/channel#get-thread-member}

--- a/rest/v9/emoji.ts
+++ b/rest/v9/emoji.ts
@@ -58,7 +58,7 @@ export type RESTPatchAPIGuildEmojiResult = APIEmoji;
 /**
  * @see {@link https://discord.com/developers/docs/resources/emoji#delete-guild-emoji}
  */
-export type RESTDeleteAPIGuildEmojiResult = void;
+export type RESTDeleteAPIGuildEmojiResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/emoji#list-application-emojis}
@@ -95,4 +95,4 @@ export type RESTPatchAPIApplicationEmojiResult = APIApplicationEmoji;
 /**
  * @see {@link https://discord.com/developers/docs/resources/emoji#delete-application-emoji}
  */
-export type RESTDeleteAPIApplicationEmojiResult = void;
+export type RESTDeleteAPIApplicationEmojiResult = undefined;

--- a/rest/v9/emoji.ts
+++ b/rest/v9/emoji.ts
@@ -58,7 +58,7 @@ export type RESTPatchAPIGuildEmojiResult = APIEmoji;
 /**
  * @see {@link https://discord.com/developers/docs/resources/emoji#delete-guild-emoji}
  */
-export type RESTDeleteAPIGuildEmojiResult = never;
+export type RESTDeleteAPIGuildEmojiResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/emoji#list-application-emojis}
@@ -95,4 +95,4 @@ export type RESTPatchAPIApplicationEmojiResult = APIApplicationEmoji;
 /**
  * @see {@link https://discord.com/developers/docs/resources/emoji#delete-application-emoji}
  */
-export type RESTDeleteAPIApplicationEmojiResult = never;
+export type RESTDeleteAPIApplicationEmojiResult = void;

--- a/rest/v9/guild.ts
+++ b/rest/v9/guild.ts
@@ -360,7 +360,7 @@ export type RESTPatchAPIGuildResult = APIGuild;
  * @see {@link https://discord.com/developers/docs/change-log#guild-create-deprecation}
  * @deprecated
  */
-export type RESTDeleteAPIGuildResult = never;
+export type RESTDeleteAPIGuildResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#get-guild-channels}
@@ -402,7 +402,7 @@ export type RESTPatchAPIGuildChannelPositionsJSONBody = {
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#modify-guild-channel-positions}
  */
-export type RESTPatchAPIGuildChannelPositionsResult = never;
+export type RESTPatchAPIGuildChannelPositionsResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#list-active-guild-threads}
@@ -739,17 +739,17 @@ export type RESTPatchAPICurrentGuildMemberResult = APIGuildMember;
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#add-guild-member-role}
  */
-export type RESTPutAPIGuildMemberRoleResult = never;
+export type RESTPutAPIGuildMemberRoleResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#remove-guild-member-role}
  */
-export type RESTDeleteAPIGuildMemberRoleResult = never;
+export type RESTDeleteAPIGuildMemberRoleResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#remove-guild-member}
  */
-export type RESTDeleteAPIGuildMemberResult = never;
+export type RESTDeleteAPIGuildMemberResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#get-guild-bans}
@@ -806,12 +806,12 @@ export interface RESTPutAPIGuildBanJSONBody {
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#create-guild-ban}
  */
-export type RESTPutAPIGuildBanResult = never;
+export type RESTPutAPIGuildBanResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#remove-guild-ban}
  */
-export type RESTDeleteAPIGuildBanResult = never;
+export type RESTDeleteAPIGuildBanResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#bulk-guild-ban}
@@ -975,7 +975,7 @@ export type RESTPatchAPIGuildRoleResult = APIRole;
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#delete-guild-role}
  */
-export type RESTDeleteAPIGuildRoleResult = never;
+export type RESTDeleteAPIGuildRoleResult = void;
 
 /**
  * A record mapping role IDs to the number of members that have that role.
@@ -1060,7 +1060,7 @@ export type RESTGetAPIGuildIntegrationsResult = APIGuildIntegration[];
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#delete-guild-integration}
  */
-export type RESTDeleteAPIGuildIntegrationResult = never;
+export type RESTDeleteAPIGuildIntegrationResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#get-guild-widget-settings}

--- a/rest/v9/guild.ts
+++ b/rest/v9/guild.ts
@@ -360,7 +360,7 @@ export type RESTPatchAPIGuildResult = APIGuild;
  * @see {@link https://discord.com/developers/docs/change-log#guild-create-deprecation}
  * @deprecated
  */
-export type RESTDeleteAPIGuildResult = void;
+export type RESTDeleteAPIGuildResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#get-guild-channels}
@@ -402,7 +402,7 @@ export type RESTPatchAPIGuildChannelPositionsJSONBody = {
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#modify-guild-channel-positions}
  */
-export type RESTPatchAPIGuildChannelPositionsResult = void;
+export type RESTPatchAPIGuildChannelPositionsResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#list-active-guild-threads}
@@ -739,17 +739,17 @@ export type RESTPatchAPICurrentGuildMemberResult = APIGuildMember;
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#add-guild-member-role}
  */
-export type RESTPutAPIGuildMemberRoleResult = void;
+export type RESTPutAPIGuildMemberRoleResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#remove-guild-member-role}
  */
-export type RESTDeleteAPIGuildMemberRoleResult = void;
+export type RESTDeleteAPIGuildMemberRoleResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#remove-guild-member}
  */
-export type RESTDeleteAPIGuildMemberResult = void;
+export type RESTDeleteAPIGuildMemberResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#get-guild-bans}
@@ -806,12 +806,12 @@ export interface RESTPutAPIGuildBanJSONBody {
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#create-guild-ban}
  */
-export type RESTPutAPIGuildBanResult = void;
+export type RESTPutAPIGuildBanResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#remove-guild-ban}
  */
-export type RESTDeleteAPIGuildBanResult = void;
+export type RESTDeleteAPIGuildBanResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#bulk-guild-ban}
@@ -975,7 +975,7 @@ export type RESTPatchAPIGuildRoleResult = APIRole;
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#delete-guild-role}
  */
-export type RESTDeleteAPIGuildRoleResult = void;
+export type RESTDeleteAPIGuildRoleResult = undefined;
 
 /**
  * A record mapping role IDs to the number of members that have that role.
@@ -1060,7 +1060,7 @@ export type RESTGetAPIGuildIntegrationsResult = APIGuildIntegration[];
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#delete-guild-integration}
  */
-export type RESTDeleteAPIGuildIntegrationResult = void;
+export type RESTDeleteAPIGuildIntegrationResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild#get-guild-widget-settings}

--- a/rest/v9/guildScheduledEvent.ts
+++ b/rest/v9/guildScheduledEvent.ts
@@ -118,7 +118,7 @@ export type RESTPatchAPIGuildScheduledEventResult = APIGuildScheduledEvent;
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild-scheduled-event#delete-guild-scheduled-event}
  */
-export type RESTDeleteAPIGuildScheduledEventResult = void;
+export type RESTDeleteAPIGuildScheduledEventResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild-scheduled-event#get-guild-scheduled-event-users}

--- a/rest/v9/guildScheduledEvent.ts
+++ b/rest/v9/guildScheduledEvent.ts
@@ -118,7 +118,7 @@ export type RESTPatchAPIGuildScheduledEventResult = APIGuildScheduledEvent;
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild-scheduled-event#delete-guild-scheduled-event}
  */
-export type RESTDeleteAPIGuildScheduledEventResult = never;
+export type RESTDeleteAPIGuildScheduledEventResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/guild-scheduled-event#get-guild-scheduled-event-users}

--- a/rest/v9/interactions.ts
+++ b/rest/v9/interactions.ts
@@ -212,7 +212,7 @@ export type RESTPostAPIInteractionCallbackFormDataBody =
 /**
  * @see {@link https://discord.com/developers/docs/interactions/receiving-and-responding#create-interaction-response}
  */
-export type RESTPostAPIInteractionCallbackResult = void;
+export type RESTPostAPIInteractionCallbackResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-callback-interaction-callback-response-object}

--- a/rest/v9/interactions.ts
+++ b/rest/v9/interactions.ts
@@ -212,7 +212,7 @@ export type RESTPostAPIInteractionCallbackFormDataBody =
 /**
  * @see {@link https://discord.com/developers/docs/interactions/receiving-and-responding#create-interaction-response}
  */
-export type RESTPostAPIInteractionCallbackResult = never;
+export type RESTPostAPIInteractionCallbackResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-callback-interaction-callback-response-object}

--- a/rest/v9/monetization.ts
+++ b/rest/v9/monetization.ts
@@ -95,7 +95,7 @@ export enum EntitlementOwnerType {
 /**
  * @see {@link https://discord.com/developers/docs/resources/entitlement#delete-test-entitlement}
  */
-export type RESTDeleteAPIEntitlementResult = void;
+export type RESTDeleteAPIEntitlementResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/sku#list-skus}
@@ -105,7 +105,7 @@ export type RESTGetAPISKUsResult = APISKU[];
 /**
  * @see {@link https://discord.com/developers/docs/resources/entitlement#consume-an-entitlement}
  */
-export type RESTPostAPIEntitlementConsumeResult = void;
+export type RESTPostAPIEntitlementConsumeResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/subscription#query-string-params}

--- a/rest/v9/monetization.ts
+++ b/rest/v9/monetization.ts
@@ -95,7 +95,7 @@ export enum EntitlementOwnerType {
 /**
  * @see {@link https://discord.com/developers/docs/resources/entitlement#delete-test-entitlement}
  */
-export type RESTDeleteAPIEntitlementResult = never;
+export type RESTDeleteAPIEntitlementResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/sku#list-skus}
@@ -105,7 +105,7 @@ export type RESTGetAPISKUsResult = APISKU[];
 /**
  * @see {@link https://discord.com/developers/docs/resources/entitlement#consume-an-entitlement}
  */
-export type RESTPostAPIEntitlementConsumeResult = never;
+export type RESTPostAPIEntitlementConsumeResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/subscription#query-string-params}

--- a/rest/v9/oauth2.ts
+++ b/rest/v9/oauth2.ts
@@ -82,7 +82,7 @@ export type RESTPostOAuth2AccessTokenURLEncodedData = RESTOAuth2TokenOptionalCli
 
 export type RESTOAuth2TokenOptionalClientCredentials =
 	| { client_id: Snowflake; client_secret: string }
-	| { client_id?: never; client_secret?: never };
+	| { client_id?: void; client_secret?: void };
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-access-token-response}

--- a/rest/v9/oauth2.ts
+++ b/rest/v9/oauth2.ts
@@ -82,7 +82,7 @@ export type RESTPostOAuth2AccessTokenURLEncodedData = RESTOAuth2TokenOptionalCli
 
 export type RESTOAuth2TokenOptionalClientCredentials =
 	| { client_id: Snowflake; client_secret: string }
-	| { client_id?: undefined; client_secret?: undefined };
+	| { client_id?: never; client_secret?: never };
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-access-token-response}

--- a/rest/v9/oauth2.ts
+++ b/rest/v9/oauth2.ts
@@ -82,7 +82,7 @@ export type RESTPostOAuth2AccessTokenURLEncodedData = RESTOAuth2TokenOptionalCli
 
 export type RESTOAuth2TokenOptionalClientCredentials =
 	| { client_id: Snowflake; client_secret: string }
-	| { client_id?: void; client_secret?: void };
+	| { client_id?: undefined; client_secret?: undefined };
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-access-token-response}

--- a/rest/v9/soundboard.ts
+++ b/rest/v9/soundboard.ts
@@ -104,4 +104,4 @@ export type RESTPatchAPIGuildSoundboardSoundResult = APISoundboardSound;
 /**
  * @see {@link https://discord.com/developers/docs/resources/soundboard#delete-guild-soundboard-sound}
  */
-export type RESTDeleteAPIGuildSoundboardSoundResult = never;
+export type RESTDeleteAPIGuildSoundboardSoundResult = void;

--- a/rest/v9/soundboard.ts
+++ b/rest/v9/soundboard.ts
@@ -104,4 +104,4 @@ export type RESTPatchAPIGuildSoundboardSoundResult = APISoundboardSound;
 /**
  * @see {@link https://discord.com/developers/docs/resources/soundboard#delete-guild-soundboard-sound}
  */
-export type RESTDeleteAPIGuildSoundboardSoundResult = void;
+export type RESTDeleteAPIGuildSoundboardSoundResult = undefined;

--- a/rest/v9/soundboard.ts
+++ b/rest/v9/soundboard.ts
@@ -4,7 +4,7 @@ import type { APISoundboardSound } from '../../payloads/v9/index';
 /**
  * @see {@link https://discord.com/developers/docs/resources/soundboard#send-soundboard-sound}
  */
-export type RESTPostAPISendSoundboardSoundResult = never;
+export type RESTPostAPISendSoundboardSoundResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/soundboard#send-soundboard-sound-json-params}

--- a/rest/v9/stageInstance.ts
+++ b/rest/v9/stageInstance.ts
@@ -61,4 +61,4 @@ export type RESTPatchAPIStageInstanceResult = APIStageInstance;
 /**
  * @see {@link https://discord.com/developers/docs/resources/stage-instance#delete-stage-instance}
  */
-export type RESTDeleteAPIStageInstanceResult = void;
+export type RESTDeleteAPIStageInstanceResult = undefined;

--- a/rest/v9/stageInstance.ts
+++ b/rest/v9/stageInstance.ts
@@ -61,4 +61,4 @@ export type RESTPatchAPIStageInstanceResult = APIStageInstance;
 /**
  * @see {@link https://discord.com/developers/docs/resources/stage-instance#delete-stage-instance}
  */
-export type RESTDeleteAPIStageInstanceResult = never;
+export type RESTDeleteAPIStageInstanceResult = void;

--- a/rest/v9/sticker.ts
+++ b/rest/v9/sticker.ts
@@ -93,4 +93,4 @@ export type RESTPatchAPIGuildStickerResult = APISticker;
 /**
  * @see {@link https://discord.com/developers/docs/resources/sticker#delete-guild-sticker}
  */
-export type RESTDeleteAPIGuildStickerResult = never;
+export type RESTDeleteAPIGuildStickerResult = void;

--- a/rest/v9/sticker.ts
+++ b/rest/v9/sticker.ts
@@ -93,4 +93,4 @@ export type RESTPatchAPIGuildStickerResult = APISticker;
 /**
  * @see {@link https://discord.com/developers/docs/resources/sticker#delete-guild-sticker}
  */
-export type RESTDeleteAPIGuildStickerResult = void;
+export type RESTDeleteAPIGuildStickerResult = undefined;

--- a/rest/v9/user.ts
+++ b/rest/v9/user.ts
@@ -92,7 +92,7 @@ export type RESTGetAPICurrentUserGuildsResult = RESTAPIPartialCurrentUserGuild[]
 /**
  * @see {@link https://discord.com/developers/docs/resources/user#leave-guild}
  */
-export type RESTDeleteAPICurrentUserGuildResult = void;
+export type RESTDeleteAPICurrentUserGuildResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/user#create-dm}

--- a/rest/v9/user.ts
+++ b/rest/v9/user.ts
@@ -92,7 +92,7 @@ export type RESTGetAPICurrentUserGuildsResult = RESTAPIPartialCurrentUserGuild[]
 /**
  * @see {@link https://discord.com/developers/docs/resources/user#leave-guild}
  */
-export type RESTDeleteAPICurrentUserGuildResult = never;
+export type RESTDeleteAPICurrentUserGuildResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/user#create-dm}

--- a/rest/v9/voice.ts
+++ b/rest/v9/voice.ts
@@ -42,7 +42,7 @@ export interface RESTPatchAPIGuildVoiceStateCurrentMemberJSONBody {
 /**
  * @see {@link https://discord.com/developers/docs/resources/voice#modify-current-user-voice-state}
  */
-export type RESTPatchAPIGuildVoiceStateCurrentMemberResult = void;
+export type RESTPatchAPIGuildVoiceStateCurrentMemberResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/voice#modify-user-voice-state}
@@ -61,4 +61,4 @@ export interface RESTPatchAPIGuildVoiceStateUserJSONBody {
 /**
  * @see {@link https://discord.com/developers/docs/resources/voice#modify-user-voice-state}
  */
-export type RESTPatchAPIGuildVoiceStateUserResult = void;
+export type RESTPatchAPIGuildVoiceStateUserResult = undefined;

--- a/rest/v9/voice.ts
+++ b/rest/v9/voice.ts
@@ -42,7 +42,7 @@ export interface RESTPatchAPIGuildVoiceStateCurrentMemberJSONBody {
 /**
  * @see {@link https://discord.com/developers/docs/resources/voice#modify-current-user-voice-state}
  */
-export type RESTPatchAPIGuildVoiceStateCurrentMemberResult = never;
+export type RESTPatchAPIGuildVoiceStateCurrentMemberResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/voice#modify-user-voice-state}
@@ -61,4 +61,4 @@ export interface RESTPatchAPIGuildVoiceStateUserJSONBody {
 /**
  * @see {@link https://discord.com/developers/docs/resources/voice#modify-user-voice-state}
  */
-export type RESTPatchAPIGuildVoiceStateUserResult = never;
+export type RESTPatchAPIGuildVoiceStateUserResult = void;

--- a/rest/v9/webhook.ts
+++ b/rest/v9/webhook.ts
@@ -89,12 +89,12 @@ export type RESTPatchAPIWebhookWithTokenResult = RESTGetAPIWebhookWithTokenResul
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#delete-webhook}
  */
-export type RESTDeleteAPIWebhookResult = never;
+export type RESTDeleteAPIWebhookResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#delete-webhook-with-token}
  */
-export type RESTDeleteAPIWebhookWithTokenResult = never;
+export type RESTDeleteAPIWebhookWithTokenResult = void;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#execute-webhook}
@@ -201,7 +201,7 @@ export interface RESTPostAPIWebhookWithTokenQuery {
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#execute-webhook}
  */
-export type RESTPostAPIWebhookWithTokenResult = never;
+export type RESTPostAPIWebhookWithTokenResult = void;
 
 /**
  * Received when a call to https://discord.com/developers/docs/resources/webhook#execute-webhook receives
@@ -219,7 +219,7 @@ export type RESTPostAPIWebhookWithTokenSlackQuery = Pick<RESTPostAPIWebhookWithT
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#execute-slackcompatible-webhook}
  */
-export type RESTPostAPIWebhookWithTokenSlackResult = never;
+export type RESTPostAPIWebhookWithTokenSlackResult = void;
 
 /**
  * Received when a call to https://discord.com/developers/docs/resources/webhook#execute-webhook receives
@@ -237,7 +237,7 @@ export type RESTPostAPIWebhookWithTokenGitHubQuery = Pick<RESTPostAPIWebhookWith
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#execute-githubcompatible-webhook}
  */
-export type RESTPostAPIWebhookWithTokenGitHubResult = never;
+export type RESTPostAPIWebhookWithTokenGitHubResult = void;
 
 /**
  * Received when a call to https://discord.com/developers/docs/resources/webhook#execute-webhook receives
@@ -319,4 +319,4 @@ export interface RESTDeleteAPIWebhookWithTokenMessageQuery {
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#delete-webhook-message}
  */
-export type RESTDeleteAPIWebhookWithTokenMessageResult = never;
+export type RESTDeleteAPIWebhookWithTokenMessageResult = void;

--- a/rest/v9/webhook.ts
+++ b/rest/v9/webhook.ts
@@ -89,12 +89,12 @@ export type RESTPatchAPIWebhookWithTokenResult = RESTGetAPIWebhookWithTokenResul
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#delete-webhook}
  */
-export type RESTDeleteAPIWebhookResult = void;
+export type RESTDeleteAPIWebhookResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#delete-webhook-with-token}
  */
-export type RESTDeleteAPIWebhookWithTokenResult = void;
+export type RESTDeleteAPIWebhookWithTokenResult = undefined;
 
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#execute-webhook}
@@ -201,7 +201,7 @@ export interface RESTPostAPIWebhookWithTokenQuery {
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#execute-webhook}
  */
-export type RESTPostAPIWebhookWithTokenResult = void;
+export type RESTPostAPIWebhookWithTokenResult = undefined;
 
 /**
  * Received when a call to https://discord.com/developers/docs/resources/webhook#execute-webhook receives
@@ -219,7 +219,7 @@ export type RESTPostAPIWebhookWithTokenSlackQuery = Pick<RESTPostAPIWebhookWithT
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#execute-slackcompatible-webhook}
  */
-export type RESTPostAPIWebhookWithTokenSlackResult = void;
+export type RESTPostAPIWebhookWithTokenSlackResult = undefined;
 
 /**
  * Received when a call to https://discord.com/developers/docs/resources/webhook#execute-webhook receives
@@ -237,7 +237,7 @@ export type RESTPostAPIWebhookWithTokenGitHubQuery = Pick<RESTPostAPIWebhookWith
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#execute-githubcompatible-webhook}
  */
-export type RESTPostAPIWebhookWithTokenGitHubResult = void;
+export type RESTPostAPIWebhookWithTokenGitHubResult = undefined;
 
 /**
  * Received when a call to https://discord.com/developers/docs/resources/webhook#execute-webhook receives
@@ -319,4 +319,4 @@ export interface RESTDeleteAPIWebhookWithTokenMessageQuery {
 /**
  * @see {@link https://discord.com/developers/docs/resources/webhook#delete-webhook-message}
  */
-export type RESTDeleteAPIWebhookWithTokenMessageResult = void;
+export type RESTDeleteAPIWebhookWithTokenMessageResult = undefined;

--- a/rpc/v10.ts
+++ b/rpc/v10.ts
@@ -1233,42 +1233,42 @@ export enum RPCEvents {
 /**
  * @unstable
  */
-export type RPCSubscribeActivityInviteArgs = Record<string, void>;
+export type RPCSubscribeActivityInviteArgs = Record<string, undefined>;
 
-export type RPCSubscribeActivityJoinArgs = Record<string, void>;
+export type RPCSubscribeActivityJoinArgs = Record<string, undefined>;
 
-export type RPCSubscribeActivityJoinRequestArgs = Record<string, void>;
+export type RPCSubscribeActivityJoinRequestArgs = Record<string, undefined>;
 
-export type RPCSubscribeActivitySpectateArgs = Record<string, void>;
+export type RPCSubscribeActivitySpectateArgs = Record<string, undefined>;
 
-export type RPCSubscribeChannelCreateArgs = Record<string, void>;
-
-/**
- * @unstable
- */
-export type RPCSubscribeCurrentUserUpdateArgs = Record<string, void>;
+export type RPCSubscribeChannelCreateArgs = Record<string, undefined>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeEntitlementCreateArgs = Record<string, void>;
+export type RPCSubscribeCurrentUserUpdateArgs = Record<string, undefined>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeEntitlementDeleteArgs = Record<string, void>;
+export type RPCSubscribeEntitlementCreateArgs = Record<string, undefined>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeGameJoinArgs = Record<string, void>;
+export type RPCSubscribeEntitlementDeleteArgs = Record<string, undefined>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeGameSpectateArgs = Record<string, void>;
+export type RPCSubscribeGameJoinArgs = Record<string, undefined>;
 
-export type RPCSubscribeGuildCreateArgs = Record<string, void>;
+/**
+ * @unstable
+ */
+export type RPCSubscribeGameSpectateArgs = Record<string, undefined>;
+
+export type RPCSubscribeGuildCreateArgs = Record<string, undefined>;
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/rpc#guildstatus-guild-status-argument-structure}
@@ -1310,22 +1310,22 @@ export interface RPCSubscribeMessageUpdateArgs {
 	channel_id: Snowflake;
 }
 
-export type RPCSubscribeNotificationCreateArgs = Record<string, void>;
+export type RPCSubscribeNotificationCreateArgs = Record<string, undefined>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeOverlayArgs = Record<string, void>;
+export type RPCSubscribeOverlayArgs = Record<string, undefined>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeOverlayUpdateArgs = Record<string, void>;
+export type RPCSubscribeOverlayUpdateArgs = Record<string, undefined>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeRelationshipUpdateArgs = Record<string, void>;
+export type RPCSubscribeRelationshipUpdateArgs = Record<string, undefined>;
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/rpc#speakingstartspeakingstop-speaking-argument-structure}
@@ -1347,19 +1347,19 @@ export interface RPCSubscribeSpeakingStopArgs {
 	channel_id: Snowflake;
 }
 
-export type RPCSubscribeVoiceChannelSelectArgs = Record<string, void>;
+export type RPCSubscribeVoiceChannelSelectArgs = Record<string, undefined>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeVoiceConnectionStatusArgs = Record<string, void>;
+export type RPCSubscribeVoiceConnectionStatusArgs = Record<string, undefined>;
 
-export type RPCSubscribeVoiceSettingsUpdateArgs = Record<string, void>;
+export type RPCSubscribeVoiceSettingsUpdateArgs = Record<string, undefined>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeVoiceSettingsUpdate2Args = Record<string, void>;
+export type RPCSubscribeVoiceSettingsUpdate2Args = Record<string, undefined>;
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/rpc#voicestatecreatevoicestateupdatevoicestatedelete-voice-state-argument-structure}

--- a/rpc/v10.ts
+++ b/rpc/v10.ts
@@ -1233,42 +1233,42 @@ export enum RPCEvents {
 /**
  * @unstable
  */
-export type RPCSubscribeActivityInviteArgs = Record<string, never>;
+export type RPCSubscribeActivityInviteArgs = Record<string, void>;
 
-export type RPCSubscribeActivityJoinArgs = Record<string, never>;
+export type RPCSubscribeActivityJoinArgs = Record<string, void>;
 
-export type RPCSubscribeActivityJoinRequestArgs = Record<string, never>;
+export type RPCSubscribeActivityJoinRequestArgs = Record<string, void>;
 
-export type RPCSubscribeActivitySpectateArgs = Record<string, never>;
+export type RPCSubscribeActivitySpectateArgs = Record<string, void>;
 
-export type RPCSubscribeChannelCreateArgs = Record<string, never>;
-
-/**
- * @unstable
- */
-export type RPCSubscribeCurrentUserUpdateArgs = Record<string, never>;
+export type RPCSubscribeChannelCreateArgs = Record<string, void>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeEntitlementCreateArgs = Record<string, never>;
+export type RPCSubscribeCurrentUserUpdateArgs = Record<string, void>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeEntitlementDeleteArgs = Record<string, never>;
+export type RPCSubscribeEntitlementCreateArgs = Record<string, void>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeGameJoinArgs = Record<string, never>;
+export type RPCSubscribeEntitlementDeleteArgs = Record<string, void>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeGameSpectateArgs = Record<string, never>;
+export type RPCSubscribeGameJoinArgs = Record<string, void>;
 
-export type RPCSubscribeGuildCreateArgs = Record<string, never>;
+/**
+ * @unstable
+ */
+export type RPCSubscribeGameSpectateArgs = Record<string, void>;
+
+export type RPCSubscribeGuildCreateArgs = Record<string, void>;
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/rpc#guildstatus-guild-status-argument-structure}
@@ -1310,22 +1310,22 @@ export interface RPCSubscribeMessageUpdateArgs {
 	channel_id: Snowflake;
 }
 
-export type RPCSubscribeNotificationCreateArgs = Record<string, never>;
+export type RPCSubscribeNotificationCreateArgs = Record<string, void>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeOverlayArgs = Record<string, never>;
+export type RPCSubscribeOverlayArgs = Record<string, void>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeOverlayUpdateArgs = Record<string, never>;
+export type RPCSubscribeOverlayUpdateArgs = Record<string, void>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeRelationshipUpdateArgs = Record<string, never>;
+export type RPCSubscribeRelationshipUpdateArgs = Record<string, void>;
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/rpc#speakingstartspeakingstop-speaking-argument-structure}
@@ -1347,19 +1347,19 @@ export interface RPCSubscribeSpeakingStopArgs {
 	channel_id: Snowflake;
 }
 
-export type RPCSubscribeVoiceChannelSelectArgs = Record<string, never>;
+export type RPCSubscribeVoiceChannelSelectArgs = Record<string, void>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeVoiceConnectionStatusArgs = Record<string, never>;
+export type RPCSubscribeVoiceConnectionStatusArgs = Record<string, void>;
 
-export type RPCSubscribeVoiceSettingsUpdateArgs = Record<string, never>;
+export type RPCSubscribeVoiceSettingsUpdateArgs = Record<string, void>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeVoiceSettingsUpdate2Args = Record<string, never>;
+export type RPCSubscribeVoiceSettingsUpdate2Args = Record<string, void>;
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/rpc#voicestatecreatevoicestateupdatevoicestatedelete-voice-state-argument-structure}

--- a/rpc/v10.ts
+++ b/rpc/v10.ts
@@ -1233,42 +1233,42 @@ export enum RPCEvents {
 /**
  * @unstable
  */
-export type RPCSubscribeActivityInviteArgs = Record<string, undefined>;
+export type RPCSubscribeActivityInviteArgs = Record<string, unknown>;
 
-export type RPCSubscribeActivityJoinArgs = Record<string, undefined>;
+export type RPCSubscribeActivityJoinArgs = Record<string, unknown>;
 
-export type RPCSubscribeActivityJoinRequestArgs = Record<string, undefined>;
+export type RPCSubscribeActivityJoinRequestArgs = Record<string, unknown>;
 
-export type RPCSubscribeActivitySpectateArgs = Record<string, undefined>;
+export type RPCSubscribeActivitySpectateArgs = Record<string, unknown>;
 
-export type RPCSubscribeChannelCreateArgs = Record<string, undefined>;
-
-/**
- * @unstable
- */
-export type RPCSubscribeCurrentUserUpdateArgs = Record<string, undefined>;
+export type RPCSubscribeChannelCreateArgs = Record<string, unknown>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeEntitlementCreateArgs = Record<string, undefined>;
+export type RPCSubscribeCurrentUserUpdateArgs = Record<string, unknown>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeEntitlementDeleteArgs = Record<string, undefined>;
+export type RPCSubscribeEntitlementCreateArgs = Record<string, unknown>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeGameJoinArgs = Record<string, undefined>;
+export type RPCSubscribeEntitlementDeleteArgs = Record<string, unknown>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeGameSpectateArgs = Record<string, undefined>;
+export type RPCSubscribeGameJoinArgs = Record<string, unknown>;
 
-export type RPCSubscribeGuildCreateArgs = Record<string, undefined>;
+/**
+ * @unstable
+ */
+export type RPCSubscribeGameSpectateArgs = Record<string, unknown>;
+
+export type RPCSubscribeGuildCreateArgs = Record<string, unknown>;
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/rpc#guildstatus-guild-status-argument-structure}
@@ -1310,22 +1310,22 @@ export interface RPCSubscribeMessageUpdateArgs {
 	channel_id: Snowflake;
 }
 
-export type RPCSubscribeNotificationCreateArgs = Record<string, undefined>;
+export type RPCSubscribeNotificationCreateArgs = Record<string, unknown>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeOverlayArgs = Record<string, undefined>;
+export type RPCSubscribeOverlayArgs = Record<string, unknown>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeOverlayUpdateArgs = Record<string, undefined>;
+export type RPCSubscribeOverlayUpdateArgs = Record<string, unknown>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeRelationshipUpdateArgs = Record<string, undefined>;
+export type RPCSubscribeRelationshipUpdateArgs = Record<string, unknown>;
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/rpc#speakingstartspeakingstop-speaking-argument-structure}
@@ -1347,19 +1347,19 @@ export interface RPCSubscribeSpeakingStopArgs {
 	channel_id: Snowflake;
 }
 
-export type RPCSubscribeVoiceChannelSelectArgs = Record<string, undefined>;
+export type RPCSubscribeVoiceChannelSelectArgs = Record<string, unknown>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeVoiceConnectionStatusArgs = Record<string, undefined>;
+export type RPCSubscribeVoiceConnectionStatusArgs = Record<string, unknown>;
 
-export type RPCSubscribeVoiceSettingsUpdateArgs = Record<string, undefined>;
+export type RPCSubscribeVoiceSettingsUpdateArgs = Record<string, unknown>;
 
 /**
  * @unstable
  */
-export type RPCSubscribeVoiceSettingsUpdate2Args = Record<string, undefined>;
+export type RPCSubscribeVoiceSettingsUpdate2Args = Record<string, unknown>;
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/rpc#voicestatecreatevoicestateupdatevoicestatedelete-voice-state-argument-structure}

--- a/website/docs/Contributing.mdx
+++ b/website/docs/Contributing.mdx
@@ -179,8 +179,7 @@ They must also follow the following structure: `REST{http_method}{type_name}{Que
   - If a route doesn't take in any parameters, be it query, JSON or FormData, it shouldn't define any of those types
   - A route should always define a `Result` type, and should reference an `API*` type unless the data returned is only
     received through a REST call
-  - If a route returns a `204 No Content` response, it should define a `Result` type with `never` as its value (this
-    does not account for errors)
+  - If a route returns a `204 No Content` response, it should define a `Result` type with `void` as its value
 
 This structure should be followed whenever possible, however that might not always be doable. Specifically, types for
 OAuth2 may not follow the structure exactly, but should aim to follow it as much as possible.

--- a/website/docs/Contributing.mdx
+++ b/website/docs/Contributing.mdx
@@ -179,7 +179,7 @@ They must also follow the following structure: `REST{http_method}{type_name}{Que
   - If a route doesn't take in any parameters, be it query, JSON or FormData, it shouldn't define any of those types
   - A route should always define a `Result` type, and should reference an `API*` type unless the data returned is only
     received through a REST call
-  - If a route returns a `204 No Content` response, it should define a `Result` type with `void` as its value
+  - If a route returns a `204 No Content` response, it should define a `Result` type with `undefined` as its value
 
 This structure should be followed whenever possible, however that might not always be doable. Specifically, types for
 OAuth2 may not follow the structure exactly, but should aim to follow it as much as possible.

--- a/website/docs/Contributing.mdx
+++ b/website/docs/Contributing.mdx
@@ -179,7 +179,8 @@ They must also follow the following structure: `REST{http_method}{type_name}{Que
   - If a route doesn't take in any parameters, be it query, JSON or FormData, it shouldn't define any of those types
   - A route should always define a `Result` type, and should reference an `API*` type unless the data returned is only
     received through a REST call
-  - If a route returns a `204 No Content` response, it should define a `Result` type with `undefined` as its value
+  - If a route returns a `204 No Content` response, it should define a `Result` type with `undefined` as its value (this
+    does not account for errors)
 
 This structure should be followed whenever possible, however that might not always be doable. Specifically, types for
 OAuth2 may not follow the structure exactly, but should aim to follow it as much as possible.

--- a/website/docs/Introduction.mdx
+++ b/website/docs/Introduction.mdx
@@ -181,8 +181,7 @@ The exports of each API version is split into three main parts:
       the fields. They will start with either `RESTOAuth2` or with something similar to `REST<HTTP Method>OAuth2`
 
   - If a type ends with `Result`, then it represents the expected result by calling its accompanying route.
-    - Types that are exported as `never` usually mean the result will be a `204 No Content`, so you can safely ignore
-      it. This does **not** account for errors.
+    - Types for a Result that will be a `204 No Content` will be typed as `void`
 
 - Anything else that is miscellaneous will be exported based on what it represents (for example the `REST` route
   object).

--- a/website/docs/Introduction.mdx
+++ b/website/docs/Introduction.mdx
@@ -181,7 +181,7 @@ The exports of each API version is split into three main parts:
       the fields. They will start with either `RESTOAuth2` or with something similar to `REST<HTTP Method>OAuth2`
 
   - If a type ends with `Result`, then it represents the expected result by calling its accompanying route.
-    - Types for a Result that will be a `204 No Content` will be typed as `void`
+    - Types for a Result that will be a `204 No Content` will be typed as `undefined`
 
 - Anything else that is miscellaneous will be exported based on what it represents (for example the `REST` route
   object).

--- a/website/docs/Introduction.mdx
+++ b/website/docs/Introduction.mdx
@@ -181,7 +181,8 @@ The exports of each API version is split into three main parts:
       the fields. They will start with either `RESTOAuth2` or with something similar to `REST<HTTP Method>OAuth2`
 
   - If a type ends with `Result`, then it represents the expected result by calling its accompanying route.
-    - Types for a Result that will be a `204 No Content` will be typed as `undefined`
+    - Types for a Result that will be a `204 No Content` will be typed as `undefined`. This does **not** account for
+      errors
 
 - Anything else that is miscellaneous will be exported based on what it represents (for example the `REST` route
   object).


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
closes #1522

The majority of the usage of `never` in the project does not align with the semantics of the keyword and this PR replaces them with `void`. The keyword implies the value being typed as `never` cannot be observed under any conditions such as in the case of only throwing an exception or `process.exit()`, which is not true in cases of where these types would be used such as return types for routes that return an HTTP 204 which is an OK status code.
It's also used in some gateway payloads which is also technically incorrect as attempting to access the values at runtime would produce an observable `undefined`.

Some of the base types for gateway payloads that would have been modified would not work to be replaced as void, so those have been kept.
API v6-v8 also has not been modified as those had clear deprecation comments, but it was assumed that api v9 was still being maintained, so types from v9 have also been modified.

Some markdown mentioning the usage of never has also been modified.

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
N.A.