### PR TITLE
feat(OAuth2Scopes): add `IdentifyPremium` scope

### DIFF
--- a/deno/payloads/v10/oauth2.ts
+++ b/deno/payloads/v10/oauth2.ts
@@ -31,6 +31,13 @@ export enum OAuth2Scopes {
 	 */
 	Identify = 'identify',
 	/**
+	 * Allows your app to read a user's Nitro subscription type as defined by `premium_type` on the
+	 * {@link https://docs.discord.com/developers/resources/user#user-object-user-structure | User object} - only available to approved partners
+	 *
+	 * @see {@link https://docs.discord.com/developers/resources/user#user-object-user-structure}
+	 */
+	IdentifyPremium = 'identify.premium',
+	/**
 	 * Allows {@link https://discord.com/developers/docs/resources/user#get-current-user-guilds | `/users/@me/guilds`}
 	 * to return basic information about all of a user's guilds
 	 *

--- a/deno/payloads/v10/user.ts
+++ b/deno/payloads/v10/user.ts
@@ -74,6 +74,7 @@ export interface APIUser {
 	/**
 	 * The type of Nitro subscription on a user's account
 	 *
+	 * @remarks This field will return `0` for applications that have not been approved for the {@link OAuth2Scopes.IdentifyPremium} scope.
 	 * @see {@link https://discord.com/developers/docs/resources/user#user-object-premium-types}
 	 */
 	premium_type?: UserPremiumType;

--- a/deno/payloads/v9/oauth2.ts
+++ b/deno/payloads/v9/oauth2.ts
@@ -31,6 +31,13 @@ export enum OAuth2Scopes {
 	 */
 	Identify = 'identify',
 	/**
+	 * Allows your app to read a user's Nitro subscription type as defined by `premium_type` on the
+	 * {@link https://docs.discord.com/developers/resources/user#user-object-user-structure | User object} - only available to approved partners
+	 *
+	 * @see {@link https://docs.discord.com/developers/resources/user#user-object-user-structure}
+	 */
+	IdentifyPremium = 'identify.premium',
+	/**
 	 * Allows {@link https://discord.com/developers/docs/resources/user#get-current-user-guilds | `/users/@me/guilds`}
 	 * to return basic information about all of a user's guilds
 	 *

--- a/deno/payloads/v9/user.ts
+++ b/deno/payloads/v9/user.ts
@@ -74,6 +74,7 @@ export interface APIUser {
 	/**
 	 * The type of Nitro subscription on a user's account
 	 *
+	 * @remarks This field will return `0` for applications that have not been approved for the {@link OAuth2Scopes.IdentifyPremium} scope.
 	 * @see {@link https://discord.com/developers/docs/resources/user#user-object-premium-types}
 	 */
 	premium_type?: UserPremiumType;

--- a/payloads/v10/oauth2.ts
+++ b/payloads/v10/oauth2.ts
@@ -31,6 +31,13 @@ export enum OAuth2Scopes {
 	 */
 	Identify = 'identify',
 	/**
+	 * Allows your app to read a user's Nitro subscription type as defined by `premium_type` on the
+	 * {@link https://docs.discord.com/developers/resources/user#user-object-user-structure | User object} - only available to approved partners
+	 *
+	 * @see {@link https://docs.discord.com/developers/resources/user#user-object-user-structure}
+	 */
+	IdentifyPremium = 'identify.premium',
+	/**
 	 * Allows {@link https://discord.com/developers/docs/resources/user#get-current-user-guilds | `/users/@me/guilds`}
 	 * to return basic information about all of a user's guilds
 	 *

--- a/payloads/v10/user.ts
+++ b/payloads/v10/user.ts
@@ -74,6 +74,7 @@ export interface APIUser {
 	/**
 	 * The type of Nitro subscription on a user's account
 	 *
+	 * @remarks This field will return `0` for applications that have not been approved for the {@link OAuth2Scopes.IdentifyPremium} scope.
 	 * @see {@link https://discord.com/developers/docs/resources/user#user-object-premium-types}
 	 */
 	premium_type?: UserPremiumType;

--- a/payloads/v9/oauth2.ts
+++ b/payloads/v9/oauth2.ts
@@ -31,6 +31,13 @@ export enum OAuth2Scopes {
 	 */
 	Identify = 'identify',
 	/**
+	 * Allows your app to read a user's Nitro subscription type as defined by `premium_type` on the
+	 * {@link https://docs.discord.com/developers/resources/user#user-object-user-structure | User object} - only available to approved partners
+	 *
+	 * @see {@link https://docs.discord.com/developers/resources/user#user-object-user-structure}
+	 */
+	IdentifyPremium = 'identify.premium',
+	/**
 	 * Allows {@link https://discord.com/developers/docs/resources/user#get-current-user-guilds | `/users/@me/guilds`}
 	 * to return basic information about all of a user's guilds
 	 *

--- a/payloads/v9/user.ts
+++ b/payloads/v9/user.ts
@@ -74,6 +74,7 @@ export interface APIUser {
 	/**
 	 * The type of Nitro subscription on a user's account
 	 *
+	 * @remarks This field will return `0` for applications that have not been approved for the {@link OAuth2Scopes.IdentifyPremium} scope.
 	 * @see {@link https://discord.com/developers/docs/resources/user#user-object-premium-types}
 	 */
 	premium_type?: UserPremiumType;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Add `identify.premium` OAuth2 Scope

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
- https://github.com/discord/discord-api-docs/pull/8340