### PR TITLE
refactor(RESTJSONErrorCodes): rename `ServerSendRateLimit` to `ServerWriteRateLimit`

### DIFF
--- a/deno/rest/common.ts
+++ b/deno/rest/common.ts
@@ -80,7 +80,11 @@ export enum RESTJSONErrorCodes {
 	 * @deprecated Use {@link RESTJSONErrorCodes.ChannelWriteRateLimit} instead
 	 */
 	ChannelSendRateLimit = ChannelWriteRateLimit,
-	ServerSendRateLimit = 20_029,
+	ServerWriteRateLimit = 20_029,
+	/**
+	 * @deprecated Use {@link RESTJSONErrorCodes.ServerWriteRateLimit} instead
+	 */
+	ServerSendRateLimit = ServerWriteRateLimit,
 
 	StageTopicServerNameServerDescriptionOrChannelNamesContainDisallowedWords = 20_031,
 

--- a/rest/common.ts
+++ b/rest/common.ts
@@ -80,7 +80,11 @@ export enum RESTJSONErrorCodes {
 	 * @deprecated Use {@link RESTJSONErrorCodes.ChannelWriteRateLimit} instead
 	 */
 	ChannelSendRateLimit = ChannelWriteRateLimit,
-	ServerSendRateLimit = 20_029,
+	ServerWriteRateLimit = 20_029,
+	/**
+	 * @deprecated Use {@link RESTJSONErrorCodes.ServerWriteRateLimit} instead
+	 */
+	ServerSendRateLimit = ServerWriteRateLimit,
 
 	StageTopicServerNameServerDescriptionOrChannelNamesContainDisallowedWords = 20_031,
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The error message for JSON error code `20029` is "The write action you are performing on the server has hit the write rate limit" so I think it is more appropriate to rename it to `ServerWriteRateLimit` similar to https://github.com/discordjs/discord-api-types/pull/1627

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
- https://docs.discord.com/developers/topics/opcodes-and-status-codes#json