### PR TITLE
fix(interactions): remove `options` and `handler` respectively

### DIFF
--- a/deno/rest/v10/interactions.ts
+++ b/deno/rest/v10/interactions.ts
@@ -1,11 +1,13 @@
 import type { Snowflake } from '../../globals.ts';
 import type {
 	APIApplicationCommand,
+	APIApplicationCommandOption,
 	APIApplicationCommandPermission,
 	APIGuildApplicationCommandPermissions,
 	APIInteractionResponse,
 	APIInteractionResponseCallbackData,
 	ApplicationCommandType,
+	EntryPointCommandHandlerType,
 	InteractionResponseType,
 	APIMessage,
 	InteractionType,
@@ -58,9 +60,11 @@ export interface RESTPostAPIBaseApplicationCommandsJSONBody
 				| 'description_localized'
 				| 'description'
 				| 'guild_id'
+				| 'handler'
 				| 'id'
 				| 'integration_types'
 				| 'name_localized'
+				| 'options'
 				| 'type'
 				| 'version'
 			>
@@ -78,6 +82,7 @@ export interface RESTPostAPIBaseApplicationCommandsJSONBody
 export interface RESTPostAPIChatInputApplicationCommandsJSONBody extends RESTPostAPIBaseApplicationCommandsJSONBody {
 	type?: ApplicationCommandType.ChatInput | undefined;
 	description: string;
+	options?: APIApplicationCommandOption[] | undefined;
 }
 
 /**
@@ -93,6 +98,7 @@ export interface RESTPostAPIContextMenuApplicationCommandsJSONBody extends RESTP
 export interface RESTPostAPIPrimaryEntryPointApplicationCommandJSONBody extends RESTPostAPIBaseApplicationCommandsJSONBody {
 	type: ApplicationCommandType.PrimaryEntryPoint;
 	description?: string | undefined;
+	handler?: EntryPointCommandHandlerType | undefined;
 }
 
 /**

--- a/deno/rest/v9/interactions.ts
+++ b/deno/rest/v9/interactions.ts
@@ -1,11 +1,13 @@
 import type { Snowflake } from '../../globals.ts';
 import type {
 	APIApplicationCommand,
+	APIApplicationCommandOption,
 	APIApplicationCommandPermission,
 	APIGuildApplicationCommandPermissions,
 	APIInteractionResponse,
 	APIInteractionResponseCallbackData,
 	ApplicationCommandType,
+	EntryPointCommandHandlerType,
 	InteractionResponseType,
 	APIMessage,
 	InteractionType,
@@ -58,9 +60,11 @@ export interface RESTPostAPIBaseApplicationCommandsJSONBody
 				| 'description_localized'
 				| 'description'
 				| 'guild_id'
+				| 'handler'
 				| 'id'
 				| 'integration_types'
 				| 'name_localized'
+				| 'options'
 				| 'type'
 				| 'version'
 			>
@@ -78,6 +82,7 @@ export interface RESTPostAPIBaseApplicationCommandsJSONBody
 export interface RESTPostAPIChatInputApplicationCommandsJSONBody extends RESTPostAPIBaseApplicationCommandsJSONBody {
 	type?: ApplicationCommandType.ChatInput | undefined;
 	description: string;
+	options?: APIApplicationCommandOption[] | undefined;
 }
 
 /**
@@ -93,6 +98,7 @@ export interface RESTPostAPIContextMenuApplicationCommandsJSONBody extends RESTP
 export interface RESTPostAPIPrimaryEntryPointApplicationCommandJSONBody extends RESTPostAPIBaseApplicationCommandsJSONBody {
 	type: ApplicationCommandType.PrimaryEntryPoint;
 	description?: string | undefined;
+	handler?: EntryPointCommandHandlerType | undefined;
 }
 
 /**

--- a/rest/v10/interactions.ts
+++ b/rest/v10/interactions.ts
@@ -1,11 +1,13 @@
 import type { Snowflake } from '../../globals';
 import type {
 	APIApplicationCommand,
+	APIApplicationCommandOption,
 	APIApplicationCommandPermission,
 	APIGuildApplicationCommandPermissions,
 	APIInteractionResponse,
 	APIInteractionResponseCallbackData,
 	ApplicationCommandType,
+	EntryPointCommandHandlerType,
 	InteractionResponseType,
 	APIMessage,
 	InteractionType,
@@ -58,9 +60,11 @@ export interface RESTPostAPIBaseApplicationCommandsJSONBody
 				| 'description_localized'
 				| 'description'
 				| 'guild_id'
+				| 'handler'
 				| 'id'
 				| 'integration_types'
 				| 'name_localized'
+				| 'options'
 				| 'type'
 				| 'version'
 			>
@@ -78,6 +82,7 @@ export interface RESTPostAPIBaseApplicationCommandsJSONBody
 export interface RESTPostAPIChatInputApplicationCommandsJSONBody extends RESTPostAPIBaseApplicationCommandsJSONBody {
 	type?: ApplicationCommandType.ChatInput | undefined;
 	description: string;
+	options?: APIApplicationCommandOption[] | undefined;
 }
 
 /**
@@ -93,6 +98,7 @@ export interface RESTPostAPIContextMenuApplicationCommandsJSONBody extends RESTP
 export interface RESTPostAPIPrimaryEntryPointApplicationCommandJSONBody extends RESTPostAPIBaseApplicationCommandsJSONBody {
 	type: ApplicationCommandType.PrimaryEntryPoint;
 	description?: string | undefined;
+	handler?: EntryPointCommandHandlerType | undefined;
 }
 
 /**

--- a/rest/v9/interactions.ts
+++ b/rest/v9/interactions.ts
@@ -1,11 +1,13 @@
 import type { Snowflake } from '../../globals';
 import type {
 	APIApplicationCommand,
+	APIApplicationCommandOption,
 	APIApplicationCommandPermission,
 	APIGuildApplicationCommandPermissions,
 	APIInteractionResponse,
 	APIInteractionResponseCallbackData,
 	ApplicationCommandType,
+	EntryPointCommandHandlerType,
 	InteractionResponseType,
 	APIMessage,
 	InteractionType,
@@ -58,9 +60,11 @@ export interface RESTPostAPIBaseApplicationCommandsJSONBody
 				| 'description_localized'
 				| 'description'
 				| 'guild_id'
+				| 'handler'
 				| 'id'
 				| 'integration_types'
 				| 'name_localized'
+				| 'options'
 				| 'type'
 				| 'version'
 			>
@@ -78,6 +82,7 @@ export interface RESTPostAPIBaseApplicationCommandsJSONBody
 export interface RESTPostAPIChatInputApplicationCommandsJSONBody extends RESTPostAPIBaseApplicationCommandsJSONBody {
 	type?: ApplicationCommandType.ChatInput | undefined;
 	description: string;
+	options?: APIApplicationCommandOption[] | undefined;
 }
 
 /**
@@ -93,6 +98,7 @@ export interface RESTPostAPIContextMenuApplicationCommandsJSONBody extends RESTP
 export interface RESTPostAPIPrimaryEntryPointApplicationCommandJSONBody extends RESTPostAPIBaseApplicationCommandsJSONBody {
 	type: ApplicationCommandType.PrimaryEntryPoint;
 	description?: string | undefined;
+	handler?: EntryPointCommandHandlerType | undefined;
 }
 
 /**

--- a/tests/v10/applicationCommands.ts
+++ b/tests/v10/applicationCommands.ts
@@ -1,0 +1,63 @@
+import type {
+	RESTPatchAPIApplicationCommandJSONBody,
+	RESTPostAPIApplicationCommandsJSONBody,
+	RESTPostAPIBaseApplicationCommandsJSONBody,
+	RESTPostAPIApplicationGuildCommandsJSONBody,
+	RESTPostAPIChatInputApplicationCommandsJSONBody,
+	RESTPostAPIContextMenuApplicationCommandsJSONBody,
+	RESTPostAPIPrimaryEntryPointApplicationCommandJSONBody,
+	RESTPutAPIApplicationCommandsJSONBody,
+	RESTPutAPIApplicationGuildCommandsJSONBody,
+} from '../../v10';
+import { ApplicationCommandType, EntryPointCommandHandlerType } from '../../v10';
+import { expectAssignable } from '../__utils__/type-assertions';
+
+const chatInputCommand = {
+	name: 'Chat input',
+	description: 'description',
+	options: [],
+};
+
+const contextMenuCommand = {
+	type: ApplicationCommandType.User as const,
+	name: 'Context menu',
+};
+
+const primaryEntryPointCommand = {
+	type: ApplicationCommandType.PrimaryEntryPoint as const,
+	name: 'Entry point',
+	handler: EntryPointCommandHandlerType.DiscordLaunchActivity,
+};
+
+expectAssignable<RESTPostAPIApplicationCommandsJSONBody>(chatInputCommand);
+expectAssignable<RESTPostAPIApplicationCommandsJSONBody>(contextMenuCommand);
+expectAssignable<RESTPostAPIApplicationCommandsJSONBody>(primaryEntryPointCommand);
+expectAssignable<RESTPutAPIApplicationCommandsJSONBody>([
+	chatInputCommand,
+	contextMenuCommand,
+	primaryEntryPointCommand,
+]);
+expectAssignable<RESTPostAPIApplicationGuildCommandsJSONBody>(chatInputCommand);
+expectAssignable<RESTPutAPIApplicationGuildCommandsJSONBody>([chatInputCommand, contextMenuCommand]);
+expectAssignable<RESTPatchAPIApplicationCommandJSONBody>({ options: [] });
+expectAssignable<RESTPatchAPIApplicationCommandJSONBody>({
+	handler: EntryPointCommandHandlerType.AppHandler,
+});
+
+// @ts-expect-error - Options are not on all types.
+expectAssignable<keyof RESTPostAPIBaseApplicationCommandsJSONBody>('options');
+expectAssignable<keyof RESTPostAPIChatInputApplicationCommandsJSONBody>('options');
+
+// @ts-expect-error - Options are only valid for chat input commands.
+expectAssignable<keyof RESTPostAPIContextMenuApplicationCommandsJSONBody>('options');
+// @ts-expect-error - Options are only valid for chat input commands.
+expectAssignable<keyof RESTPostAPIPrimaryEntryPointApplicationCommandJSONBody>('options');
+
+// @ts-expect-error - Handler is not on all types.
+expectAssignable<keyof RESTPostAPIBaseApplicationCommandsJSONBody>('handler');
+
+// @ts-expect-error - Handler is only valid for primary entry point commands.
+expectAssignable<keyof RESTPostAPIChatInputApplicationCommandsJSONBody>('handler');
+// @ts-expect-error - Handler is only valid for primary entry point commands.
+expectAssignable<keyof RESTPostAPIContextMenuApplicationCommandsJSONBody>('handler');
+expectAssignable<keyof RESTPostAPIPrimaryEntryPointApplicationCommandJSONBody>('handler');


### PR DESCRIPTION
Primary entry point commands and context menu commands were allowed to have `options` and `handler`.

- `options` is only for chat input commands
- `handler` is only for primary entry point commands