### PR TITLE
fix: allow DM channels on ChannelOption channel_type

### DIFF
--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -75,10 +75,7 @@ export type TextChannelType =
 
 export type GuildChannelType = Exclude<ChannelType, ChannelType.DM | ChannelType.GroupDM>;
 
-export type ApplicationCommandOptionAllowedChannelType = Exclude<
-	ChannelType,
-	ChannelType.DM | ChannelType.GroupDM | ChannelType.GuildDirectory
->;
+export type ApplicationCommandOptionAllowedChannelType = Exclude<ChannelType, ChannelType.GuildDirectory>;
 
 export interface APISlowmodeChannel<T extends ChannelType> extends APIChannelBase<T> {
 	/**

--- a/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/channel.ts
+++ b/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/channel.ts
@@ -4,7 +4,7 @@ import type { APIApplicationCommandOptionBase, APIInteractionDataOptionBase } fr
 import type { ApplicationCommandOptionType } from './shared.ts';
 
 export interface APIApplicationCommandChannelOption extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.Channel> {
-	channel_types?: Exclude<ChannelType, ChannelType.DM | ChannelType.GroupDM | ChannelType.GuildDirectory>[];
+	channel_types?: Exclude<ChannelType, ChannelType.GuildDirectory>[];
 }
 
 export type APIApplicationCommandInteractionDataChannelOption = APIInteractionDataOptionBase<

--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -75,10 +75,7 @@ export type TextChannelType =
 
 export type GuildChannelType = Exclude<ChannelType, ChannelType.DM | ChannelType.GroupDM>;
 
-export type ApplicationCommandOptionAllowedChannelType = Exclude<
-	ChannelType,
-	ChannelType.DM | ChannelType.GroupDM | ChannelType.GuildDirectory
->;
+export type ApplicationCommandOptionAllowedChannelType = Exclude<ChannelType, ChannelType.GuildDirectory>;
 
 export interface APISlowmodeChannel<T extends ChannelType> extends APIChannelBase<T> {
 	/**

--- a/payloads/v9/_interactions/_applicationCommands/_chatInput/channel.ts
+++ b/payloads/v9/_interactions/_applicationCommands/_chatInput/channel.ts
@@ -4,7 +4,7 @@ import type { APIApplicationCommandOptionBase, APIInteractionDataOptionBase } fr
 import type { ApplicationCommandOptionType } from './shared';
 
 export interface APIApplicationCommandChannelOption extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.Channel> {
-	channel_types?: Exclude<ChannelType, ChannelType.DM | ChannelType.GroupDM | ChannelType.GuildDirectory>[];
+	channel_types?: Exclude<ChannelType, ChannelType.GuildDirectory>[];
 }
 
 export type APIApplicationCommandInteractionDataChannelOption = APIInteractionDataOptionBase<


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

ChannelOptions on ChatInputApplicationCommands actually allow `ChannelType.DM` and `ChannelType.GroupDM` in `channel_types` since they can be run in those kinds of channels as user  installed apps.

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**

See https://github.com/discordjs/discord.js/pull/11380 for details