### PR TITLE
feat: add file_types for file uploads

### DIFF
--- a/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/attachment.ts
+++ b/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/attachment.ts
@@ -5,12 +5,6 @@ import type { ApplicationCommandOptionType } from './shared.ts';
 export type FileUploadType = 'audio' | 'image' | 'video' | `.${string}`;
 
 export interface APIApplicationCommandAttachmentOption extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.Attachment> {
-	/**
-	 * Allowed file types that can be uploaded; max 10
-	 *
-	 * If only dot-prefixed extensions is specified, due to mobile limitation, you must include `.jpg` for image uploads,
-	 * and both `.mp4` and `.mov` for video uploads
-	 */
 	file_types?: FileUploadType[];
 }
 

--- a/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/attachment.ts
+++ b/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/attachment.ts
@@ -2,8 +2,17 @@ import type { Snowflake } from '../../../../../globals.ts';
 import type { APIApplicationCommandOptionBase, APIInteractionDataOptionBase } from './base.ts';
 import type { ApplicationCommandOptionType } from './shared.ts';
 
-export type APIApplicationCommandAttachmentOption =
-	APIApplicationCommandOptionBase<ApplicationCommandOptionType.Attachment>;
+export type FileUploadType = 'audio' | 'image' | 'video' | `.${string}`;
+
+export interface APIApplicationCommandAttachmentOption extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.Attachment> {
+	/**
+	 * Allowed file types that can be uploaded; max 10
+	 *
+	 * If only dot-prefixed extensions is specified, due to mobile limitation, you must include `.jpg` for image uploads,
+	 * and both `.mp4` and `.mov` for video uploads
+	 */
+	file_types?: FileUploadType[];
+}
 
 export type APIApplicationCommandInteractionDataAttachmentOption = APIInteractionDataOptionBase<
 	ApplicationCommandOptionType.Attachment,

--- a/deno/payloads/v10/message.ts
+++ b/deno/payloads/v10/message.ts
@@ -5,7 +5,12 @@ import type { _NonNullableFields } from '../../utils/internals.ts';
 import type { APIApplication } from './application.ts';
 import type { APIChannel, APIThreadChannel, APIThreadMember, ChannelType } from './channel.ts';
 import type { APIPartialEmoji } from './emoji.ts';
-import type { APIInteractionDataResolved, APIMessageInteraction, APIMessageInteractionMetadata } from './interactions.ts';
+import type {
+	APIInteractionDataResolved,
+	APIMessageInteraction,
+	APIMessageInteractionMetadata,
+	FileUploadType,
+} from './interactions.ts';
 import type { APIRole } from './permissions.ts';
 import type { APIPoll } from './poll.ts';
 import type { APISticker, APIStickerItem } from './sticker.ts';
@@ -1890,6 +1895,13 @@ export interface APIFileUploadComponent extends APIBaseComponent<ComponentType.F
 	 * Maximum number of items that can be uploaded (defaults to 1); max 10
 	 */
 	max_values?: number;
+	/**
+	 * Allowed file types that can be uploaded; max 10
+	 *
+	 * If only dot-prefixed extensions is specified, due to mobile limitation, you must include `.jpg` for image uploads,
+	 * and both `.mp4` and `.mov` for video uploads
+	 */
+	file_types?: FileUploadType[];
 	/**
 	 * Whether the file upload requires files to be uploaded before submitting the modal
 	 *

--- a/deno/payloads/v10/message.ts
+++ b/deno/payloads/v10/message.ts
@@ -1898,8 +1898,8 @@ export interface APIFileUploadComponent extends APIBaseComponent<ComponentType.F
 	/**
 	 * Allowed file types that can be uploaded; max 10
 	 *
-	 * If only dot-prefixed extensions is specified, due to mobile limitation, you must include `.jpg` for image uploads,
-	 * and both `.mp4` and `.mov` for video uploads
+	 * If only dot-prefixed extensions are specified, you must also include `.jpg` for image uploads
+	 * and both `.mp4` and `.mov` for video uploads because of mobile platform limitations.
 	 */
 	file_types?: FileUploadType[];
 	/**

--- a/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/attachment.ts
+++ b/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/attachment.ts
@@ -5,12 +5,6 @@ import type { ApplicationCommandOptionType } from './shared.ts';
 export type FileUploadType = 'audio' | 'image' | 'video' | `.${string}`;
 
 export interface APIApplicationCommandAttachmentOption extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.Attachment> {
-	/**
-	 * Allowed file types that can be uploaded; max 10
-	 *
-	 * If only dot-prefixed extensions is specified, due to mobile limitation, you must include `.jpg` for image uploads,
-	 * and both `.mp4` and `.mov` for video uploads
-	 */
 	file_types?: FileUploadType[];
 }
 

--- a/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/attachment.ts
+++ b/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/attachment.ts
@@ -2,8 +2,17 @@ import type { Snowflake } from '../../../../../globals.ts';
 import type { APIApplicationCommandOptionBase, APIInteractionDataOptionBase } from './base.ts';
 import type { ApplicationCommandOptionType } from './shared.ts';
 
-export type APIApplicationCommandAttachmentOption =
-	APIApplicationCommandOptionBase<ApplicationCommandOptionType.Attachment>;
+export type FileUploadType = 'audio' | 'image' | 'video' | `.${string}`;
+
+export interface APIApplicationCommandAttachmentOption extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.Attachment> {
+	/**
+	 * Allowed file types that can be uploaded; max 10
+	 *
+	 * If only dot-prefixed extensions is specified, due to mobile limitation, you must include `.jpg` for image uploads,
+	 * and both `.mp4` and `.mov` for video uploads
+	 */
+	file_types?: FileUploadType[];
+}
 
 export type APIApplicationCommandInteractionDataAttachmentOption = APIInteractionDataOptionBase<
 	ApplicationCommandOptionType.Attachment,

--- a/deno/payloads/v9/message.ts
+++ b/deno/payloads/v9/message.ts
@@ -5,7 +5,12 @@ import type { _NonNullableFields } from '../../utils/internals.ts';
 import type { APIApplication } from './application.ts';
 import type { APIChannel, APIThreadChannel, APIThreadMember, ChannelType } from './channel.ts';
 import type { APIPartialEmoji } from './emoji.ts';
-import type { APIInteractionDataResolved, APIMessageInteraction, APIMessageInteractionMetadata } from './interactions.ts';
+import type {
+	APIInteractionDataResolved,
+	APIMessageInteraction,
+	APIMessageInteractionMetadata,
+	FileUploadType,
+} from './interactions.ts';
 import type { APIRole } from './permissions.ts';
 import type { APIPoll } from './poll.ts';
 import type { APISticker, APIStickerItem } from './sticker.ts';
@@ -1885,6 +1890,13 @@ export interface APIFileUploadComponent extends APIBaseComponent<ComponentType.F
 	 * Maximum number of items that can be uploaded (defaults to 1); max 10
 	 */
 	max_values?: number;
+	/**
+	 * Allowed file types that can be uploaded; max 10
+	 *
+	 * If only dot-prefixed extensions is specified, due to mobile limitation, you must include `.jpg` for image uploads,
+	 * and both `.mp4` and `.mov` for video uploads
+	 */
+	file_types?: FileUploadType[];
 	/**
 	 * Whether the file upload requires files to be uploaded before submitting the modal
 	 *

--- a/deno/payloads/v9/message.ts
+++ b/deno/payloads/v9/message.ts
@@ -1893,8 +1893,8 @@ export interface APIFileUploadComponent extends APIBaseComponent<ComponentType.F
 	/**
 	 * Allowed file types that can be uploaded; max 10
 	 *
-	 * If only dot-prefixed extensions is specified, due to mobile limitation, you must include `.jpg` for image uploads,
-	 * and both `.mp4` and `.mov` for video uploads
+	 * If only dot-prefixed extensions are specified, you must also include `.jpg` for image uploads
+	 * and both `.mp4` and `.mov` for video uploads because of mobile platform limitations.
 	 */
 	file_types?: FileUploadType[];
 	/**

--- a/payloads/v10/_interactions/_applicationCommands/_chatInput/attachment.ts
+++ b/payloads/v10/_interactions/_applicationCommands/_chatInput/attachment.ts
@@ -2,8 +2,17 @@ import type { Snowflake } from '../../../../../globals';
 import type { APIApplicationCommandOptionBase, APIInteractionDataOptionBase } from './base';
 import type { ApplicationCommandOptionType } from './shared';
 
-export type APIApplicationCommandAttachmentOption =
-	APIApplicationCommandOptionBase<ApplicationCommandOptionType.Attachment>;
+export type FileUploadType = 'audio' | 'image' | 'video' | `.${string}`;
+
+export interface APIApplicationCommandAttachmentOption extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.Attachment> {
+	/**
+	 * Allowed file types that can be uploaded; max 10
+	 *
+	 * If only dot-prefixed extensions is specified, due to mobile limitation, you must include `.jpg` for image uploads,
+	 * and both `.mp4` and `.mov` for video uploads
+	 */
+	file_types?: FileUploadType[];
+}
 
 export type APIApplicationCommandInteractionDataAttachmentOption = APIInteractionDataOptionBase<
 	ApplicationCommandOptionType.Attachment,

--- a/payloads/v10/_interactions/_applicationCommands/_chatInput/attachment.ts
+++ b/payloads/v10/_interactions/_applicationCommands/_chatInput/attachment.ts
@@ -5,12 +5,6 @@ import type { ApplicationCommandOptionType } from './shared';
 export type FileUploadType = 'audio' | 'image' | 'video' | `.${string}`;
 
 export interface APIApplicationCommandAttachmentOption extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.Attachment> {
-	/**
-	 * Allowed file types that can be uploaded; max 10
-	 *
-	 * If only dot-prefixed extensions is specified, due to mobile limitation, you must include `.jpg` for image uploads,
-	 * and both `.mp4` and `.mov` for video uploads
-	 */
 	file_types?: FileUploadType[];
 }
 

--- a/payloads/v10/message.ts
+++ b/payloads/v10/message.ts
@@ -1898,8 +1898,8 @@ export interface APIFileUploadComponent extends APIBaseComponent<ComponentType.F
 	/**
 	 * Allowed file types that can be uploaded; max 10
 	 *
-	 * If only dot-prefixed extensions is specified, due to mobile limitation, you must include `.jpg` for image uploads,
-	 * and both `.mp4` and `.mov` for video uploads
+	 * If only dot-prefixed extensions are specified, you must also include `.jpg` for image uploads
+	 * and both `.mp4` and `.mov` for video uploads because of mobile platform limitations.
 	 */
 	file_types?: FileUploadType[];
 	/**

--- a/payloads/v10/message.ts
+++ b/payloads/v10/message.ts
@@ -5,7 +5,12 @@ import type { _NonNullableFields } from '../../utils/internals';
 import type { APIApplication } from './application';
 import type { APIChannel, APIThreadChannel, APIThreadMember, ChannelType } from './channel';
 import type { APIPartialEmoji } from './emoji';
-import type { APIInteractionDataResolved, APIMessageInteraction, APIMessageInteractionMetadata } from './interactions';
+import type {
+	APIInteractionDataResolved,
+	APIMessageInteraction,
+	APIMessageInteractionMetadata,
+	FileUploadType,
+} from './interactions';
 import type { APIRole } from './permissions';
 import type { APIPoll } from './poll';
 import type { APISticker, APIStickerItem } from './sticker';
@@ -1890,6 +1895,13 @@ export interface APIFileUploadComponent extends APIBaseComponent<ComponentType.F
 	 * Maximum number of items that can be uploaded (defaults to 1); max 10
 	 */
 	max_values?: number;
+	/**
+	 * Allowed file types that can be uploaded; max 10
+	 *
+	 * If only dot-prefixed extensions is specified, due to mobile limitation, you must include `.jpg` for image uploads,
+	 * and both `.mp4` and `.mov` for video uploads
+	 */
+	file_types?: FileUploadType[];
 	/**
 	 * Whether the file upload requires files to be uploaded before submitting the modal
 	 *

--- a/payloads/v9/_interactions/_applicationCommands/_chatInput/attachment.ts
+++ b/payloads/v9/_interactions/_applicationCommands/_chatInput/attachment.ts
@@ -2,8 +2,17 @@ import type { Snowflake } from '../../../../../globals';
 import type { APIApplicationCommandOptionBase, APIInteractionDataOptionBase } from './base';
 import type { ApplicationCommandOptionType } from './shared';
 
-export type APIApplicationCommandAttachmentOption =
-	APIApplicationCommandOptionBase<ApplicationCommandOptionType.Attachment>;
+export type FileUploadType = 'audio' | 'image' | 'video' | `.${string}`;
+
+export interface APIApplicationCommandAttachmentOption extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.Attachment> {
+	/**
+	 * Allowed file types that can be uploaded; max 10
+	 *
+	 * If only dot-prefixed extensions is specified, due to mobile limitation, you must include `.jpg` for image uploads,
+	 * and both `.mp4` and `.mov` for video uploads
+	 */
+	file_types?: FileUploadType[];
+}
 
 export type APIApplicationCommandInteractionDataAttachmentOption = APIInteractionDataOptionBase<
 	ApplicationCommandOptionType.Attachment,

--- a/payloads/v9/_interactions/_applicationCommands/_chatInput/attachment.ts
+++ b/payloads/v9/_interactions/_applicationCommands/_chatInput/attachment.ts
@@ -5,12 +5,6 @@ import type { ApplicationCommandOptionType } from './shared';
 export type FileUploadType = 'audio' | 'image' | 'video' | `.${string}`;
 
 export interface APIApplicationCommandAttachmentOption extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.Attachment> {
-	/**
-	 * Allowed file types that can be uploaded; max 10
-	 *
-	 * If only dot-prefixed extensions is specified, due to mobile limitation, you must include `.jpg` for image uploads,
-	 * and both `.mp4` and `.mov` for video uploads
-	 */
 	file_types?: FileUploadType[];
 }
 

--- a/payloads/v9/message.ts
+++ b/payloads/v9/message.ts
@@ -1893,8 +1893,8 @@ export interface APIFileUploadComponent extends APIBaseComponent<ComponentType.F
 	/**
 	 * Allowed file types that can be uploaded; max 10
 	 *
-	 * If only dot-prefixed extensions is specified, due to mobile limitation, you must include `.jpg` for image uploads,
-	 * and both `.mp4` and `.mov` for video uploads
+	 * If only dot-prefixed extensions are specified, you must also include `.jpg` for image uploads
+	 * and both `.mp4` and `.mov` for video uploads because of mobile platform limitations.
 	 */
 	file_types?: FileUploadType[];
 	/**

--- a/payloads/v9/message.ts
+++ b/payloads/v9/message.ts
@@ -5,7 +5,12 @@ import type { _NonNullableFields } from '../../utils/internals';
 import type { APIApplication } from './application';
 import type { APIChannel, APIThreadChannel, APIThreadMember, ChannelType } from './channel';
 import type { APIPartialEmoji } from './emoji';
-import type { APIInteractionDataResolved, APIMessageInteraction, APIMessageInteractionMetadata } from './interactions';
+import type {
+	APIInteractionDataResolved,
+	APIMessageInteraction,
+	APIMessageInteractionMetadata,
+	FileUploadType,
+} from './interactions';
 import type { APIRole } from './permissions';
 import type { APIPoll } from './poll';
 import type { APISticker, APIStickerItem } from './sticker';
@@ -1885,6 +1890,13 @@ export interface APIFileUploadComponent extends APIBaseComponent<ComponentType.F
 	 * Maximum number of items that can be uploaded (defaults to 1); max 10
 	 */
 	max_values?: number;
+	/**
+	 * Allowed file types that can be uploaded; max 10
+	 *
+	 * If only dot-prefixed extensions is specified, due to mobile limitation, you must include `.jpg` for image uploads,
+	 * and both `.mp4` and `.mov` for video uploads
+	 */
+	file_types?: FileUploadType[];
 	/**
 	 * Whether the file upload requires files to be uploaded before submitting the modal
 	 *


### PR DESCRIPTION
**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
ref: https://discord.com/channels/1317206872763404478/1317206872763404481/1518814988721062048