### PR TITLE
fix(interactions): omit respective properties

### DIFF
--- a/deno/rest/v10/interactions.ts
+++ b/deno/rest/v10/interactions.ts
@@ -135,52 +135,67 @@ export type RESTGetAPIApplicationGuildCommandsQuery = RESTGetAPIApplicationComma
 /**
  * @see {@link https://discord.com/developers/docs/interactions/application-commands#get-guild-application-commands}
  */
-export type RESTGetAPIApplicationGuildCommandsResult = Omit<APIApplicationCommand, 'dm_permission'>[];
+export type RESTGetAPIApplicationGuildCommandsResult = Omit<
+	APIApplicationCommand,
+	'contexts' | 'dm_permission' | 'integration_types'
+>[];
 
 /**
  * @see {@link https://discord.com/developers/docs/interactions/application-commands#get-guild-application-commands}
  */
-export type RESTGetAPIApplicationGuildCommandResult = Omit<APIApplicationCommand, 'dm_permission'>;
+export type RESTGetAPIApplicationGuildCommandResult = Omit<
+	APIApplicationCommand,
+	'contexts' | 'dm_permission' | 'integration_types'
+>;
 
 /**
  * @see {@link https://discord.com/developers/docs/interactions/application-commands#create-guild-application-command}
  */
 export type RESTPostAPIApplicationGuildCommandsJSONBody =
-	| Omit<RESTPostAPIChatInputApplicationCommandsJSONBody, 'dm_permission'>
-	| Omit<RESTPostAPIContextMenuApplicationCommandsJSONBody, 'dm_permission'>;
+	| Omit<RESTPostAPIChatInputApplicationCommandsJSONBody, 'contexts' | 'dm_permission' | 'integration_types'>
+	| Omit<RESTPostAPIContextMenuApplicationCommandsJSONBody, 'contexts' | 'dm_permission' | 'integration_types'>;
 
 /**
  * @see {@link https://discord.com/developers/docs/interactions/application-commands#create-guild-application-command}
  */
-export type RESTPostAPIApplicationGuildCommandsResult = Omit<APIApplicationCommand, 'dm_permission'>;
-
-/**
- * @see {@link https://discord.com/developers/docs/interactions/application-commands#edit-guild-application-command}
- */
-export type RESTPatchAPIApplicationGuildCommandJSONBody = _StrictPartial<
-	| Omit<RESTPostAPIChatInputApplicationCommandsJSONBody, 'dm_permission'>
-	| Omit<RESTPostAPIContextMenuApplicationCommandsJSONBody, 'dm_permission'>
+export type RESTPostAPIApplicationGuildCommandsResult = Omit<
+	APIApplicationCommand,
+	'contexts' | 'dm_permission' | 'integration_types'
 >;
 
 /**
  * @see {@link https://discord.com/developers/docs/interactions/application-commands#edit-guild-application-command}
  */
-export type RESTPatchAPIApplicationGuildCommandResult = Omit<APIApplicationCommand, 'dm_permission'>;
+export type RESTPatchAPIApplicationGuildCommandJSONBody = _StrictPartial<
+	| Omit<RESTPostAPIChatInputApplicationCommandsJSONBody, 'contexts' | 'dm_permission' | 'integration_types'>
+	| Omit<RESTPostAPIContextMenuApplicationCommandsJSONBody, 'contexts' | 'dm_permission' | 'integration_types'>
+>;
+
+/**
+ * @see {@link https://discord.com/developers/docs/interactions/application-commands#edit-guild-application-command}
+ */
+export type RESTPatchAPIApplicationGuildCommandResult = Omit<
+	APIApplicationCommand,
+	'contexts' | 'dm_permission' | 'integration_types'
+>;
 
 /**
  * @see {@link https://discord.com/developers/docs/interactions/application-commands#bulk-overwrite-guild-application-commands}
  */
 export type RESTPutAPIApplicationGuildCommandsJSONBody = (
-	| (Omit<RESTPostAPIChatInputApplicationCommandsJSONBody, 'dm_permission'> &
+	| (Omit<RESTPostAPIChatInputApplicationCommandsJSONBody, 'contexts' | 'dm_permission' | 'integration_types'> &
 			Pick<Partial<APIApplicationCommand>, 'id'>)
-	| (Omit<RESTPostAPIContextMenuApplicationCommandsJSONBody, 'dm_permission'> &
+	| (Omit<RESTPostAPIContextMenuApplicationCommandsJSONBody, 'contexts' | 'dm_permission' | 'integration_types'> &
 			Pick<Partial<APIApplicationCommand>, 'id'>)
 )[];
 
 /**
  * @see {@link https://discord.com/developers/docs/interactions/application-commands#bulk-overwrite-guild-application-commands}
  */
-export type RESTPutAPIApplicationGuildCommandsResult = Omit<APIApplicationCommand, 'dm_permission'>[];
+export type RESTPutAPIApplicationGuildCommandsResult = Omit<
+	APIApplicationCommand,
+	'contexts' | 'dm_permission' | 'integration_types'
+>[];
 
 /**
  * @see {@link https://discord.com/developers/docs/interactions/receiving-and-responding#create-interaction-response}

--- a/deno/rest/v9/interactions.ts
+++ b/deno/rest/v9/interactions.ts
@@ -135,52 +135,67 @@ export type RESTGetAPIApplicationGuildCommandsQuery = RESTGetAPIApplicationComma
 /**
  * @see {@link https://discord.com/developers/docs/interactions/application-commands#get-guild-application-commands}
  */
-export type RESTGetAPIApplicationGuildCommandsResult = Omit<APIApplicationCommand, 'dm_permission'>[];
+export type RESTGetAPIApplicationGuildCommandsResult = Omit<
+	APIApplicationCommand,
+	'contexts' | 'dm_permission' | 'integration_types'
+>[];
 
 /**
  * @see {@link https://discord.com/developers/docs/interactions/application-commands#get-guild-application-commands}
  */
-export type RESTGetAPIApplicationGuildCommandResult = Omit<APIApplicationCommand, 'dm_permission'>;
+export type RESTGetAPIApplicationGuildCommandResult = Omit<
+	APIApplicationCommand,
+	'contexts' | 'dm_permission' | 'integration_types'
+>;
 
 /**
  * @see {@link https://discord.com/developers/docs/interactions/application-commands#create-guild-application-command}
  */
 export type RESTPostAPIApplicationGuildCommandsJSONBody =
-	| Omit<RESTPostAPIChatInputApplicationCommandsJSONBody, 'dm_permission'>
-	| Omit<RESTPostAPIContextMenuApplicationCommandsJSONBody, 'dm_permission'>;
+	| Omit<RESTPostAPIChatInputApplicationCommandsJSONBody, 'contexts' | 'dm_permission' | 'integration_types'>
+	| Omit<RESTPostAPIContextMenuApplicationCommandsJSONBody, 'contexts' | 'dm_permission' | 'integration_types'>;
 
 /**
  * @see {@link https://discord.com/developers/docs/interactions/application-commands#create-guild-application-command}
  */
-export type RESTPostAPIApplicationGuildCommandsResult = Omit<APIApplicationCommand, 'dm_permission'>;
-
-/**
- * @see {@link https://discord.com/developers/docs/interactions/application-commands#edit-guild-application-command}
- */
-export type RESTPatchAPIApplicationGuildCommandJSONBody = _StrictPartial<
-	| Omit<RESTPostAPIChatInputApplicationCommandsJSONBody, 'dm_permission'>
-	| Omit<RESTPostAPIContextMenuApplicationCommandsJSONBody, 'dm_permission'>
+export type RESTPostAPIApplicationGuildCommandsResult = Omit<
+	APIApplicationCommand,
+	'contexts' | 'dm_permission' | 'integration_types'
 >;
 
 /**
  * @see {@link https://discord.com/developers/docs/interactions/application-commands#edit-guild-application-command}
  */
-export type RESTPatchAPIApplicationGuildCommandResult = Omit<APIApplicationCommand, 'dm_permission'>;
+export type RESTPatchAPIApplicationGuildCommandJSONBody = _StrictPartial<
+	| Omit<RESTPostAPIChatInputApplicationCommandsJSONBody, 'contexts' | 'dm_permission' | 'integration_types'>
+	| Omit<RESTPostAPIContextMenuApplicationCommandsJSONBody, 'contexts' | 'dm_permission' | 'integration_types'>
+>;
+
+/**
+ * @see {@link https://discord.com/developers/docs/interactions/application-commands#edit-guild-application-command}
+ */
+export type RESTPatchAPIApplicationGuildCommandResult = Omit<
+	APIApplicationCommand,
+	'contexts' | 'dm_permission' | 'integration_types'
+>;
 
 /**
  * @see {@link https://discord.com/developers/docs/interactions/application-commands#bulk-overwrite-guild-application-commands}
  */
 export type RESTPutAPIApplicationGuildCommandsJSONBody = (
-	| (Omit<RESTPostAPIChatInputApplicationCommandsJSONBody, 'dm_permission'> &
+	| (Omit<RESTPostAPIChatInputApplicationCommandsJSONBody, 'contexts' | 'dm_permission' | 'integration_types'> &
 			Pick<Partial<APIApplicationCommand>, 'id'>)
-	| (Omit<RESTPostAPIContextMenuApplicationCommandsJSONBody, 'dm_permission'> &
+	| (Omit<RESTPostAPIContextMenuApplicationCommandsJSONBody, 'contexts' | 'dm_permission' | 'integration_types'> &
 			Pick<Partial<APIApplicationCommand>, 'id'>)
 )[];
 
 /**
  * @see {@link https://discord.com/developers/docs/interactions/application-commands#bulk-overwrite-guild-application-commands}
  */
-export type RESTPutAPIApplicationGuildCommandsResult = Omit<APIApplicationCommand, 'dm_permission'>[];
+export type RESTPutAPIApplicationGuildCommandsResult = Omit<
+	APIApplicationCommand,
+	'contexts' | 'dm_permission' | 'integration_types'
+>[];
 
 /**
  * @see {@link https://discord.com/developers/docs/interactions/receiving-and-responding#create-interaction-response}

--- a/rest/v10/interactions.ts
+++ b/rest/v10/interactions.ts
@@ -135,52 +135,67 @@ export type RESTGetAPIApplicationGuildCommandsQuery = RESTGetAPIApplicationComma
 /**
  * @see {@link https://discord.com/developers/docs/interactions/application-commands#get-guild-application-commands}
  */
-export type RESTGetAPIApplicationGuildCommandsResult = Omit<APIApplicationCommand, 'dm_permission'>[];
+export type RESTGetAPIApplicationGuildCommandsResult = Omit<
+	APIApplicationCommand,
+	'contexts' | 'dm_permission' | 'integration_types'
+>[];
 
 /**
  * @see {@link https://discord.com/developers/docs/interactions/application-commands#get-guild-application-commands}
  */
-export type RESTGetAPIApplicationGuildCommandResult = Omit<APIApplicationCommand, 'dm_permission'>;
+export type RESTGetAPIApplicationGuildCommandResult = Omit<
+	APIApplicationCommand,
+	'contexts' | 'dm_permission' | 'integration_types'
+>;
 
 /**
  * @see {@link https://discord.com/developers/docs/interactions/application-commands#create-guild-application-command}
  */
 export type RESTPostAPIApplicationGuildCommandsJSONBody =
-	| Omit<RESTPostAPIChatInputApplicationCommandsJSONBody, 'dm_permission'>
-	| Omit<RESTPostAPIContextMenuApplicationCommandsJSONBody, 'dm_permission'>;
+	| Omit<RESTPostAPIChatInputApplicationCommandsJSONBody, 'contexts' | 'dm_permission' | 'integration_types'>
+	| Omit<RESTPostAPIContextMenuApplicationCommandsJSONBody, 'contexts' | 'dm_permission' | 'integration_types'>;
 
 /**
  * @see {@link https://discord.com/developers/docs/interactions/application-commands#create-guild-application-command}
  */
-export type RESTPostAPIApplicationGuildCommandsResult = Omit<APIApplicationCommand, 'dm_permission'>;
-
-/**
- * @see {@link https://discord.com/developers/docs/interactions/application-commands#edit-guild-application-command}
- */
-export type RESTPatchAPIApplicationGuildCommandJSONBody = _StrictPartial<
-	| Omit<RESTPostAPIChatInputApplicationCommandsJSONBody, 'dm_permission'>
-	| Omit<RESTPostAPIContextMenuApplicationCommandsJSONBody, 'dm_permission'>
+export type RESTPostAPIApplicationGuildCommandsResult = Omit<
+	APIApplicationCommand,
+	'contexts' | 'dm_permission' | 'integration_types'
 >;
 
 /**
  * @see {@link https://discord.com/developers/docs/interactions/application-commands#edit-guild-application-command}
  */
-export type RESTPatchAPIApplicationGuildCommandResult = Omit<APIApplicationCommand, 'dm_permission'>;
+export type RESTPatchAPIApplicationGuildCommandJSONBody = _StrictPartial<
+	| Omit<RESTPostAPIChatInputApplicationCommandsJSONBody, 'contexts' | 'dm_permission' | 'integration_types'>
+	| Omit<RESTPostAPIContextMenuApplicationCommandsJSONBody, 'contexts' | 'dm_permission' | 'integration_types'>
+>;
+
+/**
+ * @see {@link https://discord.com/developers/docs/interactions/application-commands#edit-guild-application-command}
+ */
+export type RESTPatchAPIApplicationGuildCommandResult = Omit<
+	APIApplicationCommand,
+	'contexts' | 'dm_permission' | 'integration_types'
+>;
 
 /**
  * @see {@link https://discord.com/developers/docs/interactions/application-commands#bulk-overwrite-guild-application-commands}
  */
 export type RESTPutAPIApplicationGuildCommandsJSONBody = (
-	| (Omit<RESTPostAPIChatInputApplicationCommandsJSONBody, 'dm_permission'> &
+	| (Omit<RESTPostAPIChatInputApplicationCommandsJSONBody, 'contexts' | 'dm_permission' | 'integration_types'> &
 			Pick<Partial<APIApplicationCommand>, 'id'>)
-	| (Omit<RESTPostAPIContextMenuApplicationCommandsJSONBody, 'dm_permission'> &
+	| (Omit<RESTPostAPIContextMenuApplicationCommandsJSONBody, 'contexts' | 'dm_permission' | 'integration_types'> &
 			Pick<Partial<APIApplicationCommand>, 'id'>)
 )[];
 
 /**
  * @see {@link https://discord.com/developers/docs/interactions/application-commands#bulk-overwrite-guild-application-commands}
  */
-export type RESTPutAPIApplicationGuildCommandsResult = Omit<APIApplicationCommand, 'dm_permission'>[];
+export type RESTPutAPIApplicationGuildCommandsResult = Omit<
+	APIApplicationCommand,
+	'contexts' | 'dm_permission' | 'integration_types'
+>[];
 
 /**
  * @see {@link https://discord.com/developers/docs/interactions/receiving-and-responding#create-interaction-response}

--- a/rest/v9/interactions.ts
+++ b/rest/v9/interactions.ts
@@ -135,52 +135,67 @@ export type RESTGetAPIApplicationGuildCommandsQuery = RESTGetAPIApplicationComma
 /**
  * @see {@link https://discord.com/developers/docs/interactions/application-commands#get-guild-application-commands}
  */
-export type RESTGetAPIApplicationGuildCommandsResult = Omit<APIApplicationCommand, 'dm_permission'>[];
+export type RESTGetAPIApplicationGuildCommandsResult = Omit<
+	APIApplicationCommand,
+	'contexts' | 'dm_permission' | 'integration_types'
+>[];
 
 /**
  * @see {@link https://discord.com/developers/docs/interactions/application-commands#get-guild-application-commands}
  */
-export type RESTGetAPIApplicationGuildCommandResult = Omit<APIApplicationCommand, 'dm_permission'>;
+export type RESTGetAPIApplicationGuildCommandResult = Omit<
+	APIApplicationCommand,
+	'contexts' | 'dm_permission' | 'integration_types'
+>;
 
 /**
  * @see {@link https://discord.com/developers/docs/interactions/application-commands#create-guild-application-command}
  */
 export type RESTPostAPIApplicationGuildCommandsJSONBody =
-	| Omit<RESTPostAPIChatInputApplicationCommandsJSONBody, 'dm_permission'>
-	| Omit<RESTPostAPIContextMenuApplicationCommandsJSONBody, 'dm_permission'>;
+	| Omit<RESTPostAPIChatInputApplicationCommandsJSONBody, 'contexts' | 'dm_permission' | 'integration_types'>
+	| Omit<RESTPostAPIContextMenuApplicationCommandsJSONBody, 'contexts' | 'dm_permission' | 'integration_types'>;
 
 /**
  * @see {@link https://discord.com/developers/docs/interactions/application-commands#create-guild-application-command}
  */
-export type RESTPostAPIApplicationGuildCommandsResult = Omit<APIApplicationCommand, 'dm_permission'>;
-
-/**
- * @see {@link https://discord.com/developers/docs/interactions/application-commands#edit-guild-application-command}
- */
-export type RESTPatchAPIApplicationGuildCommandJSONBody = _StrictPartial<
-	| Omit<RESTPostAPIChatInputApplicationCommandsJSONBody, 'dm_permission'>
-	| Omit<RESTPostAPIContextMenuApplicationCommandsJSONBody, 'dm_permission'>
+export type RESTPostAPIApplicationGuildCommandsResult = Omit<
+	APIApplicationCommand,
+	'contexts' | 'dm_permission' | 'integration_types'
 >;
 
 /**
  * @see {@link https://discord.com/developers/docs/interactions/application-commands#edit-guild-application-command}
  */
-export type RESTPatchAPIApplicationGuildCommandResult = Omit<APIApplicationCommand, 'dm_permission'>;
+export type RESTPatchAPIApplicationGuildCommandJSONBody = _StrictPartial<
+	| Omit<RESTPostAPIChatInputApplicationCommandsJSONBody, 'contexts' | 'dm_permission' | 'integration_types'>
+	| Omit<RESTPostAPIContextMenuApplicationCommandsJSONBody, 'contexts' | 'dm_permission' | 'integration_types'>
+>;
+
+/**
+ * @see {@link https://discord.com/developers/docs/interactions/application-commands#edit-guild-application-command}
+ */
+export type RESTPatchAPIApplicationGuildCommandResult = Omit<
+	APIApplicationCommand,
+	'contexts' | 'dm_permission' | 'integration_types'
+>;
 
 /**
  * @see {@link https://discord.com/developers/docs/interactions/application-commands#bulk-overwrite-guild-application-commands}
  */
 export type RESTPutAPIApplicationGuildCommandsJSONBody = (
-	| (Omit<RESTPostAPIChatInputApplicationCommandsJSONBody, 'dm_permission'> &
+	| (Omit<RESTPostAPIChatInputApplicationCommandsJSONBody, 'contexts' | 'dm_permission' | 'integration_types'> &
 			Pick<Partial<APIApplicationCommand>, 'id'>)
-	| (Omit<RESTPostAPIContextMenuApplicationCommandsJSONBody, 'dm_permission'> &
+	| (Omit<RESTPostAPIContextMenuApplicationCommandsJSONBody, 'contexts' | 'dm_permission' | 'integration_types'> &
 			Pick<Partial<APIApplicationCommand>, 'id'>)
 )[];
 
 /**
  * @see {@link https://discord.com/developers/docs/interactions/application-commands#bulk-overwrite-guild-application-commands}
  */
-export type RESTPutAPIApplicationGuildCommandsResult = Omit<APIApplicationCommand, 'dm_permission'>[];
+export type RESTPutAPIApplicationGuildCommandsResult = Omit<
+	APIApplicationCommand,
+	'contexts' | 'dm_permission' | 'integration_types'
+>[];
 
 /**
  * @see {@link https://discord.com/developers/docs/interactions/receiving-and-responding#create-interaction-response}


### PR DESCRIPTION
Observed in the API and written in the documentation, `contexts` and `integration_types` should be removed from guild types.

Resolves #1776.