### PR TITLE
feat(Routes): add `DELETE` method for `userApplicationRoleConnection()`

### DIFF
--- a/deno/rest/v10/mod.ts
+++ b/deno/rest/v10/mod.ts
@@ -598,8 +598,9 @@ export const Routes = {
 
 	/**
 	 * Route for:
-	 * - GET `/users/@me/applications/{application.id}/role-connection`
-	 * - PUT `/users/@me/applications/{application.id}/role-connection`
+	 * - GET    `/users/@me/applications/{application.id}/role-connection`
+	 * - PUT    `/users/@me/applications/{application.id}/role-connection`
+	 * - DELETE `/users/@me/applications/{application.id}/role-connection`
 	 */
 	userApplicationRoleConnection(applicationId: Snowflake) {
 		return `/users/@me/applications/${applicationId}/role-connection` as const;

--- a/deno/rest/v10/user.ts
+++ b/deno/rest/v10/user.ts
@@ -141,3 +141,8 @@ export interface RESTPutAPICurrentUserApplicationRoleConnectionJSONBody {
  * @see {@link https://discord.com/developers/docs/resources/user#update-user-application-role-connection}
  */
 export type RESTPutAPICurrentUserApplicationRoleConnectionResult = APIApplicationRoleConnection;
+
+/**
+ * @see {@link https://docs.discord.com/developers/resources/user#delete-current-user-application-role-connection}
+ */
+export type RESTDeleteAPICurrentUserApplicationRoleConnectionResult = undefined;

--- a/deno/rest/v9/mod.ts
+++ b/deno/rest/v9/mod.ts
@@ -607,8 +607,9 @@ export const Routes = {
 
 	/**
 	 * Route for:
-	 * - GET `/users/@me/applications/{application.id}/role-connection`
-	 * - PUT `/users/@me/applications/{application.id}/role-connection`
+	 * - GET    `/users/@me/applications/{application.id}/role-connection`
+	 * - PUT    `/users/@me/applications/{application.id}/role-connection`
+	 * - DELETE `/users/@me/applications/{application.id}/role-connection`
 	 */
 	userApplicationRoleConnection(applicationId: Snowflake) {
 		return `/users/@me/applications/${applicationId}/role-connection` as const;

--- a/deno/rest/v9/user.ts
+++ b/deno/rest/v9/user.ts
@@ -141,3 +141,8 @@ export interface RESTPutAPICurrentUserApplicationRoleConnectionJSONBody {
  * @see {@link https://discord.com/developers/docs/resources/user#update-user-application-role-connection}
  */
 export type RESTPutAPICurrentUserApplicationRoleConnectionResult = APIApplicationRoleConnection;
+
+/**
+ * @see {@link https://docs.discord.com/developers/resources/user#delete-current-user-application-role-connection}
+ */
+export type RESTDeleteAPICurrentUserApplicationRoleConnectionResult = undefined;

--- a/rest/v10/index.ts
+++ b/rest/v10/index.ts
@@ -598,8 +598,9 @@ export const Routes = {
 
 	/**
 	 * Route for:
-	 * - GET `/users/@me/applications/{application.id}/role-connection`
-	 * - PUT `/users/@me/applications/{application.id}/role-connection`
+	 * - GET    `/users/@me/applications/{application.id}/role-connection`
+	 * - PUT    `/users/@me/applications/{application.id}/role-connection`
+	 * - DELETE `/users/@me/applications/{application.id}/role-connection`
 	 */
 	userApplicationRoleConnection(applicationId: Snowflake) {
 		return `/users/@me/applications/${applicationId}/role-connection` as const;

--- a/rest/v10/user.ts
+++ b/rest/v10/user.ts
@@ -141,3 +141,8 @@ export interface RESTPutAPICurrentUserApplicationRoleConnectionJSONBody {
  * @see {@link https://discord.com/developers/docs/resources/user#update-user-application-role-connection}
  */
 export type RESTPutAPICurrentUserApplicationRoleConnectionResult = APIApplicationRoleConnection;
+
+/**
+ * @see {@link https://docs.discord.com/developers/resources/user#delete-current-user-application-role-connection}
+ */
+export type RESTDeleteAPICurrentUserApplicationRoleConnectionResult = undefined;

--- a/rest/v9/index.ts
+++ b/rest/v9/index.ts
@@ -607,8 +607,9 @@ export const Routes = {
 
 	/**
 	 * Route for:
-	 * - GET `/users/@me/applications/{application.id}/role-connection`
-	 * - PUT `/users/@me/applications/{application.id}/role-connection`
+	 * - GET    `/users/@me/applications/{application.id}/role-connection`
+	 * - PUT    `/users/@me/applications/{application.id}/role-connection`
+	 * - DELETE `/users/@me/applications/{application.id}/role-connection`
 	 */
 	userApplicationRoleConnection(applicationId: Snowflake) {
 		return `/users/@me/applications/${applicationId}/role-connection` as const;

--- a/rest/v9/user.ts
+++ b/rest/v9/user.ts
@@ -141,3 +141,8 @@ export interface RESTPutAPICurrentUserApplicationRoleConnectionJSONBody {
  * @see {@link https://discord.com/developers/docs/resources/user#update-user-application-role-connection}
  */
 export type RESTPutAPICurrentUserApplicationRoleConnectionResult = APIApplicationRoleConnection;
+
+/**
+ * @see {@link https://docs.discord.com/developers/resources/user#delete-current-user-application-role-connection}
+ */
+export type RESTDeleteAPICurrentUserApplicationRoleConnectionResult = undefined;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Add documentation for deleting user application role connection using `userApplicationRoleConnection()` route.

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
- https://github.com/discord/discord-api-docs/pull/8348