### PR TITLE
feat: new rpc oauth scopes

### DIFF
--- a/deno/payloads/v10/oauth2.ts
+++ b/deno/payloads/v10/oauth2.ts
@@ -89,11 +89,11 @@ export enum OAuth2Scopes {
 	 */
 	RPCVoiceWrite = 'rpc.voice.write',
 	/**
-	 * For local rpc server access, this allows you to read a user's screenshare status- requires Discord approval
+	 * For local rpc server access, this allows you to read a user's screenshare status - requires Discord approval
 	 */
 	RPCScreenshareRead = 'rpc.screenshare.read',
 	/**
-	 * For local rpc server access, this allows you to update a user's screenshare settings- requires Discord approval
+	 * For local rpc server access, this allows you to update a user's screenshare settings - requires Discord approval
 	 */
 	RPCScreenshareWrite = 'rpc.screenshare.write',
 	/**

--- a/deno/payloads/v10/oauth2.ts
+++ b/deno/payloads/v10/oauth2.ts
@@ -89,6 +89,22 @@ export enum OAuth2Scopes {
 	 */
 	RPCVoiceWrite = 'rpc.voice.write',
 	/**
+	 * For local rpc server access, this allows you to read a user's screenshare status- requires Discord approval
+	 */
+	RPCScreenshareRead = 'rpc.screenshare.read',
+	/**
+	 * For local rpc server access, this allows you to update a user's screenshare settings- requires Discord approval
+	 */
+	RPCScreenshareWrite = 'rpc.screenshare.write',
+	/**
+	 * For local rpc server access, this allows you to read a user's video status - requires Discord approval
+	 */
+	RPCVideoRead = 'rpc.video.read',
+	/**
+	 * For local rpc server access, this allows you to update a user's video settings - requires Discord approval
+	 */
+	RPCVideoWrite = 'rpc.video.write',
+	/**
 	 * For local rpc server api access, this allows you to receive notifications pushed out to the user - requires Discord approval
 	 */
 	RPCNotificationsRead = 'rpc.notifications.read',

--- a/payloads/v10/oauth2.ts
+++ b/payloads/v10/oauth2.ts
@@ -89,11 +89,11 @@ export enum OAuth2Scopes {
 	 */
 	RPCVoiceWrite = 'rpc.voice.write',
 	/**
-	 * For local rpc server access, this allows you to read a user's screenshare status- requires Discord approval
+	 * For local rpc server access, this allows you to read a user's screenshare status - requires Discord approval
 	 */
 	RPCScreenshareRead = 'rpc.screenshare.read',
 	/**
-	 * For local rpc server access, this allows you to update a user's screenshare settings- requires Discord approval
+	 * For local rpc server access, this allows you to update a user's screenshare settings - requires Discord approval
 	 */
 	RPCScreenshareWrite = 'rpc.screenshare.write',
 	/**

--- a/payloads/v10/oauth2.ts
+++ b/payloads/v10/oauth2.ts
@@ -89,6 +89,22 @@ export enum OAuth2Scopes {
 	 */
 	RPCVoiceWrite = 'rpc.voice.write',
 	/**
+	 * For local rpc server access, this allows you to read a user's screenshare status- requires Discord approval
+	 */
+	RPCScreenshareRead = 'rpc.screenshare.read',
+	/**
+	 * For local rpc server access, this allows you to update a user's screenshare settings- requires Discord approval
+	 */
+	RPCScreenshareWrite = 'rpc.screenshare.write',
+	/**
+	 * For local rpc server access, this allows you to read a user's video status - requires Discord approval
+	 */
+	RPCVideoRead = 'rpc.video.read',
+	/**
+	 * For local rpc server access, this allows you to update a user's video settings - requires Discord approval
+	 */
+	RPCVideoWrite = 'rpc.video.write',
+	/**
 	 * For local rpc server api access, this allows you to receive notifications pushed out to the user - requires Discord approval
 	 */
 	RPCNotificationsRead = 'rpc.notifications.read',


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Adds 4 RPC oauth scopes:
- `rpc.screenshare.read`
- `rpc.screenshare.write`
- `rpc.video.read`
- `rpc.video.write`

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
~~Found in Discord's OpenAPI spec, will make a PR to docs soon~~
- https://github.com/discord/discord-api-docs/pull/8447