### PR TITLE
feat(GatewayReadyDispatchData): expose `flags_new`

### DIFF
--- a/deno/gateway/v10.ts
+++ b/deno/gateway/v10.ts
@@ -515,11 +515,11 @@ export interface GatewayReadyDispatchData {
 	 */
 	shard?: [shard_id: number, shard_count: number];
 	/**
-	 * Contains `id` and `flags`
+	 * Contains `id`, `flags`, and `flags_new`
 	 *
-	 * @see {@link https://discord.com/developers/docs/resources/application#application-object}
+	 * @see {@link https://docs.discord.com/developers/resources/application#application-object}
 	 */
-	application: Pick<APIApplication, 'flags' | 'id'>;
+	application: Pick<APIApplication, 'flags_new' | 'flags' | 'id'>;
 }
 
 /**

--- a/deno/gateway/v9.ts
+++ b/deno/gateway/v9.ts
@@ -514,11 +514,11 @@ export interface GatewayReadyDispatchData {
 	 */
 	shard?: [shard_id: number, shard_count: number];
 	/**
-	 * Contains `id` and `flags`
+	 * Contains `id`, `flags`, and `flags_new`
 	 *
-	 * @see {@link https://discord.com/developers/docs/resources/application#application-object}
+	 * @see {@link https://docs.discord.com/developers/resources/application#application-object}
 	 */
-	application: Pick<APIApplication, 'flags' | 'id'>;
+	application: Pick<APIApplication, 'flags_new' | 'flags' | 'id'>;
 }
 
 /**

--- a/deno/payloads/v10/application.ts
+++ b/deno/payloads/v10/application.ts
@@ -12,7 +12,7 @@ import type { APIUser } from './user.ts';
 import type { ApplicationWebhookEventType } from './webhook.ts';
 
 /**
- * @see {@link https://discord.com/developers/docs/resources/application#application-object}
+ * @see {@link https://docs.discord.com/developers/resources/application#application-object}
  */
 export interface APIApplication {
 	/**

--- a/deno/payloads/v10/invite.ts
+++ b/deno/payloads/v10/invite.ts
@@ -69,7 +69,7 @@ export interface APIInvite {
 	/**
 	 * The embedded application to open for this voice channel embedded application invite
 	 *
-	 * @see {@link https://discord.com/developers/docs/resources/application#application-object}
+	 * @see {@link https://docs.discord.com/developers/resources/application#application-object}
 	 */
 	target_application?: Partial<APIApplication>;
 	/**

--- a/deno/payloads/v10/message.ts
+++ b/deno/payloads/v10/message.ts
@@ -151,7 +151,7 @@ export interface APIBaseMessageNoChannel {
 	/**
 	 * Sent with Rich Presence-related chat embeds
 	 *
-	 * @see {@link https://discord.com/developers/docs/resources/application#application-object}
+	 * @see {@link https://docs.discord.com/developers/resources/application#application-object}
 	 */
 	application?: Partial<APIApplication>;
 	/**

--- a/deno/payloads/v9/application.ts
+++ b/deno/payloads/v9/application.ts
@@ -12,7 +12,7 @@ import type { APIUser } from './user.ts';
 import type { ApplicationWebhookEventType } from './webhook.ts';
 
 /**
- * @see {@link https://discord.com/developers/docs/resources/application#application-object}
+ * @see {@link https://docs.discord.com/developers/resources/application#application-object}
  */
 export interface APIApplication {
 	/**

--- a/deno/payloads/v9/invite.ts
+++ b/deno/payloads/v9/invite.ts
@@ -69,7 +69,7 @@ export interface APIInvite {
 	/**
 	 * The embedded application to open for this voice channel embedded application invite
 	 *
-	 * @see {@link https://discord.com/developers/docs/resources/application#application-object}
+	 * @see {@link https://docs.discord.com/developers/resources/application#application-object}
 	 */
 	target_application?: Partial<APIApplication>;
 	/**

--- a/deno/payloads/v9/message.ts
+++ b/deno/payloads/v9/message.ts
@@ -148,7 +148,7 @@ export interface APIBaseMessageNoChannel {
 	/**
 	 * Sent with Rich Presence-related chat embeds
 	 *
-	 * @see {@link https://discord.com/developers/docs/resources/application#application-object}
+	 * @see {@link https://docs.discord.com/developers/resources/application#application-object}
 	 */
 	application?: Partial<APIApplication>;
 	/**

--- a/gateway/v10.ts
+++ b/gateway/v10.ts
@@ -515,11 +515,11 @@ export interface GatewayReadyDispatchData {
 	 */
 	shard?: [shard_id: number, shard_count: number];
 	/**
-	 * Contains `id` and `flags`
+	 * Contains `id`, `flags`, and `flags_new`
 	 *
-	 * @see {@link https://discord.com/developers/docs/resources/application#application-object}
+	 * @see {@link https://docs.discord.com/developers/resources/application#application-object}
 	 */
-	application: Pick<APIApplication, 'flags' | 'id'>;
+	application: Pick<APIApplication, 'flags_new' | 'flags' | 'id'>;
 }
 
 /**

--- a/gateway/v9.ts
+++ b/gateway/v9.ts
@@ -514,11 +514,11 @@ export interface GatewayReadyDispatchData {
 	 */
 	shard?: [shard_id: number, shard_count: number];
 	/**
-	 * Contains `id` and `flags`
+	 * Contains `id`, `flags`, and `flags_new`
 	 *
-	 * @see {@link https://discord.com/developers/docs/resources/application#application-object}
+	 * @see {@link https://docs.discord.com/developers/resources/application#application-object}
 	 */
-	application: Pick<APIApplication, 'flags' | 'id'>;
+	application: Pick<APIApplication, 'flags_new' | 'flags' | 'id'>;
 }
 
 /**

--- a/payloads/v10/application.ts
+++ b/payloads/v10/application.ts
@@ -12,7 +12,7 @@ import type { APIUser } from './user';
 import type { ApplicationWebhookEventType } from './webhook';
 
 /**
- * @see {@link https://discord.com/developers/docs/resources/application#application-object}
+ * @see {@link https://docs.discord.com/developers/resources/application#application-object}
  */
 export interface APIApplication {
 	/**

--- a/payloads/v10/invite.ts
+++ b/payloads/v10/invite.ts
@@ -69,7 +69,7 @@ export interface APIInvite {
 	/**
 	 * The embedded application to open for this voice channel embedded application invite
 	 *
-	 * @see {@link https://discord.com/developers/docs/resources/application#application-object}
+	 * @see {@link https://docs.discord.com/developers/resources/application#application-object}
 	 */
 	target_application?: Partial<APIApplication>;
 	/**

--- a/payloads/v10/message.ts
+++ b/payloads/v10/message.ts
@@ -151,7 +151,7 @@ export interface APIBaseMessageNoChannel {
 	/**
 	 * Sent with Rich Presence-related chat embeds
 	 *
-	 * @see {@link https://discord.com/developers/docs/resources/application#application-object}
+	 * @see {@link https://docs.discord.com/developers/resources/application#application-object}
 	 */
 	application?: Partial<APIApplication>;
 	/**

--- a/payloads/v9/application.ts
+++ b/payloads/v9/application.ts
@@ -12,7 +12,7 @@ import type { APIUser } from './user';
 import type { ApplicationWebhookEventType } from './webhook';
 
 /**
- * @see {@link https://discord.com/developers/docs/resources/application#application-object}
+ * @see {@link https://docs.discord.com/developers/resources/application#application-object}
  */
 export interface APIApplication {
 	/**

--- a/payloads/v9/invite.ts
+++ b/payloads/v9/invite.ts
@@ -69,7 +69,7 @@ export interface APIInvite {
 	/**
 	 * The embedded application to open for this voice channel embedded application invite
 	 *
-	 * @see {@link https://discord.com/developers/docs/resources/application#application-object}
+	 * @see {@link https://docs.discord.com/developers/resources/application#application-object}
 	 */
 	target_application?: Partial<APIApplication>;
 	/**

--- a/payloads/v9/message.ts
+++ b/payloads/v9/message.ts
@@ -148,7 +148,7 @@ export interface APIBaseMessageNoChannel {
 	/**
 	 * Sent with Rich Presence-related chat embeds
 	 *
-	 * @see {@link https://discord.com/developers/docs/resources/application#application-object}
+	 * @see {@link https://docs.discord.com/developers/resources/application#application-object}
 	 */
 	application?: Partial<APIApplication>;
 	/**


### PR DESCRIPTION
- https://github.com/discord/discord-api-docs/pull/8486

This is already observed too. Additionally, the URL was updated.