### PR TITLE
feat(APIApplication): `flags_new`

### DIFF
--- a/deno/payloads/v10/application.ts
+++ b/deno/payloads/v10/application.ts
@@ -103,9 +103,15 @@ export interface APIApplication {
 	/**
 	 * The application's public flags
 	 *
-	 * @see {@link https://discord.com/developers/docs/resources/application#application-object-application-flags}
+	 * @see {@link https://docs.discord.com/developers/resources/application#application-object-application-flags}
 	 */
 	flags: ApplicationFlags;
+	/**
+	 * The application's public flags
+	 *
+	 * @see {@link https://docs.discord.com/developers/resources/application#application-object-application-flags}
+	 */
+	flags_new: string;
 	/**
 	 * Approximate count of guilds the application has been added to
 	 */
@@ -175,7 +181,7 @@ export type APIApplicationIntegrationTypesConfigMap = {
 };
 
 /**
- * @see {@link https://discord.com/developers/docs/resources/application#application-object-application-flags}
+ * @see {@link https://docs.discord.com/developers/resources/application#application-object-application-flags}
  */
 export enum ApplicationFlags {
 	/**

--- a/deno/payloads/v9/application.ts
+++ b/deno/payloads/v9/application.ts
@@ -103,9 +103,15 @@ export interface APIApplication {
 	/**
 	 * The application's public flags
 	 *
-	 * @see {@link https://discord.com/developers/docs/resources/application#application-object-application-flags}
+	 * @see {@link https://docs.discord.com/developers/resources/application#application-object-application-flags}
 	 */
 	flags: ApplicationFlags;
+	/**
+	 * The application's public flags
+	 *
+	 * @see {@link https://docs.discord.com/developers/resources/application#application-object-application-flags}
+	 */
+	flags_new: string;
 	/**
 	 * Approximate count of guilds the application has been added to
 	 */
@@ -175,7 +181,7 @@ export type APIApplicationIntegrationTypesConfigMap = {
 };
 
 /**
- * @see {@link https://discord.com/developers/docs/resources/application#application-object-application-flags}
+ * @see {@link https://docs.discord.com/developers/resources/application#application-object-application-flags}
  */
 export enum ApplicationFlags {
 	/**

--- a/payloads/v10/application.ts
+++ b/payloads/v10/application.ts
@@ -103,9 +103,15 @@ export interface APIApplication {
 	/**
 	 * The application's public flags
 	 *
-	 * @see {@link https://discord.com/developers/docs/resources/application#application-object-application-flags}
+	 * @see {@link https://docs.discord.com/developers/resources/application#application-object-application-flags}
 	 */
 	flags: ApplicationFlags;
+	/**
+	 * The application's public flags
+	 *
+	 * @see {@link https://docs.discord.com/developers/resources/application#application-object-application-flags}
+	 */
+	flags_new: string;
 	/**
 	 * Approximate count of guilds the application has been added to
 	 */
@@ -175,7 +181,7 @@ export type APIApplicationIntegrationTypesConfigMap = {
 };
 
 /**
- * @see {@link https://discord.com/developers/docs/resources/application#application-object-application-flags}
+ * @see {@link https://docs.discord.com/developers/resources/application#application-object-application-flags}
  */
 export enum ApplicationFlags {
 	/**

--- a/payloads/v9/application.ts
+++ b/payloads/v9/application.ts
@@ -103,9 +103,15 @@ export interface APIApplication {
 	/**
 	 * The application's public flags
 	 *
-	 * @see {@link https://discord.com/developers/docs/resources/application#application-object-application-flags}
+	 * @see {@link https://docs.discord.com/developers/resources/application#application-object-application-flags}
 	 */
 	flags: ApplicationFlags;
+	/**
+	 * The application's public flags
+	 *
+	 * @see {@link https://docs.discord.com/developers/resources/application#application-object-application-flags}
+	 */
+	flags_new: string;
 	/**
 	 * Approximate count of guilds the application has been added to
 	 */
@@ -175,7 +181,7 @@ export type APIApplicationIntegrationTypesConfigMap = {
 };
 
 /**
- * @see {@link https://discord.com/developers/docs/resources/application#application-object-application-flags}
+ * @see {@link https://docs.discord.com/developers/resources/application#application-object-application-flags}
  */
 export enum ApplicationFlags {
 	/**


### PR DESCRIPTION
- https://github.com/discord/discord-api-docs/pull/8345

This is not added to the table, but per the changelog, it should be.

To sum it up: `flags_new` is returned when fetching and when patching, continue to use the documented `flags` property.