### PR TITLE
refactor(APIGroupDMChannel): mark `application_id` as nullable

### DIFF
--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -215,9 +215,9 @@ export interface APIGroupDMChannel extends APIDMChannelBase<ChannelType.GroupDM>
 	 */
 	name: string | null;
 	/**
-	 * Application id of the group DM creator if it is bot-created
+	 * Application id associated with the channel. For group DMs, this is the application that created the group
 	 */
-	application_id?: Snowflake;
+	application_id?: Snowflake | null;
 	/**
 	 * Icon hash
 	 */

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -210,9 +210,9 @@ export interface APIGroupDMChannel extends APIDMChannelBase<ChannelType.GroupDM>
 	 */
 	name: string | null;
 	/**
-	 * Application id of the group DM creator if it is bot-created
+	 * Application id associated with the channel. For group DMs, this is the application that created the group
 	 */
-	application_id?: Snowflake;
+	application_id?: Snowflake | null;
 	/**
 	 * Icon hash
 	 */

--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -215,9 +215,9 @@ export interface APIGroupDMChannel extends APIDMChannelBase<ChannelType.GroupDM>
 	 */
 	name: string | null;
 	/**
-	 * Application id of the group DM creator if it is bot-created
+	 * Application id associated with the channel. For group DMs, this is the application that created the group
 	 */
-	application_id?: Snowflake;
+	application_id?: Snowflake | null;
 	/**
 	 * Icon hash
 	 */

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -210,9 +210,9 @@ export interface APIGroupDMChannel extends APIDMChannelBase<ChannelType.GroupDM>
 	 */
 	name: string | null;
 	/**
-	 * Application id of the group DM creator if it is bot-created
+	 * Application id associated with the channel. For group DMs, this is the application that created the group
 	 */
-	application_id?: Snowflake;
+	application_id?: Snowflake | null;
 	/**
 	 * Icon hash
 	 */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Mark channel `application_id` as nullable.

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
- https://github.com/discord/discord-api-docs/pull/8507