### PR TITLE
docs(v8): fix broken template resource links (#1533)

### DIFF
--- a/deno/payloads/v8/template.ts
+++ b/deno/payloads/v8/template.ts
@@ -1,5 +1,5 @@
 /**
- * Types extracted from https://discord.com/developers/docs/resources/template
+ * Types extracted from https://discord.com/developers/docs/resources/guild-template
  */
 
 import type { Snowflake } from '../../globals.ts';
@@ -7,7 +7,7 @@ import type { RESTPostAPIGuildsJSONBody } from '../../rest/v8/mod.ts';
 import type { APIUser } from './user.ts';
 
 /**
- * https://discord.com/developers/docs/resources/template#template-object
+ * https://discord.com/developers/docs/resources/guild-template#guild-template-object
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */

--- a/deno/rest/v8/template.ts
+++ b/deno/rest/v8/template.ts
@@ -2,14 +2,14 @@ import type { APIGuild, APITemplate } from '../../payloads/v8/mod.ts';
 import type { _StrictPartial } from '../../utils/internals.ts';
 
 /**
- * https://discord.com/developers/docs/resources/template#get-template
+ * https://discord.com/developers/docs/resources/guild-template#get-guild-template
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
 export type RESTGetAPITemplateResult = APITemplate;
 
 /**
- * https://discord.com/developers/docs/resources/template#create-guild-from-template
+ * https://discord.com/developers/docs/change-log#guild-create-deprecation
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
@@ -27,21 +27,21 @@ export interface RESTPostAPITemplateCreateGuildJSONBody {
 }
 
 /**
- * https://discord.com/developers/docs/resources/template#create-guild-from-template
+ * https://discord.com/developers/docs/change-log#guild-create-deprecation
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
 export type RESTPostAPITemplateCreateGuildResult = APIGuild;
 
 /**
- * https://discord.com/developers/docs/resources/template#get-guild-templates
+ * https://discord.com/developers/docs/resources/guild-template#get-guild-templates
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
 export type RESTGetAPIGuildTemplatesResult = APITemplate[];
 
 /**
- * https://discord.com/developers/docs/resources/template#create-guild-template
+ * https://discord.com/developers/docs/resources/guild-template#create-guild-template
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
@@ -57,35 +57,35 @@ export interface RESTPostAPIGuildTemplatesJSONBody {
 }
 
 /**
- * https://discord.com/developers/docs/resources/template#create-guild-template
+ * https://discord.com/developers/docs/resources/guild-template#create-guild-template
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
 export type RESTPostAPIGuildTemplatesResult = APITemplate;
 
 /**
- * https://discord.com/developers/docs/resources/template#sync-guild-template
+ * https://discord.com/developers/docs/resources/guild-template#sync-guild-template
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
 export type RESTPutAPIGuildTemplateSyncResult = APITemplate;
 
 /**
- * https://discord.com/developers/docs/resources/template#modify-guild-template
+ * https://discord.com/developers/docs/resources/guild-template#modify-guild-template
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
 export type RESTPatchAPIGuildTemplateJSONBody = _StrictPartial<RESTPostAPIGuildTemplatesJSONBody>;
 
 /**
- * https://discord.com/developers/docs/resources/template#modify-guild-template
+ * https://discord.com/developers/docs/resources/guild-template#modify-guild-template
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
 export type RESTPatchAPIGuildTemplateResult = APITemplate;
 
 /**
- * https://discord.com/developers/docs/resources/template#delete-guild-template
+ * https://discord.com/developers/docs/resources/guild-template#delete-guild-template
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */

--- a/payloads/v8/template.ts
+++ b/payloads/v8/template.ts
@@ -1,5 +1,5 @@
 /**
- * Types extracted from https://discord.com/developers/docs/resources/template
+ * Types extracted from https://discord.com/developers/docs/resources/guild-template
  */
 
 import type { Snowflake } from '../../globals';
@@ -7,7 +7,7 @@ import type { RESTPostAPIGuildsJSONBody } from '../../rest/v8/index';
 import type { APIUser } from './user';
 
 /**
- * https://discord.com/developers/docs/resources/template#template-object
+ * https://discord.com/developers/docs/resources/guild-template#guild-template-object
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */

--- a/rest/v8/template.ts
+++ b/rest/v8/template.ts
@@ -2,14 +2,14 @@ import type { APIGuild, APITemplate } from '../../payloads/v8/index';
 import type { _StrictPartial } from '../../utils/internals';
 
 /**
- * https://discord.com/developers/docs/resources/template#get-template
+ * https://discord.com/developers/docs/resources/guild-template#get-guild-template
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
 export type RESTGetAPITemplateResult = APITemplate;
 
 /**
- * https://discord.com/developers/docs/resources/template#create-guild-from-template
+ * https://discord.com/developers/docs/change-log#guild-create-deprecation
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
@@ -27,21 +27,21 @@ export interface RESTPostAPITemplateCreateGuildJSONBody {
 }
 
 /**
- * https://discord.com/developers/docs/resources/template#create-guild-from-template
+ * https://discord.com/developers/docs/change-log#guild-create-deprecation
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
 export type RESTPostAPITemplateCreateGuildResult = APIGuild;
 
 /**
- * https://discord.com/developers/docs/resources/template#get-guild-templates
+ * https://discord.com/developers/docs/resources/guild-template#get-guild-templates
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
 export type RESTGetAPIGuildTemplatesResult = APITemplate[];
 
 /**
- * https://discord.com/developers/docs/resources/template#create-guild-template
+ * https://discord.com/developers/docs/resources/guild-template#create-guild-template
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
@@ -57,35 +57,35 @@ export interface RESTPostAPIGuildTemplatesJSONBody {
 }
 
 /**
- * https://discord.com/developers/docs/resources/template#create-guild-template
+ * https://discord.com/developers/docs/resources/guild-template#create-guild-template
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
 export type RESTPostAPIGuildTemplatesResult = APITemplate;
 
 /**
- * https://discord.com/developers/docs/resources/template#sync-guild-template
+ * https://discord.com/developers/docs/resources/guild-template#sync-guild-template
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
 export type RESTPutAPIGuildTemplateSyncResult = APITemplate;
 
 /**
- * https://discord.com/developers/docs/resources/template#modify-guild-template
+ * https://discord.com/developers/docs/resources/guild-template#modify-guild-template
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
 export type RESTPatchAPIGuildTemplateJSONBody = _StrictPartial<RESTPostAPIGuildTemplatesJSONBody>;
 
 /**
- * https://discord.com/developers/docs/resources/template#modify-guild-template
+ * https://discord.com/developers/docs/resources/guild-template#modify-guild-template
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */
 export type RESTPatchAPIGuildTemplateResult = APITemplate;
 
 /**
- * https://discord.com/developers/docs/resources/template#delete-guild-template
+ * https://discord.com/developers/docs/resources/guild-template#delete-guild-template
  *
  * @deprecated API and gateway v8 are deprecated and the types will not receive further updates, please update to v10.
  */


### PR DESCRIPTION
## Please describe the changes this PR makes and why it should be merged

Part of #1533. Discord's documentation domain migration removed the `/developers/docs/resources/template` page. The old links now `301`-redirect to a URL that returns **404**, so every `@see` link in the v8 `template` typings is dead.

This points the v8 `template` typings at the current documentation, matching the convention already used by the v9/v10 typings in this repo:

| Old (404) | New (200) |
| --- | --- |
| `resources/template#get-template` | `resources/guild-template#get-guild-template` |
| `resources/template#template-object` | `resources/guild-template#guild-template-object` |
| `resources/template#get-guild-templates` | `resources/guild-template#get-guild-templates` |
| `resources/template#create-guild-template` | `resources/guild-template#create-guild-template` |
| `resources/template#sync-guild-template` | `resources/guild-template#sync-guild-template` |
| `resources/template#modify-guild-template` | `resources/guild-template#modify-guild-template` |
| `resources/template#delete-guild-template` | `resources/guild-template#delete-guild-template` |
| `resources/template#create-guild-from-template` | `change-log#guild-create-deprecation` |

The `create-guild-from-template` endpoint no longer has a documentation anchor (it was deprecated), so those two references now point to the change-log deprecation entry, exactly as the v9/v10 `RESTPostAPITemplateCreateGuild*` types already do.

Generated `deno/` copies are kept in sync.

## Status and versioning classification

- [x] I know how to update typings and have done so, or typings don't need updating
- Code change (typings/docs only; comment-only, no runtime or type-shape changes)

## Validation

- `yarn prettier --check` on all four touched files: passes
- `yarn build:ci` (`tsc --noEmit`): passes
- Each new URL verified to return HTTP `200` (old ones return `404` after the redirect)