### PR TITLE
feat: support `None` enum value for flags

### DIFF
--- a/deno/payloads/v10/application.ts
+++ b/deno/payloads/v10/application.ts
@@ -178,9 +178,6 @@ export type APIApplicationIntegrationTypesConfigMap = {
  * @see {@link https://discord.com/developers/docs/resources/application#application-object-application-flags}
  */
 export enum ApplicationFlags {
-	/**
-	 * No application flags are set
-	 */
 	None = 0,
 	/**
 	 * @unstable This application flag is currently not documented by Discord but has a known value which we will try to keep up to date.

--- a/deno/payloads/v10/application.ts
+++ b/deno/payloads/v10/application.ts
@@ -179,6 +179,10 @@ export type APIApplicationIntegrationTypesConfigMap = {
  */
 export enum ApplicationFlags {
 	/**
+	 * No application flags are set
+	 */
+	None = 0,
+	/**
 	 * @unstable This application flag is currently not documented by Discord but has a known value which we will try to keep up to date.
 	 */
 	EmbeddedReleased = 1 << 1,

--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -656,9 +656,6 @@ export interface APIThreadMember {
 }
 
 export enum ThreadMemberFlags {
-	/**
-	 * No thread member flags are set
-	 */
 	None = 0,
 	/**
 	 * @unstable This thread member flag is currently not documented by Discord but has a known value which we will try to keep up to date.
@@ -693,9 +690,6 @@ export interface APIThreadList {
  * @see {@link https://discord.com/developers/docs/resources/channel#channel-object-channel-flags}
  */
 export enum ChannelFlags {
-	/**
-	 * No channel flags are set
-	 */
 	None = 0,
 	/**
 	 * @unstable This channel flag is currently not documented by Discord but has a known value which we will try to keep up to date.

--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -657,6 +657,10 @@ export interface APIThreadMember {
 
 export enum ThreadMemberFlags {
 	/**
+	 * No thread member flags are set
+	 */
+	None = 0,
+	/**
 	 * @unstable This thread member flag is currently not documented by Discord but has a known value which we will try to keep up to date.
 	 */
 	HasInteracted = 1 << 0,
@@ -689,6 +693,10 @@ export interface APIThreadList {
  * @see {@link https://discord.com/developers/docs/resources/channel#channel-object-channel-flags}
  */
 export enum ChannelFlags {
+	/**
+	 * No channel flags are set
+	 */
+	None = 0,
 	/**
 	 * @unstable This channel flag is currently not documented by Discord but has a known value which we will try to keep up to date.
 	 */

--- a/deno/payloads/v10/gateway.ts
+++ b/deno/payloads/v10/gateway.ts
@@ -406,6 +406,7 @@ export interface GatewayActivitySecrets {
  * @see {@link https://discord.com/developers/docs/topics/gateway-events#activity-object-activity-flags}
  */
 export enum ActivityFlags {
+	None = 0,
 	Instance = 1 << 0,
 	Join = 1 << 1,
 	Spectate = 1 << 2,

--- a/deno/payloads/v10/guild.ts
+++ b/deno/payloads/v10/guild.ts
@@ -389,6 +389,10 @@ export enum GuildHubType {
  */
 export enum GuildSystemChannelFlags {
 	/**
+	 * No system channel flags are set
+	 */
+	None = 0,
+	/**
 	 * Suppress member join notifications
 	 */
 	SuppressJoinNotifications = 1 << 0,
@@ -783,6 +787,10 @@ export interface APIGuildMember
  * @see {@link https://discord.com/developers/docs/resources/guild#guild-member-object-guild-member-flags}
  */
 export enum GuildMemberFlags {
+	/**
+	 * No guild member flags are set
+	 */
+	None = 0,
 	/**
 	 * Member has left and rejoined the guild
 	 */

--- a/deno/payloads/v10/guild.ts
+++ b/deno/payloads/v10/guild.ts
@@ -388,9 +388,6 @@ export enum GuildHubType {
  * @see {@link https://discord.com/developers/docs/resources/guild#guild-object-system-channel-flags}
  */
 export enum GuildSystemChannelFlags {
-	/**
-	 * No system channel flags are set
-	 */
 	None = 0,
 	/**
 	 * Suppress member join notifications
@@ -787,9 +784,6 @@ export interface APIGuildMember
  * @see {@link https://discord.com/developers/docs/resources/guild#guild-member-object-guild-member-flags}
  */
 export enum GuildMemberFlags {
-	/**
-	 * No guild member flags are set
-	 */
 	None = 0,
 	/**
 	 * Member has left and rejoined the guild

--- a/deno/payloads/v10/invite.ts
+++ b/deno/payloads/v10/invite.ts
@@ -113,6 +113,7 @@ export interface APIInvite {
  * @see {@link https://discord.com/developers/docs/resources/invite#invite-object-guild-invite-flags}
  */
 export enum InviteFlags {
+	None = 0,
 	IsGuestInvite = 1 << 0,
 }
 

--- a/deno/payloads/v10/message.ts
+++ b/deno/payloads/v10/message.ts
@@ -394,6 +394,10 @@ export enum MessageReferenceType {
  */
 export enum MessageFlags {
 	/**
+	 * No message flags are set
+	 */
+	None = 0,
+	/**
 	 * This message has been published to subscribed channels (via Channel Following)
 	 */
 	Crossposted = 1 << 0,
@@ -700,6 +704,10 @@ export enum EmbedType {
  */
 export enum EmbedFlags {
 	/**
+	 * No embed flags are set
+	 */
+	None = 0,
+	/**
 	 * This embed is a fallback for a reply to an activity card
 	 */
 	IsContentInventoryEntry = 1 << 5,
@@ -709,6 +717,10 @@ export enum EmbedFlags {
  * @see {@link https://docs.discord.com/developers/resources/message#embed-object-embed-media-flags}
  */
 export enum EmbedMediaFlags {
+	/**
+	 * No embed media flags are set
+	 */
+	None = 0,
 	/**
 	 * This image is animated
 	 */
@@ -993,6 +1005,10 @@ export interface APIAttachment {
  * @see {@link https://docs.discord.com/developers/resources/message#attachment-object-attachment-flags}
  */
 export enum AttachmentFlags {
+	/**
+	 * No attachment flags are set
+	 */
+	None = 0,
 	/**
 	 * This attachment is a Clip from a stream
 	 *
@@ -1671,6 +1687,10 @@ export interface APIUnfurledMediaItem {
  * @see {@link https://docs.discord.com/developers/components/reference#unfurled-media-item-unfurled-media-item-flags}
  */
 export enum UnfurledMediaItemFlags {
+	/**
+	 * No media item flags are set
+	 */
+	None = 0,
 	/**
 	 * This image is animated
 	 */

--- a/deno/payloads/v10/message.ts
+++ b/deno/payloads/v10/message.ts
@@ -393,9 +393,6 @@ export enum MessageReferenceType {
  * @see {@link https://discord.com/developers/docs/resources/message#message-object-message-flags}
  */
 export enum MessageFlags {
-	/**
-	 * No message flags are set
-	 */
 	None = 0,
 	/**
 	 * This message has been published to subscribed channels (via Channel Following)
@@ -703,9 +700,6 @@ export enum EmbedType {
  * @see {@link https://docs.discord.com/developers/resources/message#embed-object-embed-flags}
  */
 export enum EmbedFlags {
-	/**
-	 * No embed flags are set
-	 */
 	None = 0,
 	/**
 	 * This embed is a fallback for a reply to an activity card
@@ -717,9 +711,6 @@ export enum EmbedFlags {
  * @see {@link https://docs.discord.com/developers/resources/message#embed-object-embed-media-flags}
  */
 export enum EmbedMediaFlags {
-	/**
-	 * No embed media flags are set
-	 */
 	None = 0,
 	/**
 	 * This image is animated
@@ -1005,9 +996,6 @@ export interface APIAttachment {
  * @see {@link https://docs.discord.com/developers/resources/message#attachment-object-attachment-flags}
  */
 export enum AttachmentFlags {
-	/**
-	 * No attachment flags are set
-	 */
 	None = 0,
 	/**
 	 * This attachment is a Clip from a stream
@@ -1687,9 +1675,6 @@ export interface APIUnfurledMediaItem {
  * @see {@link https://docs.discord.com/developers/components/reference#unfurled-media-item-unfurled-media-item-flags}
  */
 export enum UnfurledMediaItemFlags {
-	/**
-	 * No media item flags are set
-	 */
 	None = 0,
 	/**
 	 * This image is animated

--- a/deno/payloads/v10/monetization.ts
+++ b/deno/payloads/v10/monetization.ts
@@ -121,6 +121,10 @@ export interface APISKU {
  */
 export enum SKUFlags {
 	/**
+	 * No SKU flags are set
+	 */
+	None = 0,
+	/**
 	 * SKU is available for purchase
 	 */
 	Available = 1 << 2,

--- a/deno/payloads/v10/monetization.ts
+++ b/deno/payloads/v10/monetization.ts
@@ -120,9 +120,6 @@ export interface APISKU {
  * @see {@link https://discord.com/developers/docs/monetization/skus#sku-object-sku-flags}
  */
 export enum SKUFlags {
-	/**
-	 * No SKU flags are set
-	 */
 	None = 0,
 	/**
 	 * SKU is available for purchase

--- a/deno/payloads/v10/permissions.ts
+++ b/deno/payloads/v10/permissions.ts
@@ -102,6 +102,10 @@ export interface APIRoleTags {
  */
 export enum RoleFlags {
 	/**
+	 * No role flags are set
+	 */
+	None = 0,
+	/**
 	 * Role can be selected by members in an onboarding prompt
 	 */
 	InPrompt = 1 << 0,

--- a/deno/payloads/v10/permissions.ts
+++ b/deno/payloads/v10/permissions.ts
@@ -101,9 +101,6 @@ export interface APIRoleTags {
  * @see {@link https://discord.com/developers/docs/topics/permissions#role-object-role-flags}
  */
 export enum RoleFlags {
-	/**
-	 * No role flags are set
-	 */
 	None = 0,
 	/**
 	 * Role can be selected by members in an onboarding prompt

--- a/deno/payloads/v10/user.ts
+++ b/deno/payloads/v10/user.ts
@@ -116,6 +116,10 @@ export interface APIUser {
  */
 export enum UserFlags {
 	/**
+	 * No user flags are set
+	 */
+	None = 0,
+	/**
 	 * Discord Employee
 	 */
 	Staff = 1 << 0,

--- a/deno/payloads/v10/user.ts
+++ b/deno/payloads/v10/user.ts
@@ -115,9 +115,6 @@ export interface APIUser {
  * @see {@link https://discord.com/developers/docs/resources/user#user-object-user-flags}
  */
 export enum UserFlags {
-	/**
-	 * No user flags are set
-	 */
 	None = 0,
 	/**
 	 * Discord Employee

--- a/deno/payloads/v9/application.ts
+++ b/deno/payloads/v9/application.ts
@@ -178,9 +178,6 @@ export type APIApplicationIntegrationTypesConfigMap = {
  * @see {@link https://discord.com/developers/docs/resources/application#application-object-application-flags}
  */
 export enum ApplicationFlags {
-	/**
-	 * No application flags are set
-	 */
 	None = 0,
 	/**
 	 * @unstable This application flag is currently not documented by Discord but has a known value which we will try to keep up to date.

--- a/deno/payloads/v9/application.ts
+++ b/deno/payloads/v9/application.ts
@@ -179,6 +179,10 @@ export type APIApplicationIntegrationTypesConfigMap = {
  */
 export enum ApplicationFlags {
 	/**
+	 * No application flags are set
+	 */
+	None = 0,
+	/**
 	 * @unstable This application flag is currently not documented by Discord but has a known value which we will try to keep up to date.
 	 */
 	EmbeddedReleased = 1 << 1,

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -652,6 +652,10 @@ export interface APIThreadMember {
 
 export enum ThreadMemberFlags {
 	/**
+	 * No thread member flags are set
+	 */
+	None = 0,
+	/**
 	 * @unstable This thread member flag is currently not documented by Discord but has a known value which we will try to keep up to date.
 	 */
 	HasInteracted = 1 << 0,
@@ -688,6 +692,10 @@ export interface APIThreadList {
  * @see {@link https://discord.com/developers/docs/resources/channel#channel-object-channel-flags}
  */
 export enum ChannelFlags {
+	/**
+	 * No channel flags are set
+	 */
+	None = 0,
 	/**
 	 * @unstable This channel flag is currently not documented by Discord but has a known value which we will try to keep up to date.
 	 */

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -651,9 +651,6 @@ export interface APIThreadMember {
 }
 
 export enum ThreadMemberFlags {
-	/**
-	 * No thread member flags are set
-	 */
 	None = 0,
 	/**
 	 * @unstable This thread member flag is currently not documented by Discord but has a known value which we will try to keep up to date.
@@ -692,9 +689,6 @@ export interface APIThreadList {
  * @see {@link https://discord.com/developers/docs/resources/channel#channel-object-channel-flags}
  */
 export enum ChannelFlags {
-	/**
-	 * No channel flags are set
-	 */
 	None = 0,
 	/**
 	 * @unstable This channel flag is currently not documented by Discord but has a known value which we will try to keep up to date.

--- a/deno/payloads/v9/gateway.ts
+++ b/deno/payloads/v9/gateway.ts
@@ -394,6 +394,7 @@ export interface GatewayActivitySecrets {
  * @see {@link https://discord.com/developers/docs/topics/gateway-events#activity-object-activity-flags}
  */
 export enum ActivityFlags {
+	None = 0,
 	Instance = 1 << 0,
 	Join = 1 << 1,
 	Spectate = 1 << 2,

--- a/deno/payloads/v9/guild.ts
+++ b/deno/payloads/v9/guild.ts
@@ -389,6 +389,10 @@ export enum GuildHubType {
  */
 export enum GuildSystemChannelFlags {
 	/**
+	 * No system channel flags are set
+	 */
+	None = 0,
+	/**
 	 * Suppress member join notifications
 	 */
 	SuppressJoinNotifications = 1 << 0,
@@ -775,6 +779,10 @@ export interface APIGuildMember
  * @see {@link https://discord.com/developers/docs/resources/guild#guild-member-object-guild-member-flags}
  */
 export enum GuildMemberFlags {
+	/**
+	 * No guild member flags are set
+	 */
+	None = 0,
 	/**
 	 * Member has left and rejoined the guild
 	 */

--- a/deno/payloads/v9/guild.ts
+++ b/deno/payloads/v9/guild.ts
@@ -388,9 +388,6 @@ export enum GuildHubType {
  * @see {@link https://discord.com/developers/docs/resources/guild#guild-object-system-channel-flags}
  */
 export enum GuildSystemChannelFlags {
-	/**
-	 * No system channel flags are set
-	 */
 	None = 0,
 	/**
 	 * Suppress member join notifications
@@ -779,9 +776,6 @@ export interface APIGuildMember
  * @see {@link https://discord.com/developers/docs/resources/guild#guild-member-object-guild-member-flags}
  */
 export enum GuildMemberFlags {
-	/**
-	 * No guild member flags are set
-	 */
 	None = 0,
 	/**
 	 * Member has left and rejoined the guild

--- a/deno/payloads/v9/invite.ts
+++ b/deno/payloads/v9/invite.ts
@@ -113,6 +113,7 @@ export interface APIInvite {
  * @see {@link https://discord.com/developers/docs/resources/invite#invite-object-guild-invite-flags}
  */
 export enum InviteFlags {
+	None = 0,
 	IsGuestInvite = 1 << 0,
 }
 

--- a/deno/payloads/v9/message.ts
+++ b/deno/payloads/v9/message.ts
@@ -388,9 +388,6 @@ export enum MessageReferenceType {
  * @see {@link https://discord.com/developers/docs/resources/message#message-object-message-flags}
  */
 export enum MessageFlags {
-	/**
-	 * No message flags are set
-	 */
 	None = 0,
 	/**
 	 * This message has been published to subscribed channels (via Channel Following)
@@ -698,9 +695,6 @@ export enum EmbedType {
  * @see {@link https://docs.discord.com/developers/resources/message#embed-object-embed-flags}
  */
 export enum EmbedFlags {
-	/**
-	 * No embed flags are set
-	 */
 	None = 0,
 	/**
 	 * This embed is a fallback for a reply to an activity card
@@ -712,9 +706,6 @@ export enum EmbedFlags {
  * @see {@link https://docs.discord.com/developers/resources/message#embed-object-embed-media-flags}
  */
 export enum EmbedMediaFlags {
-	/**
-	 * No embed media flags are set
-	 */
 	None = 0,
 	/**
 	 * This image is animated
@@ -1000,9 +991,6 @@ export interface APIAttachment {
  * @see {@link https://docs.discord.com/developers/resources/message#attachment-object-attachment-flags}
  */
 export enum AttachmentFlags {
-	/**
-	 * No attachment flags are set
-	 */
 	None = 0,
 	/**
 	 * This attachment is a Clip from a stream
@@ -1682,9 +1670,6 @@ export interface APIUnfurledMediaItem {
  * @see {@link https://docs.discord.com/developers/components/reference#unfurled-media-item-unfurled-media-item-flags}
  */
 export enum UnfurledMediaItemFlags {
-	/**
-	 * No media item flags are set
-	 */
 	None = 0,
 	/**
 	 * This image is animated

--- a/deno/payloads/v9/message.ts
+++ b/deno/payloads/v9/message.ts
@@ -389,6 +389,10 @@ export enum MessageReferenceType {
  */
 export enum MessageFlags {
 	/**
+	 * No message flags are set
+	 */
+	None = 0,
+	/**
 	 * This message has been published to subscribed channels (via Channel Following)
 	 */
 	Crossposted = 1 << 0,
@@ -695,6 +699,10 @@ export enum EmbedType {
  */
 export enum EmbedFlags {
 	/**
+	 * No embed flags are set
+	 */
+	None = 0,
+	/**
 	 * This embed is a fallback for a reply to an activity card
 	 */
 	IsContentInventoryEntry = 1 << 5,
@@ -704,6 +712,10 @@ export enum EmbedFlags {
  * @see {@link https://docs.discord.com/developers/resources/message#embed-object-embed-media-flags}
  */
 export enum EmbedMediaFlags {
+	/**
+	 * No embed media flags are set
+	 */
+	None = 0,
 	/**
 	 * This image is animated
 	 */
@@ -988,6 +1000,10 @@ export interface APIAttachment {
  * @see {@link https://docs.discord.com/developers/resources/message#attachment-object-attachment-flags}
  */
 export enum AttachmentFlags {
+	/**
+	 * No attachment flags are set
+	 */
+	None = 0,
 	/**
 	 * This attachment is a Clip from a stream
 	 *
@@ -1666,6 +1682,10 @@ export interface APIUnfurledMediaItem {
  * @see {@link https://docs.discord.com/developers/components/reference#unfurled-media-item-unfurled-media-item-flags}
  */
 export enum UnfurledMediaItemFlags {
+	/**
+	 * No media item flags are set
+	 */
+	None = 0,
 	/**
 	 * This image is animated
 	 */

--- a/deno/payloads/v9/monetization.ts
+++ b/deno/payloads/v9/monetization.ts
@@ -121,6 +121,10 @@ export interface APISKU {
  */
 export enum SKUFlags {
 	/**
+	 * No SKU flags are set
+	 */
+	None = 0,
+	/**
 	 * SKU is available for purchase
 	 */
 	Available = 1 << 2,

--- a/deno/payloads/v9/monetization.ts
+++ b/deno/payloads/v9/monetization.ts
@@ -120,9 +120,6 @@ export interface APISKU {
  * @see {@link https://discord.com/developers/docs/monetization/skus#sku-object-sku-flags}
  */
 export enum SKUFlags {
-	/**
-	 * No SKU flags are set
-	 */
 	None = 0,
 	/**
 	 * SKU is available for purchase

--- a/deno/payloads/v9/permissions.ts
+++ b/deno/payloads/v9/permissions.ts
@@ -102,6 +102,10 @@ export interface APIRoleTags {
  */
 export enum RoleFlags {
 	/**
+	 * No role flags are set
+	 */
+	None = 0,
+	/**
 	 * Role can be selected by members in an onboarding prompt
 	 */
 	InPrompt = 1 << 0,

--- a/deno/payloads/v9/permissions.ts
+++ b/deno/payloads/v9/permissions.ts
@@ -101,9 +101,6 @@ export interface APIRoleTags {
  * @see {@link https://discord.com/developers/docs/topics/permissions#role-object-role-flags}
  */
 export enum RoleFlags {
-	/**
-	 * No role flags are set
-	 */
 	None = 0,
 	/**
 	 * Role can be selected by members in an onboarding prompt

--- a/deno/payloads/v9/user.ts
+++ b/deno/payloads/v9/user.ts
@@ -116,6 +116,10 @@ export interface APIUser {
  */
 export enum UserFlags {
 	/**
+	 * No user flags are set
+	 */
+	None = 0,
+	/**
 	 * Discord Employee
 	 */
 	Staff = 1 << 0,

--- a/deno/payloads/v9/user.ts
+++ b/deno/payloads/v9/user.ts
@@ -115,9 +115,6 @@ export interface APIUser {
  * @see {@link https://discord.com/developers/docs/resources/user#user-object-user-flags}
  */
 export enum UserFlags {
-	/**
-	 * No user flags are set
-	 */
 	None = 0,
 	/**
 	 * Discord Employee

--- a/payloads/v10/application.ts
+++ b/payloads/v10/application.ts
@@ -178,9 +178,6 @@ export type APIApplicationIntegrationTypesConfigMap = {
  * @see {@link https://discord.com/developers/docs/resources/application#application-object-application-flags}
  */
 export enum ApplicationFlags {
-	/**
-	 * No application flags are set
-	 */
 	None = 0,
 	/**
 	 * @unstable This application flag is currently not documented by Discord but has a known value which we will try to keep up to date.

--- a/payloads/v10/application.ts
+++ b/payloads/v10/application.ts
@@ -179,6 +179,10 @@ export type APIApplicationIntegrationTypesConfigMap = {
  */
 export enum ApplicationFlags {
 	/**
+	 * No application flags are set
+	 */
+	None = 0,
+	/**
 	 * @unstable This application flag is currently not documented by Discord but has a known value which we will try to keep up to date.
 	 */
 	EmbeddedReleased = 1 << 1,

--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -656,9 +656,6 @@ export interface APIThreadMember {
 }
 
 export enum ThreadMemberFlags {
-	/**
-	 * No thread member flags are set
-	 */
 	None = 0,
 	/**
 	 * @unstable This thread member flag is currently not documented by Discord but has a known value which we will try to keep up to date.
@@ -693,9 +690,6 @@ export interface APIThreadList {
  * @see {@link https://discord.com/developers/docs/resources/channel#channel-object-channel-flags}
  */
 export enum ChannelFlags {
-	/**
-	 * No channel flags are set
-	 */
 	None = 0,
 	/**
 	 * @unstable This channel flag is currently not documented by Discord but has a known value which we will try to keep up to date.

--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -657,6 +657,10 @@ export interface APIThreadMember {
 
 export enum ThreadMemberFlags {
 	/**
+	 * No thread member flags are set
+	 */
+	None = 0,
+	/**
 	 * @unstable This thread member flag is currently not documented by Discord but has a known value which we will try to keep up to date.
 	 */
 	HasInteracted = 1 << 0,
@@ -689,6 +693,10 @@ export interface APIThreadList {
  * @see {@link https://discord.com/developers/docs/resources/channel#channel-object-channel-flags}
  */
 export enum ChannelFlags {
+	/**
+	 * No channel flags are set
+	 */
+	None = 0,
 	/**
 	 * @unstable This channel flag is currently not documented by Discord but has a known value which we will try to keep up to date.
 	 */

--- a/payloads/v10/gateway.ts
+++ b/payloads/v10/gateway.ts
@@ -406,6 +406,7 @@ export interface GatewayActivitySecrets {
  * @see {@link https://discord.com/developers/docs/topics/gateway-events#activity-object-activity-flags}
  */
 export enum ActivityFlags {
+	None = 0,
 	Instance = 1 << 0,
 	Join = 1 << 1,
 	Spectate = 1 << 2,

--- a/payloads/v10/guild.ts
+++ b/payloads/v10/guild.ts
@@ -389,6 +389,10 @@ export enum GuildHubType {
  */
 export enum GuildSystemChannelFlags {
 	/**
+	 * No system channel flags are set
+	 */
+	None = 0,
+	/**
 	 * Suppress member join notifications
 	 */
 	SuppressJoinNotifications = 1 << 0,
@@ -783,6 +787,10 @@ export interface APIGuildMember
  * @see {@link https://discord.com/developers/docs/resources/guild#guild-member-object-guild-member-flags}
  */
 export enum GuildMemberFlags {
+	/**
+	 * No guild member flags are set
+	 */
+	None = 0,
 	/**
 	 * Member has left and rejoined the guild
 	 */

--- a/payloads/v10/guild.ts
+++ b/payloads/v10/guild.ts
@@ -388,9 +388,6 @@ export enum GuildHubType {
  * @see {@link https://discord.com/developers/docs/resources/guild#guild-object-system-channel-flags}
  */
 export enum GuildSystemChannelFlags {
-	/**
-	 * No system channel flags are set
-	 */
 	None = 0,
 	/**
 	 * Suppress member join notifications
@@ -787,9 +784,6 @@ export interface APIGuildMember
  * @see {@link https://discord.com/developers/docs/resources/guild#guild-member-object-guild-member-flags}
  */
 export enum GuildMemberFlags {
-	/**
-	 * No guild member flags are set
-	 */
 	None = 0,
 	/**
 	 * Member has left and rejoined the guild

--- a/payloads/v10/invite.ts
+++ b/payloads/v10/invite.ts
@@ -113,6 +113,7 @@ export interface APIInvite {
  * @see {@link https://discord.com/developers/docs/resources/invite#invite-object-guild-invite-flags}
  */
 export enum InviteFlags {
+	None = 0,
 	IsGuestInvite = 1 << 0,
 }
 

--- a/payloads/v10/message.ts
+++ b/payloads/v10/message.ts
@@ -394,6 +394,10 @@ export enum MessageReferenceType {
  */
 export enum MessageFlags {
 	/**
+	 * No message flags are set
+	 */
+	None = 0,
+	/**
 	 * This message has been published to subscribed channels (via Channel Following)
 	 */
 	Crossposted = 1 << 0,
@@ -700,6 +704,10 @@ export enum EmbedType {
  */
 export enum EmbedFlags {
 	/**
+	 * No embed flags are set
+	 */
+	None = 0,
+	/**
 	 * This embed is a fallback for a reply to an activity card
 	 */
 	IsContentInventoryEntry = 1 << 5,
@@ -709,6 +717,10 @@ export enum EmbedFlags {
  * @see {@link https://docs.discord.com/developers/resources/message#embed-object-embed-media-flags}
  */
 export enum EmbedMediaFlags {
+	/**
+	 * No embed media flags are set
+	 */
+	None = 0,
 	/**
 	 * This image is animated
 	 */
@@ -993,6 +1005,10 @@ export interface APIAttachment {
  * @see {@link https://docs.discord.com/developers/resources/message#attachment-object-attachment-flags}
  */
 export enum AttachmentFlags {
+	/**
+	 * No attachment flags are set
+	 */
+	None = 0,
 	/**
 	 * This attachment is a Clip from a stream
 	 *
@@ -1671,6 +1687,10 @@ export interface APIUnfurledMediaItem {
  * @see {@link https://docs.discord.com/developers/components/reference#unfurled-media-item-unfurled-media-item-flags}
  */
 export enum UnfurledMediaItemFlags {
+	/**
+	 * No media item flags are set
+	 */
+	None = 0,
 	/**
 	 * This image is animated
 	 */

--- a/payloads/v10/message.ts
+++ b/payloads/v10/message.ts
@@ -393,9 +393,6 @@ export enum MessageReferenceType {
  * @see {@link https://discord.com/developers/docs/resources/message#message-object-message-flags}
  */
 export enum MessageFlags {
-	/**
-	 * No message flags are set
-	 */
 	None = 0,
 	/**
 	 * This message has been published to subscribed channels (via Channel Following)
@@ -703,9 +700,6 @@ export enum EmbedType {
  * @see {@link https://docs.discord.com/developers/resources/message#embed-object-embed-flags}
  */
 export enum EmbedFlags {
-	/**
-	 * No embed flags are set
-	 */
 	None = 0,
 	/**
 	 * This embed is a fallback for a reply to an activity card
@@ -717,9 +711,6 @@ export enum EmbedFlags {
  * @see {@link https://docs.discord.com/developers/resources/message#embed-object-embed-media-flags}
  */
 export enum EmbedMediaFlags {
-	/**
-	 * No embed media flags are set
-	 */
 	None = 0,
 	/**
 	 * This image is animated
@@ -1005,9 +996,6 @@ export interface APIAttachment {
  * @see {@link https://docs.discord.com/developers/resources/message#attachment-object-attachment-flags}
  */
 export enum AttachmentFlags {
-	/**
-	 * No attachment flags are set
-	 */
 	None = 0,
 	/**
 	 * This attachment is a Clip from a stream
@@ -1687,9 +1675,6 @@ export interface APIUnfurledMediaItem {
  * @see {@link https://docs.discord.com/developers/components/reference#unfurled-media-item-unfurled-media-item-flags}
  */
 export enum UnfurledMediaItemFlags {
-	/**
-	 * No media item flags are set
-	 */
 	None = 0,
 	/**
 	 * This image is animated

--- a/payloads/v10/monetization.ts
+++ b/payloads/v10/monetization.ts
@@ -121,6 +121,10 @@ export interface APISKU {
  */
 export enum SKUFlags {
 	/**
+	 * No SKU flags are set
+	 */
+	None = 0,
+	/**
 	 * SKU is available for purchase
 	 */
 	Available = 1 << 2,

--- a/payloads/v10/monetization.ts
+++ b/payloads/v10/monetization.ts
@@ -120,9 +120,6 @@ export interface APISKU {
  * @see {@link https://discord.com/developers/docs/monetization/skus#sku-object-sku-flags}
  */
 export enum SKUFlags {
-	/**
-	 * No SKU flags are set
-	 */
 	None = 0,
 	/**
 	 * SKU is available for purchase

--- a/payloads/v10/permissions.ts
+++ b/payloads/v10/permissions.ts
@@ -102,6 +102,10 @@ export interface APIRoleTags {
  */
 export enum RoleFlags {
 	/**
+	 * No role flags are set
+	 */
+	None = 0,
+	/**
 	 * Role can be selected by members in an onboarding prompt
 	 */
 	InPrompt = 1 << 0,

--- a/payloads/v10/permissions.ts
+++ b/payloads/v10/permissions.ts
@@ -101,9 +101,6 @@ export interface APIRoleTags {
  * @see {@link https://discord.com/developers/docs/topics/permissions#role-object-role-flags}
  */
 export enum RoleFlags {
-	/**
-	 * No role flags are set
-	 */
 	None = 0,
 	/**
 	 * Role can be selected by members in an onboarding prompt

--- a/payloads/v10/user.ts
+++ b/payloads/v10/user.ts
@@ -116,6 +116,10 @@ export interface APIUser {
  */
 export enum UserFlags {
 	/**
+	 * No user flags are set
+	 */
+	None = 0,
+	/**
 	 * Discord Employee
 	 */
 	Staff = 1 << 0,

--- a/payloads/v10/user.ts
+++ b/payloads/v10/user.ts
@@ -115,9 +115,6 @@ export interface APIUser {
  * @see {@link https://discord.com/developers/docs/resources/user#user-object-user-flags}
  */
 export enum UserFlags {
-	/**
-	 * No user flags are set
-	 */
 	None = 0,
 	/**
 	 * Discord Employee

--- a/payloads/v9/application.ts
+++ b/payloads/v9/application.ts
@@ -178,9 +178,6 @@ export type APIApplicationIntegrationTypesConfigMap = {
  * @see {@link https://discord.com/developers/docs/resources/application#application-object-application-flags}
  */
 export enum ApplicationFlags {
-	/**
-	 * No application flags are set
-	 */
 	None = 0,
 	/**
 	 * @unstable This application flag is currently not documented by Discord but has a known value which we will try to keep up to date.

--- a/payloads/v9/application.ts
+++ b/payloads/v9/application.ts
@@ -179,6 +179,10 @@ export type APIApplicationIntegrationTypesConfigMap = {
  */
 export enum ApplicationFlags {
 	/**
+	 * No application flags are set
+	 */
+	None = 0,
+	/**
 	 * @unstable This application flag is currently not documented by Discord but has a known value which we will try to keep up to date.
 	 */
 	EmbeddedReleased = 1 << 1,

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -652,6 +652,10 @@ export interface APIThreadMember {
 
 export enum ThreadMemberFlags {
 	/**
+	 * No thread member flags are set
+	 */
+	None = 0,
+	/**
 	 * @unstable This thread member flag is currently not documented by Discord but has a known value which we will try to keep up to date.
 	 */
 	HasInteracted = 1 << 0,
@@ -688,6 +692,10 @@ export interface APIThreadList {
  * @see {@link https://discord.com/developers/docs/resources/channel#channel-object-channel-flags}
  */
 export enum ChannelFlags {
+	/**
+	 * No channel flags are set
+	 */
+	None = 0,
 	/**
 	 * @unstable This channel flag is currently not documented by Discord but has a known value which we will try to keep up to date.
 	 */

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -651,9 +651,6 @@ export interface APIThreadMember {
 }
 
 export enum ThreadMemberFlags {
-	/**
-	 * No thread member flags are set
-	 */
 	None = 0,
 	/**
 	 * @unstable This thread member flag is currently not documented by Discord but has a known value which we will try to keep up to date.
@@ -692,9 +689,6 @@ export interface APIThreadList {
  * @see {@link https://discord.com/developers/docs/resources/channel#channel-object-channel-flags}
  */
 export enum ChannelFlags {
-	/**
-	 * No channel flags are set
-	 */
 	None = 0,
 	/**
 	 * @unstable This channel flag is currently not documented by Discord but has a known value which we will try to keep up to date.

--- a/payloads/v9/gateway.ts
+++ b/payloads/v9/gateway.ts
@@ -394,6 +394,7 @@ export interface GatewayActivitySecrets {
  * @see {@link https://discord.com/developers/docs/topics/gateway-events#activity-object-activity-flags}
  */
 export enum ActivityFlags {
+	None = 0,
 	Instance = 1 << 0,
 	Join = 1 << 1,
 	Spectate = 1 << 2,

--- a/payloads/v9/guild.ts
+++ b/payloads/v9/guild.ts
@@ -389,6 +389,10 @@ export enum GuildHubType {
  */
 export enum GuildSystemChannelFlags {
 	/**
+	 * No system channel flags are set
+	 */
+	None = 0,
+	/**
 	 * Suppress member join notifications
 	 */
 	SuppressJoinNotifications = 1 << 0,
@@ -775,6 +779,10 @@ export interface APIGuildMember
  * @see {@link https://discord.com/developers/docs/resources/guild#guild-member-object-guild-member-flags}
  */
 export enum GuildMemberFlags {
+	/**
+	 * No guild member flags are set
+	 */
+	None = 0,
 	/**
 	 * Member has left and rejoined the guild
 	 */

--- a/payloads/v9/guild.ts
+++ b/payloads/v9/guild.ts
@@ -388,9 +388,6 @@ export enum GuildHubType {
  * @see {@link https://discord.com/developers/docs/resources/guild#guild-object-system-channel-flags}
  */
 export enum GuildSystemChannelFlags {
-	/**
-	 * No system channel flags are set
-	 */
 	None = 0,
 	/**
 	 * Suppress member join notifications
@@ -779,9 +776,6 @@ export interface APIGuildMember
  * @see {@link https://discord.com/developers/docs/resources/guild#guild-member-object-guild-member-flags}
  */
 export enum GuildMemberFlags {
-	/**
-	 * No guild member flags are set
-	 */
 	None = 0,
 	/**
 	 * Member has left and rejoined the guild

--- a/payloads/v9/invite.ts
+++ b/payloads/v9/invite.ts
@@ -113,6 +113,7 @@ export interface APIInvite {
  * @see {@link https://discord.com/developers/docs/resources/invite#invite-object-guild-invite-flags}
  */
 export enum InviteFlags {
+	None = 0,
 	IsGuestInvite = 1 << 0,
 }
 

--- a/payloads/v9/message.ts
+++ b/payloads/v9/message.ts
@@ -388,9 +388,6 @@ export enum MessageReferenceType {
  * @see {@link https://discord.com/developers/docs/resources/message#message-object-message-flags}
  */
 export enum MessageFlags {
-	/**
-	 * No message flags are set
-	 */
 	None = 0,
 	/**
 	 * This message has been published to subscribed channels (via Channel Following)
@@ -698,9 +695,6 @@ export enum EmbedType {
  * @see {@link https://docs.discord.com/developers/resources/message#embed-object-embed-flags}
  */
 export enum EmbedFlags {
-	/**
-	 * No embed flags are set
-	 */
 	None = 0,
 	/**
 	 * This embed is a fallback for a reply to an activity card
@@ -712,9 +706,6 @@ export enum EmbedFlags {
  * @see {@link https://docs.discord.com/developers/resources/message#embed-object-embed-media-flags}
  */
 export enum EmbedMediaFlags {
-	/**
-	 * No embed media flags are set
-	 */
 	None = 0,
 	/**
 	 * This image is animated
@@ -1000,9 +991,6 @@ export interface APIAttachment {
  * @see {@link https://docs.discord.com/developers/resources/message#attachment-object-attachment-flags}
  */
 export enum AttachmentFlags {
-	/**
-	 * No attachment flags are set
-	 */
 	None = 0,
 	/**
 	 * This attachment is a Clip from a stream
@@ -1682,9 +1670,6 @@ export interface APIUnfurledMediaItem {
  * @see {@link https://docs.discord.com/developers/components/reference#unfurled-media-item-unfurled-media-item-flags}
  */
 export enum UnfurledMediaItemFlags {
-	/**
-	 * No media item flags are set
-	 */
 	None = 0,
 	/**
 	 * This image is animated

--- a/payloads/v9/message.ts
+++ b/payloads/v9/message.ts
@@ -389,6 +389,10 @@ export enum MessageReferenceType {
  */
 export enum MessageFlags {
 	/**
+	 * No message flags are set
+	 */
+	None = 0,
+	/**
 	 * This message has been published to subscribed channels (via Channel Following)
 	 */
 	Crossposted = 1 << 0,
@@ -695,6 +699,10 @@ export enum EmbedType {
  */
 export enum EmbedFlags {
 	/**
+	 * No embed flags are set
+	 */
+	None = 0,
+	/**
 	 * This embed is a fallback for a reply to an activity card
 	 */
 	IsContentInventoryEntry = 1 << 5,
@@ -704,6 +712,10 @@ export enum EmbedFlags {
  * @see {@link https://docs.discord.com/developers/resources/message#embed-object-embed-media-flags}
  */
 export enum EmbedMediaFlags {
+	/**
+	 * No embed media flags are set
+	 */
+	None = 0,
 	/**
 	 * This image is animated
 	 */
@@ -988,6 +1000,10 @@ export interface APIAttachment {
  * @see {@link https://docs.discord.com/developers/resources/message#attachment-object-attachment-flags}
  */
 export enum AttachmentFlags {
+	/**
+	 * No attachment flags are set
+	 */
+	None = 0,
 	/**
 	 * This attachment is a Clip from a stream
 	 *
@@ -1666,6 +1682,10 @@ export interface APIUnfurledMediaItem {
  * @see {@link https://docs.discord.com/developers/components/reference#unfurled-media-item-unfurled-media-item-flags}
  */
 export enum UnfurledMediaItemFlags {
+	/**
+	 * No media item flags are set
+	 */
+	None = 0,
 	/**
 	 * This image is animated
 	 */

--- a/payloads/v9/monetization.ts
+++ b/payloads/v9/monetization.ts
@@ -121,6 +121,10 @@ export interface APISKU {
  */
 export enum SKUFlags {
 	/**
+	 * No SKU flags are set
+	 */
+	None = 0,
+	/**
 	 * SKU is available for purchase
 	 */
 	Available = 1 << 2,

--- a/payloads/v9/monetization.ts
+++ b/payloads/v9/monetization.ts
@@ -120,9 +120,6 @@ export interface APISKU {
  * @see {@link https://discord.com/developers/docs/monetization/skus#sku-object-sku-flags}
  */
 export enum SKUFlags {
-	/**
-	 * No SKU flags are set
-	 */
 	None = 0,
 	/**
 	 * SKU is available for purchase

--- a/payloads/v9/permissions.ts
+++ b/payloads/v9/permissions.ts
@@ -102,6 +102,10 @@ export interface APIRoleTags {
  */
 export enum RoleFlags {
 	/**
+	 * No role flags are set
+	 */
+	None = 0,
+	/**
 	 * Role can be selected by members in an onboarding prompt
 	 */
 	InPrompt = 1 << 0,

--- a/payloads/v9/permissions.ts
+++ b/payloads/v9/permissions.ts
@@ -101,9 +101,6 @@ export interface APIRoleTags {
  * @see {@link https://discord.com/developers/docs/topics/permissions#role-object-role-flags}
  */
 export enum RoleFlags {
-	/**
-	 * No role flags are set
-	 */
 	None = 0,
 	/**
 	 * Role can be selected by members in an onboarding prompt

--- a/payloads/v9/user.ts
+++ b/payloads/v9/user.ts
@@ -116,6 +116,10 @@ export interface APIUser {
  */
 export enum UserFlags {
 	/**
+	 * No user flags are set
+	 */
+	None = 0,
+	/**
 	 * Discord Employee
 	 */
 	Staff = 1 << 0,

--- a/payloads/v9/user.ts
+++ b/payloads/v9/user.ts
@@ -115,9 +115,6 @@ export interface APIUser {
  * @see {@link https://discord.com/developers/docs/resources/user#user-object-user-flags}
  */
 export enum UserFlags {
-	/**
-	 * No user flags are set
-	 */
 	None = 0,
 	/**
 	 * Discord Employee


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Passing `flags: 0` was not allowed with current bitfield Flags enums, adding a `None = 0` value to each of them solves this issue. Downstream users need to make sure to not handle these as actual flags but just as placeholder for no flags.

Closes #1699

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
