### PR TITLE
fix: correct `available_tags` types

### DIFF
--- a/deno/payloads/v10/channel.ts
+++ b/deno/payloads/v10/channel.ts
@@ -283,7 +283,7 @@ export type APIPrivateThreadChannel = APIThreadChannel<ChannelType.PrivateThread
 export type APIAnnouncementThreadChannel = APIThreadChannel<ChannelType.AnnouncementThread>;
 
 /**
- * @see {@link https://discord.com/developers/docs/resources/channel#forum-tag-object-forum-tag-structure}
+ * @see {@link https://docs.discord.com/developers/resources/channel#forum-tag-object}
  */
 export interface APIGuildForumTag {
 	/**

--- a/deno/payloads/v9/channel.ts
+++ b/deno/payloads/v9/channel.ts
@@ -278,7 +278,7 @@ export type APIPrivateThreadChannel = APIThreadChannel<ChannelType.PrivateThread
 export type APIAnnouncementThreadChannel = APIThreadChannel<ChannelType.AnnouncementThread>;
 
 /**
- * @see {@link https://discord.com/developers/docs/resources/channel#forum-tag-object-forum-tag-structure}
+ * @see {@link https://docs.discord.com/developers/resources/channel#forum-tag-object}
  */
 export interface APIGuildForumTag {
 	/**

--- a/deno/rest/v10/channel.ts
+++ b/deno/rest/v10/channel.ts
@@ -42,12 +42,27 @@ export interface RESTAPIChannelPatchOverwrite extends RESTPutAPIChannelPermissio
 export type APIChannelPatchOverwrite = RESTAPIChannelPatchOverwrite;
 
 /**
+ * A forum tag in a create channel request.
+ *
+ * @see {@link https://docs.discord.com/developers/resources/channel#forum-tag-object}
+ */
+export type RESTPostAPIGuildChannelForumTagJSONBody = _StrictPartial<Omit<APIGuildForumTag, 'id'>> &
+	Pick<APIGuildForumTag, 'name'>;
+
+/**
+ * A forum tag in an update channel request.
+ *
+ * @see {@link https://docs.discord.com/developers/resources/channel#forum-tag-object}
+ */
+export type RESTPatchAPIChannelForumTagJSONBody = _StrictPartial<APIGuildForumTag> & Pick<APIGuildForumTag, 'name'>;
+
+/**
  * @see {@link https://discord.com/developers/docs/resources/channel#get-channel}
  */
 export type RESTGetAPIChannelResult = APIChannel;
 
 /**
- * @see {@link https://discord.com/developers/docs/resources/channel#modify-channel}
+ * @see {@link https://docs.discord.com/developers/resources/channel#modify-channel}
  */
 export interface RESTPatchAPIChannelJSONBody {
 	/**
@@ -158,7 +173,7 @@ export interface RESTPatchAPIChannelJSONBody {
 	 *
 	 * Channel types: forum, media
 	 */
-	available_tags?: (Partial<APIGuildForumTag> & Pick<APIGuildForumTag, 'name'>)[] | undefined;
+	available_tags?: RESTPatchAPIChannelForumTagJSONBody[] | undefined;
 	/**
 	 * Whether non-moderators can add other non-moderators to the thread
 	 *

--- a/deno/rest/v10/guild.ts
+++ b/deno/rest/v10/guild.ts
@@ -46,7 +46,7 @@ import type {
 	_StrictRequired,
 } from '../../utils/internals.ts';
 import type { Locale } from '../common.ts';
-import type { RESTPutAPIChannelPermissionJSONBody } from './channel.ts';
+import type { RESTPostAPIGuildChannelForumTagJSONBody, RESTPutAPIChannelPermissionJSONBody } from './channel.ts';
 
 export interface RESTAPIGuildCreateOverwrite extends RESTPutAPIChannelPermissionJSONBody {
 	id: number | string;
@@ -67,7 +67,6 @@ export type APIGuildChannelResolvable = RESTAPIGuildChannelResolvable;
 export type RESTAPIGuildCreatePartialChannel = _StrictPartial<
 	_DistributivePick<
 		RESTAPIGuildChannelResolvable,
-		| 'available_tags'
 		| 'bitrate'
 		| 'default_auto_archive_duration'
 		| 'default_forum_layout'
@@ -86,6 +85,10 @@ export type RESTAPIGuildCreatePartialChannel = _StrictPartial<
 	>
 > & {
 	name: string;
+	/**
+	 * The set of tags that can be used in a thread-only channel; limited to 20
+	 */
+	available_tags?: RESTPostAPIGuildChannelForumTagJSONBody[] | null | undefined;
 	id?: number | string | undefined;
 	parent_id?: number | string | null | undefined;
 	permission_overwrites?: RESTAPIGuildCreateOverwrite[] | undefined;
@@ -368,7 +371,7 @@ export type RESTDeleteAPIGuildResult = undefined;
 export type RESTGetAPIGuildChannelsResult = APIGuildChannel[];
 
 /**
- * @see {@link https://discord.com/developers/docs/resources/guild#create-guild-channel}
+ * @see {@link https://docs.discord.com/developers/resources/guild#create-guild-channel}
  */
 export type RESTPostAPIGuildChannelJSONBody = _DistributiveOmit<RESTAPIGuildCreatePartialChannel, 'id'>;
 

--- a/deno/rest/v9/channel.ts
+++ b/deno/rest/v9/channel.ts
@@ -42,12 +42,27 @@ export interface RESTAPIChannelPatchOverwrite extends RESTPutAPIChannelPermissio
 export type APIChannelPatchOverwrite = RESTAPIChannelPatchOverwrite;
 
 /**
+ * A forum tag in a create channel request.
+ *
+ * @see {@link https://docs.discord.com/developers/resources/channel#forum-tag-object}
+ */
+export type RESTPostAPIGuildChannelForumTagJSONBody = _StrictPartial<Omit<APIGuildForumTag, 'id'>> &
+	Pick<APIGuildForumTag, 'name'>;
+
+/**
+ * A forum tag in an update channel request.
+ *
+ * @see {@link https://docs.discord.com/developers/resources/channel#forum-tag-object}
+ */
+export type RESTPatchAPIChannelForumTagJSONBody = _StrictPartial<APIGuildForumTag> & Pick<APIGuildForumTag, 'name'>;
+
+/**
  * @see {@link https://discord.com/developers/docs/resources/channel#get-channel}
  */
 export type RESTGetAPIChannelResult = APIChannel;
 
 /**
- * @see {@link https://discord.com/developers/docs/resources/channel#modify-channel}
+ * @see {@link https://docs.discord.com/developers/resources/channel#modify-channel}
  */
 export interface RESTPatchAPIChannelJSONBody {
 	/**
@@ -158,7 +173,7 @@ export interface RESTPatchAPIChannelJSONBody {
 	 *
 	 * Channel types: forum, media
 	 */
-	available_tags?: (Partial<APIGuildForumTag> & Pick<APIGuildForumTag, 'name'>)[] | undefined;
+	available_tags?: RESTPatchAPIChannelForumTagJSONBody[] | undefined;
 	/**
 	 * Whether non-moderators can add other non-moderators to the thread
 	 *

--- a/deno/rest/v9/guild.ts
+++ b/deno/rest/v9/guild.ts
@@ -46,7 +46,7 @@ import type {
 	_StrictRequired,
 } from '../../utils/internals.ts';
 import type { Locale } from '../common.ts';
-import type { RESTPutAPIChannelPermissionJSONBody } from './channel.ts';
+import type { RESTPostAPIGuildChannelForumTagJSONBody, RESTPutAPIChannelPermissionJSONBody } from './channel.ts';
 
 export interface RESTAPIGuildCreateOverwrite extends RESTPutAPIChannelPermissionJSONBody {
 	id: number | string;
@@ -67,7 +67,6 @@ export type APIGuildChannelResolvable = RESTAPIGuildChannelResolvable;
 export type RESTAPIGuildCreatePartialChannel = _StrictPartial<
 	_DistributivePick<
 		RESTAPIGuildChannelResolvable,
-		| 'available_tags'
 		| 'bitrate'
 		| 'default_auto_archive_duration'
 		| 'default_forum_layout'
@@ -86,6 +85,10 @@ export type RESTAPIGuildCreatePartialChannel = _StrictPartial<
 	>
 > & {
 	name: string;
+	/**
+	 * The set of tags that can be used in a thread-only channel; limited to 20
+	 */
+	available_tags?: RESTPostAPIGuildChannelForumTagJSONBody[] | null | undefined;
 	id?: number | string | undefined;
 	parent_id?: number | string | null | undefined;
 	permission_overwrites?: RESTAPIGuildCreateOverwrite[] | undefined;
@@ -368,7 +371,7 @@ export type RESTDeleteAPIGuildResult = undefined;
 export type RESTGetAPIGuildChannelsResult = APIGuildChannel[];
 
 /**
- * @see {@link https://discord.com/developers/docs/resources/guild#create-guild-channel}
+ * @see {@link https://docs.discord.com/developers/resources/guild#create-guild-channel}
  */
 export type RESTPostAPIGuildChannelJSONBody = _DistributiveOmit<RESTAPIGuildCreatePartialChannel, 'id'>;
 

--- a/payloads/v10/channel.ts
+++ b/payloads/v10/channel.ts
@@ -283,7 +283,7 @@ export type APIPrivateThreadChannel = APIThreadChannel<ChannelType.PrivateThread
 export type APIAnnouncementThreadChannel = APIThreadChannel<ChannelType.AnnouncementThread>;
 
 /**
- * @see {@link https://discord.com/developers/docs/resources/channel#forum-tag-object-forum-tag-structure}
+ * @see {@link https://docs.discord.com/developers/resources/channel#forum-tag-object}
  */
 export interface APIGuildForumTag {
 	/**

--- a/payloads/v9/channel.ts
+++ b/payloads/v9/channel.ts
@@ -278,7 +278,7 @@ export type APIPrivateThreadChannel = APIThreadChannel<ChannelType.PrivateThread
 export type APIAnnouncementThreadChannel = APIThreadChannel<ChannelType.AnnouncementThread>;
 
 /**
- * @see {@link https://discord.com/developers/docs/resources/channel#forum-tag-object-forum-tag-structure}
+ * @see {@link https://docs.discord.com/developers/resources/channel#forum-tag-object}
  */
 export interface APIGuildForumTag {
 	/**

--- a/rest/v10/channel.ts
+++ b/rest/v10/channel.ts
@@ -42,12 +42,27 @@ export interface RESTAPIChannelPatchOverwrite extends RESTPutAPIChannelPermissio
 export type APIChannelPatchOverwrite = RESTAPIChannelPatchOverwrite;
 
 /**
+ * A forum tag in a create channel request.
+ *
+ * @see {@link https://docs.discord.com/developers/resources/channel#forum-tag-object}
+ */
+export type RESTPostAPIGuildChannelForumTagJSONBody = _StrictPartial<Omit<APIGuildForumTag, 'id'>> &
+	Pick<APIGuildForumTag, 'name'>;
+
+/**
+ * A forum tag in an update channel request.
+ *
+ * @see {@link https://docs.discord.com/developers/resources/channel#forum-tag-object}
+ */
+export type RESTPatchAPIChannelForumTagJSONBody = _StrictPartial<APIGuildForumTag> & Pick<APIGuildForumTag, 'name'>;
+
+/**
  * @see {@link https://discord.com/developers/docs/resources/channel#get-channel}
  */
 export type RESTGetAPIChannelResult = APIChannel;
 
 /**
- * @see {@link https://discord.com/developers/docs/resources/channel#modify-channel}
+ * @see {@link https://docs.discord.com/developers/resources/channel#modify-channel}
  */
 export interface RESTPatchAPIChannelJSONBody {
 	/**
@@ -158,7 +173,7 @@ export interface RESTPatchAPIChannelJSONBody {
 	 *
 	 * Channel types: forum, media
 	 */
-	available_tags?: (Partial<APIGuildForumTag> & Pick<APIGuildForumTag, 'name'>)[] | undefined;
+	available_tags?: RESTPatchAPIChannelForumTagJSONBody[] | undefined;
 	/**
 	 * Whether non-moderators can add other non-moderators to the thread
 	 *

--- a/rest/v10/guild.ts
+++ b/rest/v10/guild.ts
@@ -46,7 +46,7 @@ import type {
 	_StrictRequired,
 } from '../../utils/internals';
 import type { Locale } from '../common';
-import type { RESTPutAPIChannelPermissionJSONBody } from './channel';
+import type { RESTPostAPIGuildChannelForumTagJSONBody, RESTPutAPIChannelPermissionJSONBody } from './channel';
 
 export interface RESTAPIGuildCreateOverwrite extends RESTPutAPIChannelPermissionJSONBody {
 	id: number | string;
@@ -67,7 +67,6 @@ export type APIGuildChannelResolvable = RESTAPIGuildChannelResolvable;
 export type RESTAPIGuildCreatePartialChannel = _StrictPartial<
 	_DistributivePick<
 		RESTAPIGuildChannelResolvable,
-		| 'available_tags'
 		| 'bitrate'
 		| 'default_auto_archive_duration'
 		| 'default_forum_layout'
@@ -86,6 +85,10 @@ export type RESTAPIGuildCreatePartialChannel = _StrictPartial<
 	>
 > & {
 	name: string;
+	/**
+	 * The set of tags that can be used in a thread-only channel; limited to 20
+	 */
+	available_tags?: RESTPostAPIGuildChannelForumTagJSONBody[] | null | undefined;
 	id?: number | string | undefined;
 	parent_id?: number | string | null | undefined;
 	permission_overwrites?: RESTAPIGuildCreateOverwrite[] | undefined;
@@ -368,7 +371,7 @@ export type RESTDeleteAPIGuildResult = undefined;
 export type RESTGetAPIGuildChannelsResult = APIGuildChannel[];
 
 /**
- * @see {@link https://discord.com/developers/docs/resources/guild#create-guild-channel}
+ * @see {@link https://docs.discord.com/developers/resources/guild#create-guild-channel}
  */
 export type RESTPostAPIGuildChannelJSONBody = _DistributiveOmit<RESTAPIGuildCreatePartialChannel, 'id'>;
 

--- a/rest/v9/channel.ts
+++ b/rest/v9/channel.ts
@@ -42,12 +42,27 @@ export interface RESTAPIChannelPatchOverwrite extends RESTPutAPIChannelPermissio
 export type APIChannelPatchOverwrite = RESTAPIChannelPatchOverwrite;
 
 /**
+ * A forum tag in a create channel request.
+ *
+ * @see {@link https://docs.discord.com/developers/resources/channel#forum-tag-object}
+ */
+export type RESTPostAPIGuildChannelForumTagJSONBody = _StrictPartial<Omit<APIGuildForumTag, 'id'>> &
+	Pick<APIGuildForumTag, 'name'>;
+
+/**
+ * A forum tag in an update channel request.
+ *
+ * @see {@link https://docs.discord.com/developers/resources/channel#forum-tag-object}
+ */
+export type RESTPatchAPIChannelForumTagJSONBody = _StrictPartial<APIGuildForumTag> & Pick<APIGuildForumTag, 'name'>;
+
+/**
  * @see {@link https://discord.com/developers/docs/resources/channel#get-channel}
  */
 export type RESTGetAPIChannelResult = APIChannel;
 
 /**
- * @see {@link https://discord.com/developers/docs/resources/channel#modify-channel}
+ * @see {@link https://docs.discord.com/developers/resources/channel#modify-channel}
  */
 export interface RESTPatchAPIChannelJSONBody {
 	/**
@@ -158,7 +173,7 @@ export interface RESTPatchAPIChannelJSONBody {
 	 *
 	 * Channel types: forum, media
 	 */
-	available_tags?: (Partial<APIGuildForumTag> & Pick<APIGuildForumTag, 'name'>)[] | undefined;
+	available_tags?: RESTPatchAPIChannelForumTagJSONBody[] | undefined;
 	/**
 	 * Whether non-moderators can add other non-moderators to the thread
 	 *

--- a/rest/v9/guild.ts
+++ b/rest/v9/guild.ts
@@ -46,7 +46,7 @@ import type {
 	_StrictRequired,
 } from '../../utils/internals';
 import type { Locale } from '../common';
-import type { RESTPutAPIChannelPermissionJSONBody } from './channel';
+import type { RESTPostAPIGuildChannelForumTagJSONBody, RESTPutAPIChannelPermissionJSONBody } from './channel';
 
 export interface RESTAPIGuildCreateOverwrite extends RESTPutAPIChannelPermissionJSONBody {
 	id: number | string;
@@ -67,7 +67,6 @@ export type APIGuildChannelResolvable = RESTAPIGuildChannelResolvable;
 export type RESTAPIGuildCreatePartialChannel = _StrictPartial<
 	_DistributivePick<
 		RESTAPIGuildChannelResolvable,
-		| 'available_tags'
 		| 'bitrate'
 		| 'default_auto_archive_duration'
 		| 'default_forum_layout'
@@ -86,6 +85,10 @@ export type RESTAPIGuildCreatePartialChannel = _StrictPartial<
 	>
 > & {
 	name: string;
+	/**
+	 * The set of tags that can be used in a thread-only channel; limited to 20
+	 */
+	available_tags?: RESTPostAPIGuildChannelForumTagJSONBody[] | null | undefined;
 	id?: number | string | undefined;
 	parent_id?: number | string | null | undefined;
 	permission_overwrites?: RESTAPIGuildCreateOverwrite[] | undefined;
@@ -368,7 +371,7 @@ export type RESTDeleteAPIGuildResult = undefined;
 export type RESTGetAPIGuildChannelsResult = APIGuildChannel[];
 
 /**
- * @see {@link https://discord.com/developers/docs/resources/guild#create-guild-channel}
+ * @see {@link https://docs.discord.com/developers/resources/guild#create-guild-channel}
  */
 export type RESTPostAPIGuildChannelJSONBody = _DistributiveOmit<RESTAPIGuildCreatePartialChannel, 'id'>;
 


### PR DESCRIPTION
Resolves #1482.

`available_tags` are different on create and update. Distinct types have been made.

For this:

```diff
- https://discord.com/developers/docs/resources/channel#forum-tag-object-forum-tag-structure
+ https://docs.discord.com/developers/resources/channel#forum-tag-object
```

The removal off the end, whilst works, was explicitly removed as when I viewed the link, the top of the screen was the table, which made me immediately believe I was scrolled to an improper place. Feel free to request otherwise.