### PR TITLE
fix(APITeamMember): `permissions` is now missing

### DIFF
--- a/deno/payloads/v10/teams.ts
+++ b/deno/payloads/v10/teams.ts
@@ -44,9 +44,10 @@ export interface APITeamMember {
 	/**
 	 * Will always be `["*"]`
 	 *
+	 * @remarks At or before 2026-04-14, Discord stopped sending this field.
 	 * @deprecated Use {@link APITeamMember.role} instead.
 	 */
-	permissions: ['*'];
+	permissions?: ['*'] | undefined;
 	/**
 	 * The id of the parent team of which they are a member
 	 */

--- a/deno/payloads/v9/teams.ts
+++ b/deno/payloads/v9/teams.ts
@@ -44,9 +44,10 @@ export interface APITeamMember {
 	/**
 	 * Will always be `["*"]`
 	 *
+	 * @remarks At or before 2026-04-14, Discord stopped sending this field.
 	 * @deprecated Use {@link APITeamMember.role} instead.
 	 */
-	permissions: ['*'];
+	permissions?: ['*'] | undefined;
 	/**
 	 * The id of the parent team of which they are a member
 	 */

--- a/payloads/v10/teams.ts
+++ b/payloads/v10/teams.ts
@@ -44,9 +44,10 @@ export interface APITeamMember {
 	/**
 	 * Will always be `["*"]`
 	 *
+	 * @remarks At or before 2026-04-14, Discord stopped sending this field.
 	 * @deprecated Use {@link APITeamMember.role} instead.
 	 */
-	permissions: ['*'];
+	permissions?: ['*'] | undefined;
 	/**
 	 * The id of the parent team of which they are a member
 	 */

--- a/payloads/v9/teams.ts
+++ b/payloads/v9/teams.ts
@@ -44,9 +44,10 @@ export interface APITeamMember {
 	/**
 	 * Will always be `["*"]`
 	 *
+	 * @remarks At or before 2026-04-14, Discord stopped sending this field.
 	 * @deprecated Use {@link APITeamMember.role} instead.
 	 */
-	permissions: ['*'];
+	permissions?: ['*'] | undefined;
 	/**
 	 * The id of the parent team of which they are a member
 	 */


### PR DESCRIPTION
At or before 2026-04-14, Discord stopped sending this field.

I have not opted to remove the field, but would be open to it since this is supposed to mirror the Discord API.