### PR TITLE
build(api-extractor): match discord.js

### DIFF
--- a/api-extractor.json
+++ b/api-extractor.json
@@ -30,7 +30,7 @@
 
 				"allowArbitraryExtensions": false,
 				"allowImportingTsExtensions": false,
-				"module": "ESNext",
+				"module": "NodeNext",
 				"moduleResolution": "nodenext",
 				"resolveJsonModule": true,
 				"resolvePackageJsonExports": false,


### PR DESCRIPTION
https://github.com/discordjs/discord.js/pull/11520 caused a TypeScript update for API extractor, which made this repository's configuration cause a mismatch (`NodeNext` must be used with `"moduleResolution": "nodenext"`).

Failing workflow: https://github.com/discordjs/discord-api-types/actions/runs/29007471311
Succeeding workflow from this branch: https://github.com/discordjs/discord-api-types/actions/runs/29009753607