### PR TITLE
fix: allow descriptions for primary entry point commands

### DIFF
--- a/deno/rest/v10/interactions.ts
+++ b/deno/rest/v10/interactions.ts
@@ -92,6 +92,7 @@ export interface RESTPostAPIContextMenuApplicationCommandsJSONBody extends RESTP
  */
 export interface RESTPostAPIPrimaryEntryPointApplicationCommandJSONBody extends RESTPostAPIBaseApplicationCommandsJSONBody {
 	type: ApplicationCommandType.PrimaryEntryPoint;
+	description?: string | undefined;
 }
 
 /**

--- a/deno/rest/v9/interactions.ts
+++ b/deno/rest/v9/interactions.ts
@@ -92,6 +92,7 @@ export interface RESTPostAPIContextMenuApplicationCommandsJSONBody extends RESTP
  */
 export interface RESTPostAPIPrimaryEntryPointApplicationCommandJSONBody extends RESTPostAPIBaseApplicationCommandsJSONBody {
 	type: ApplicationCommandType.PrimaryEntryPoint;
+	description?: string | undefined;
 }
 
 /**

--- a/rest/v10/interactions.ts
+++ b/rest/v10/interactions.ts
@@ -92,6 +92,7 @@ export interface RESTPostAPIContextMenuApplicationCommandsJSONBody extends RESTP
  */
 export interface RESTPostAPIPrimaryEntryPointApplicationCommandJSONBody extends RESTPostAPIBaseApplicationCommandsJSONBody {
 	type: ApplicationCommandType.PrimaryEntryPoint;
+	description?: string | undefined;
 }
 
 /**

--- a/rest/v9/interactions.ts
+++ b/rest/v9/interactions.ts
@@ -92,6 +92,7 @@ export interface RESTPostAPIContextMenuApplicationCommandsJSONBody extends RESTP
  */
 export interface RESTPostAPIPrimaryEntryPointApplicationCommandJSONBody extends RESTPostAPIBaseApplicationCommandsJSONBody {
 	type: ApplicationCommandType.PrimaryEntryPoint;
+	description?: string | undefined;
 }
 
 /**


### PR DESCRIPTION
`PRIMARY_ENTRY_POINT` has an example of using a description:

https://github.com/discord/discord-api-docs/blob/35f3280dc8fe9f00db39e0d5eecc3620a6059d8d/developers/activities/development-guides/user-actions.mdx#L131-L148

Also, the specification indicates this too:

https://github.com/discord/discord-api-spec/blob/4e5c3dbe385cc148dde582325314e598fddbd7a9/specs/openapi.json#L17937

`description_localizations` was already supported.

Verified API-wise that `description` was returned:

```JSON
{
	"id": "1544490830700609538",
	"application_id": "1071822091814441000",
	"version": "1544699542987866232",
	"default_member_permissions": null,
	"type": 4,
	"name": "Games",
	"name_localizations": null,
	"description": "Let's play!",
	"description_localizations": null,
	"dm_permission": true,
	"contexts": [0, 1, 2],
	"integration_types": [0, 1],
	"nsfw": false
},
```