### PR TITLE
feat(RESTJSONErrorCodes): add `CannotForwardMessageWithUnreadableContent`

### DIFF
--- a/deno/rest/common.ts
+++ b/deno/rest/common.ts
@@ -301,6 +301,8 @@ export enum RESTJSONErrorCodes {
 	MaximumActiveThreads,
 	MaximumActiveAnnouncementThreads,
 
+	CannotForwardMessageWithUnreadableContent = 160_014,
+
 	InvalidJSONForUploadedLottieFile = 170_001,
 	UploadedLottiesCannotContainRasterizedImages,
 	StickerMaximumFramerateExceeded,

--- a/rest/common.ts
+++ b/rest/common.ts
@@ -301,6 +301,8 @@ export enum RESTJSONErrorCodes {
 	MaximumActiveThreads,
 	MaximumActiveAnnouncementThreads,
 
+	CannotForwardMessageWithUnreadableContent = 160_014,
+
 	InvalidJSONForUploadedLottieFile = 170_001,
 	UploadedLottiesCannotContainRasterizedImages,
 	StickerMaximumFramerateExceeded,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
- https://github.com/discord/discord-api-docs/pull/8295