### PR TITLE
feat(Rpc): add RPCOpcodes

### DIFF
--- a/deno/rpc/v10.ts
+++ b/deno/rpc/v10.ts
@@ -32,6 +32,32 @@ export * from './common.ts';
 export const RPCVersion = '1';
 
 /**
+ * @see {@link https://docs.discord.com/developers/topics/rpc#handshake-payload}
+ */
+export enum RPCOpcodes {
+	/**
+	 * Sent by the client to initiate the connection.
+	 */
+	Handshake,
+	/**
+	 * Used for all standard RPC commands and events.
+	 */
+	Frame,
+	/**
+	 * Sent by either side to close the connection.
+	 */
+	Close,
+	/**
+	 * Sent to check if the connection is alive.
+	 */
+	Ping,
+	/**
+	 * Response to a `PING`.
+	 */
+	Pong,
+}
+
+/**
  * @unstable
  */
 export interface Relationship {

--- a/rpc/v10.ts
+++ b/rpc/v10.ts
@@ -32,6 +32,32 @@ export * from './common';
 export const RPCVersion = '1';
 
 /**
+ * @see {@link https://docs.discord.com/developers/topics/rpc#handshake-payload}
+ */
+export enum RPCOpcodes {
+	/**
+	 * Sent by the client to initiate the connection.
+	 */
+	Handshake,
+	/**
+	 * Used for all standard RPC commands and events.
+	 */
+	Frame,
+	/**
+	 * Sent by either side to close the connection.
+	 */
+	Close,
+	/**
+	 * Sent to check if the connection is alive.
+	 */
+	Ping,
+	/**
+	 * Response to a `PING`.
+	 */
+	Pong,
+}
+
+/**
  * @unstable
  */
 export interface Relationship {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds the RPCOpcodes enum, containing the opcodes used by Discord's RPC API.
This provides typed constants for RPC opcodes and makes them easier to use consistently across the library.

**If applicable, please reference Discord API Docs PRs or commits that influenced this PR:**
- https://github.com/discord/discord-api-docs/pull/8246