### PR TITLE
feat: Obfuscation

### DIFF
--- a/deno/gateway/v10.ts
+++ b/deno/gateway/v10.ts
@@ -233,6 +233,18 @@ export enum GatewayIntentBits {
 }
 
 /**
+ * @see {@link https://docs.discord.com/developers/events/gateway-events#identify-gateway-capabilities}
+ */
+export enum GatewayCapabilityBits {
+	/**
+	 * Opts the app into receiving obfuscated channel metadata over the Gateway for channels it can't view
+	 *
+	 * @unstable This is a temporary, testing-only opt-in for channel obfuscation.
+	 */
+	ChannelObfuscation = 1 << 15,
+}
+
+/**
  * @see {@link https://discord.com/developers/docs/topics/gateway-events#receive-events}
  */
 export enum GatewayDispatchEvents {
@@ -2528,6 +2540,13 @@ export interface GatewayIdentifyData {
 	 * @see {@link https://discord.com/developers/docs/topics/gateway#gateway-intents}
 	 */
 	intents: number;
+	/**
+	 * Gateway capabilities opt-in bitfield for gateway behaviors
+	 *
+	 * @defaultValue `0`
+	 * @see {@link https://docs.discord.com/developers/events/gateway-events#identify-gateway-capabilities}
+	 */
+	capabilities?: number;
 }
 
 /**

--- a/deno/gateway/v10.ts
+++ b/deno/gateway/v10.ts
@@ -237,9 +237,11 @@ export enum GatewayIntentBits {
  */
 export enum GatewayCapabilityBits {
 	/**
-	 * Opts the app into receiving obfuscated channel metadata over the Gateway for channels it can't view
+	 * Opts the client into receiving {@link https://docs.discord.com/developers/resources/channel#channel-object-obfuscated-channels | obfuscated channel metadata} over the Gateway for channels it can't view
 	 *
-	 * @unstable This is a temporary, testing-only opt-in for channel obfuscation.
+	 * @unstable `CHANNEL_OBFUSCATION` is a temporary, testing-only opt-in for channel obfuscation. This opt-in mechanism
+	 * will change before the feature reaches general availability. Obfuscation is then planned to apply to all bots
+	 * automatically, even when they don't provide this capability.
 	 */
 	ChannelObfuscation = 1 << 15,
 }
@@ -2541,7 +2543,7 @@ export interface GatewayIdentifyData {
 	 */
 	intents: number;
 	/**
-	 * Gateway capabilities opt-in bitfield for gateway behaviors
+	 * Bitfield representing {@link https://docs.discord.com/developers/events/gateway-events#identify-gateway-capabilities | capabilities} of your gateway client
 	 *
 	 * @defaultValue `0`
 	 * @see {@link https://docs.discord.com/developers/events/gateway-events#identify-gateway-capabilities}

--- a/deno/gateway/v9.ts
+++ b/deno/gateway/v9.ts
@@ -232,6 +232,18 @@ export enum GatewayIntentBits {
 }
 
 /**
+ * @see {@link https://docs.discord.com/developers/events/gateway-events#identify-gateway-capabilities}
+ */
+export enum GatewayCapabilityBits {
+	/**
+	 * Opts the app into receiving obfuscated channel metadata over the Gateway for channels it can't view
+	 *
+	 * @unstable This is a temporary, testing-only opt-in for channel obfuscation.
+	 */
+	ChannelObfuscation = 1 << 15,
+}
+
+/**
  * @see {@link https://discord.com/developers/docs/topics/gateway-events#receive-events}
  */
 export enum GatewayDispatchEvents {
@@ -2527,6 +2539,13 @@ export interface GatewayIdentifyData {
 	 * @see {@link https://discord.com/developers/docs/topics/gateway#gateway-intents}
 	 */
 	intents: number;
+	/**
+	 * Gateway capabilities opt-in bitfield for gateway behaviors
+	 *
+	 * @defaultValue `0`
+	 * @see {@link https://docs.discord.com/developers/events/gateway-events#identify-gateway-capabilities}
+	 */
+	capabilities?: number;
 }
 
 /**

--- a/deno/gateway/v9.ts
+++ b/deno/gateway/v9.ts
@@ -236,9 +236,11 @@ export enum GatewayIntentBits {
  */
 export enum GatewayCapabilityBits {
 	/**
-	 * Opts the app into receiving obfuscated channel metadata over the Gateway for channels it can't view
+	 * Opts the client into receiving {@link https://docs.discord.com/developers/resources/channel#channel-object-obfuscated-channels | obfuscated channel metadata} over the Gateway for channels it can't view
 	 *
-	 * @unstable This is a temporary, testing-only opt-in for channel obfuscation.
+	 * @unstable `CHANNEL_OBFUSCATION` is a temporary, testing-only opt-in for channel obfuscation. This opt-in mechanism
+	 * will change before the feature reaches general availability. Obfuscation is then planned to apply to all bots
+	 * automatically, even when they don't provide this capability.
 	 */
 	ChannelObfuscation = 1 << 15,
 }
@@ -2540,7 +2542,7 @@ export interface GatewayIdentifyData {
 	 */
 	intents: number;
 	/**
-	 * Gateway capabilities opt-in bitfield for gateway behaviors
+	 * Bitfield representing {@link https://docs.discord.com/developers/events/gateway-events#identify-gateway-capabilities | capabilities} of your gateway client
 	 *
 	 * @defaultValue `0`
 	 * @see {@link https://docs.discord.com/developers/events/gateway-events#identify-gateway-capabilities}

--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -726,4 +726,11 @@ export enum ChannelFlags {
 	 * Whether media download options are hidden.
 	 */
 	HideMediaDownloadOptions = 1 << 15,
+	/**
+	 * This channel's metadata has been obfuscated because the current app cannot view it. Only ever set on channels
+	 * received over the Gateway; the HTTP API never sets this flag.
+	 *
+	 * @see {@link https://docs.discord.com/developers/resources/channel#channel-object-obfuscated-channels}
+	 */
+	ChannelObfuscated = 1 << 17,
 }

--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -724,10 +724,9 @@ export enum ChannelFlags {
 	 */
 	HideMediaDownloadOptions = 1 << 15,
 	/**
-	 * This channel's metadata has been obfuscated because the current app cannot view it. Only ever set on channels
-	 * received over the Gateway; the HTTP API never sets this flag.
-	 *
-	 * @see {@link https://docs.discord.com/developers/resources/channel#channel-object-obfuscated-channels}
+	 * This channel's metadata has been obfuscated because the current user cannot view it. Only ever set on channels
+	 * received over the {@link https://docs.discord.com/developers/events/gateway | Gateway}; the HTTP API never sets this flag. See
+	 * {@link https://docs.discord.com/developers/resources/channel#channel-object-obfuscated-channels | Obfuscated Channels}.
 	 */
 	ChannelObfuscated = 1 << 17,
 	/**

--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -724,6 +724,13 @@ export enum ChannelFlags {
 	 */
 	HideMediaDownloadOptions = 1 << 15,
 	/**
+	 * This channel's metadata has been obfuscated because the current app cannot view it. Only ever set on channels
+	 * received over the Gateway; the HTTP API never sets this flag.
+	 *
+	 * @see {@link https://docs.discord.com/developers/resources/channel#channel-object-obfuscated-channels}
+	 */
+	ChannelObfuscated = 1 << 17,
+	/**
 	 * This channel is a Spoiler Channel i.e. users must opt in to view its contents.
 	 */
 	IsSpoilerChannel = 1 << 21,

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -725,4 +725,11 @@ export enum ChannelFlags {
 	 * Whether media download options are hidden.
 	 */
 	HideMediaDownloadOptions = 1 << 15,
+	/**
+	 * This channel's metadata has been obfuscated because the current app cannot view it. Only ever set on channels
+	 * received over the Gateway; the HTTP API never sets this flag.
+	 *
+	 * @see {@link https://docs.discord.com/developers/resources/channel#channel-object-obfuscated-channels}
+	 */
+	ChannelObfuscated = 1 << 17,
 }

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -726,10 +726,9 @@ export enum ChannelFlags {
 	 */
 	HideMediaDownloadOptions = 1 << 15,
 	/**
-	 * This channel's metadata has been obfuscated because the current app cannot view it. Only ever set on channels
-	 * received over the Gateway; the HTTP API never sets this flag.
-	 *
-	 * @see {@link https://docs.discord.com/developers/resources/channel#channel-object-obfuscated-channels}
+	 * This channel's metadata has been obfuscated because the current user cannot view it. Only ever set on channels
+	 * received over the {@link https://docs.discord.com/developers/events/gateway | Gateway}; the HTTP API never sets this flag. See
+	 * {@link https://docs.discord.com/developers/resources/channel#channel-object-obfuscated-channels | Obfuscated Channels}.
 	 */
 	ChannelObfuscated = 1 << 17,
 	/**

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -726,6 +726,13 @@ export enum ChannelFlags {
 	 */
 	HideMediaDownloadOptions = 1 << 15,
 	/**
+	 * This channel's metadata has been obfuscated because the current app cannot view it. Only ever set on channels
+	 * received over the Gateway; the HTTP API never sets this flag.
+	 *
+	 * @see {@link https://docs.discord.com/developers/resources/channel#channel-object-obfuscated-channels}
+	 */
+	ChannelObfuscated = 1 << 17,
+	/**
 	 * This channel is a Spoiler Channel i.e. users must opt in to view its contents.
 	 */
 	IsSpoilerChannel = 1 << 21,

--- a/gateway/v10.ts
+++ b/gateway/v10.ts
@@ -233,6 +233,18 @@ export enum GatewayIntentBits {
 }
 
 /**
+ * @see {@link https://docs.discord.com/developers/events/gateway-events#identify-gateway-capabilities}
+ */
+export enum GatewayCapabilityBits {
+	/**
+	 * Opts the app into receiving obfuscated channel metadata over the Gateway for channels it can't view
+	 *
+	 * @unstable This is a temporary, testing-only opt-in for channel obfuscation.
+	 */
+	ChannelObfuscation = 1 << 15,
+}
+
+/**
  * @see {@link https://discord.com/developers/docs/topics/gateway-events#receive-events}
  */
 export enum GatewayDispatchEvents {
@@ -2528,6 +2540,13 @@ export interface GatewayIdentifyData {
 	 * @see {@link https://discord.com/developers/docs/topics/gateway#gateway-intents}
 	 */
 	intents: number;
+	/**
+	 * Gateway capabilities opt-in bitfield for gateway behaviors
+	 *
+	 * @defaultValue `0`
+	 * @see {@link https://docs.discord.com/developers/events/gateway-events#identify-gateway-capabilities}
+	 */
+	capabilities?: number;
 }
 
 /**

--- a/gateway/v10.ts
+++ b/gateway/v10.ts
@@ -237,9 +237,11 @@ export enum GatewayIntentBits {
  */
 export enum GatewayCapabilityBits {
 	/**
-	 * Opts the app into receiving obfuscated channel metadata over the Gateway for channels it can't view
+	 * Opts the client into receiving {@link https://docs.discord.com/developers/resources/channel#channel-object-obfuscated-channels | obfuscated channel metadata} over the Gateway for channels it can't view
 	 *
-	 * @unstable This is a temporary, testing-only opt-in for channel obfuscation.
+	 * @unstable `CHANNEL_OBFUSCATION` is a temporary, testing-only opt-in for channel obfuscation. This opt-in mechanism
+	 * will change before the feature reaches general availability. Obfuscation is then planned to apply to all bots
+	 * automatically, even when they don't provide this capability.
 	 */
 	ChannelObfuscation = 1 << 15,
 }
@@ -2541,7 +2543,7 @@ export interface GatewayIdentifyData {
 	 */
 	intents: number;
 	/**
-	 * Gateway capabilities opt-in bitfield for gateway behaviors
+	 * Bitfield representing {@link https://docs.discord.com/developers/events/gateway-events#identify-gateway-capabilities | capabilities} of your gateway client
 	 *
 	 * @defaultValue `0`
 	 * @see {@link https://docs.discord.com/developers/events/gateway-events#identify-gateway-capabilities}

--- a/gateway/v9.ts
+++ b/gateway/v9.ts
@@ -232,6 +232,18 @@ export enum GatewayIntentBits {
 }
 
 /**
+ * @see {@link https://docs.discord.com/developers/events/gateway-events#identify-gateway-capabilities}
+ */
+export enum GatewayCapabilityBits {
+	/**
+	 * Opts the app into receiving obfuscated channel metadata over the Gateway for channels it can't view
+	 *
+	 * @unstable This is a temporary, testing-only opt-in for channel obfuscation.
+	 */
+	ChannelObfuscation = 1 << 15,
+}
+
+/**
  * @see {@link https://discord.com/developers/docs/topics/gateway-events#receive-events}
  */
 export enum GatewayDispatchEvents {
@@ -2527,6 +2539,13 @@ export interface GatewayIdentifyData {
 	 * @see {@link https://discord.com/developers/docs/topics/gateway#gateway-intents}
 	 */
 	intents: number;
+	/**
+	 * Gateway capabilities opt-in bitfield for gateway behaviors
+	 *
+	 * @defaultValue `0`
+	 * @see {@link https://docs.discord.com/developers/events/gateway-events#identify-gateway-capabilities}
+	 */
+	capabilities?: number;
 }
 
 /**

--- a/gateway/v9.ts
+++ b/gateway/v9.ts
@@ -236,9 +236,11 @@ export enum GatewayIntentBits {
  */
 export enum GatewayCapabilityBits {
 	/**
-	 * Opts the app into receiving obfuscated channel metadata over the Gateway for channels it can't view
+	 * Opts the client into receiving {@link https://docs.discord.com/developers/resources/channel#channel-object-obfuscated-channels | obfuscated channel metadata} over the Gateway for channels it can't view
 	 *
-	 * @unstable This is a temporary, testing-only opt-in for channel obfuscation.
+	 * @unstable `CHANNEL_OBFUSCATION` is a temporary, testing-only opt-in for channel obfuscation. This opt-in mechanism
+	 * will change before the feature reaches general availability. Obfuscation is then planned to apply to all bots
+	 * automatically, even when they don't provide this capability.
 	 */
 	ChannelObfuscation = 1 << 15,
 }
@@ -2540,7 +2542,7 @@ export interface GatewayIdentifyData {
 	 */
 	intents: number;
 	/**
-	 * Gateway capabilities opt-in bitfield for gateway behaviors
+	 * Bitfield representing {@link https://docs.discord.com/developers/events/gateway-events#identify-gateway-capabilities | capabilities} of your gateway client
 	 *
 	 * @defaultValue `0`
 	 * @see {@link https://docs.discord.com/developers/events/gateway-events#identify-gateway-capabilities}

--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -726,4 +726,11 @@ export enum ChannelFlags {
 	 * Whether media download options are hidden.
 	 */
 	HideMediaDownloadOptions = 1 << 15,
+	/**
+	 * This channel's metadata has been obfuscated because the current app cannot view it. Only ever set on channels
+	 * received over the Gateway; the HTTP API never sets this flag.
+	 *
+	 * @see {@link https://docs.discord.com/developers/resources/channel#channel-object-obfuscated-channels}
+	 */
+	ChannelObfuscated = 1 << 17,
 }

--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -724,10 +724,9 @@ export enum ChannelFlags {
 	 */
 	HideMediaDownloadOptions = 1 << 15,
 	/**
-	 * This channel's metadata has been obfuscated because the current app cannot view it. Only ever set on channels
-	 * received over the Gateway; the HTTP API never sets this flag.
-	 *
-	 * @see {@link https://docs.discord.com/developers/resources/channel#channel-object-obfuscated-channels}
+	 * This channel's metadata has been obfuscated because the current user cannot view it. Only ever set on channels
+	 * received over the {@link https://docs.discord.com/developers/events/gateway | Gateway}; the HTTP API never sets this flag. See
+	 * {@link https://docs.discord.com/developers/resources/channel#channel-object-obfuscated-channels | Obfuscated Channels}.
 	 */
 	ChannelObfuscated = 1 << 17,
 	/**

--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -724,6 +724,13 @@ export enum ChannelFlags {
 	 */
 	HideMediaDownloadOptions = 1 << 15,
 	/**
+	 * This channel's metadata has been obfuscated because the current app cannot view it. Only ever set on channels
+	 * received over the Gateway; the HTTP API never sets this flag.
+	 *
+	 * @see {@link https://docs.discord.com/developers/resources/channel#channel-object-obfuscated-channels}
+	 */
+	ChannelObfuscated = 1 << 17,
+	/**
 	 * This channel is a Spoiler Channel i.e. users must opt in to view its contents.
 	 */
 	IsSpoilerChannel = 1 << 21,

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -725,4 +725,11 @@ export enum ChannelFlags {
 	 * Whether media download options are hidden.
 	 */
 	HideMediaDownloadOptions = 1 << 15,
+	/**
+	 * This channel's metadata has been obfuscated because the current app cannot view it. Only ever set on channels
+	 * received over the Gateway; the HTTP API never sets this flag.
+	 *
+	 * @see {@link https://docs.discord.com/developers/resources/channel#channel-object-obfuscated-channels}
+	 */
+	ChannelObfuscated = 1 << 17,
 }

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -726,10 +726,9 @@ export enum ChannelFlags {
 	 */
 	HideMediaDownloadOptions = 1 << 15,
 	/**
-	 * This channel's metadata has been obfuscated because the current app cannot view it. Only ever set on channels
-	 * received over the Gateway; the HTTP API never sets this flag.
-	 *
-	 * @see {@link https://docs.discord.com/developers/resources/channel#channel-object-obfuscated-channels}
+	 * This channel's metadata has been obfuscated because the current user cannot view it. Only ever set on channels
+	 * received over the {@link https://docs.discord.com/developers/events/gateway | Gateway}; the HTTP API never sets this flag. See
+	 * {@link https://docs.discord.com/developers/resources/channel#channel-object-obfuscated-channels | Obfuscated Channels}.
 	 */
 	ChannelObfuscated = 1 << 17,
 	/**

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -726,6 +726,13 @@ export enum ChannelFlags {
 	 */
 	HideMediaDownloadOptions = 1 << 15,
 	/**
+	 * This channel's metadata has been obfuscated because the current app cannot view it. Only ever set on channels
+	 * received over the Gateway; the HTTP API never sets this flag.
+	 *
+	 * @see {@link https://docs.discord.com/developers/resources/channel#channel-object-obfuscated-channels}
+	 */
+	ChannelObfuscated = 1 << 17,
+	/**
 	 * This channel is a Spoiler Channel i.e. users must opt in to view its contents.
 	 */
 	IsSpoilerChannel = 1 << 21,


### PR DESCRIPTION
- https://github.com/discord/discord-api-docs/pull/8454

> [!NOTE]
> `capabilities` was added, but the flag has been marked as `@unstable`.
