### PR TITLE
fix(interactions): include individual locale property

### DIFF
--- a/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/attachment.ts
+++ b/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/attachment.ts
@@ -1,10 +1,18 @@
 import type { Snowflake } from '../../../../../globals.ts';
-import type { APIApplicationCommandOptionBase, APIInteractionDataOptionBase } from './base.ts';
+import type {
+	APIApplicationCommandOptionBase,
+	APIApplicationCommandOptionBaseResponse,
+	APIInteractionDataOptionBase,
+} from './base.ts';
 import type { ApplicationCommandOptionType } from './shared.ts';
 
 export type FileUploadType = 'audio' | 'image' | 'video' | `.${string}`;
 
 export interface APIApplicationCommandAttachmentOption extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.Attachment> {
+	file_types?: FileUploadType[];
+}
+
+export interface APIApplicationCommandAttachmentOptionResponse extends APIApplicationCommandOptionBaseResponse<ApplicationCommandOptionType.Attachment> {
 	file_types?: FileUploadType[];
 }
 

--- a/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/base.ts
+++ b/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/base.ts
@@ -10,6 +10,13 @@ export interface APIApplicationCommandOptionBase<Type extends ApplicationCommand
 	required?: boolean;
 }
 
+export interface APIApplicationCommandOptionBaseResponse<
+	Type extends ApplicationCommandOptionType,
+> extends APIApplicationCommandOptionBase<Type> {
+	name_localized?: string;
+	description_localized?: string;
+}
+
 export interface APIInteractionDataOptionBase<T extends ApplicationCommandOptionType, D> {
 	name: string;
 	type: T;

--- a/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/boolean.ts
+++ b/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/boolean.ts
@@ -1,7 +1,14 @@
-import type { APIApplicationCommandOptionBase, APIInteractionDataOptionBase } from './base.ts';
+import type {
+	APIApplicationCommandOptionBase,
+	APIApplicationCommandOptionBaseResponse,
+	APIInteractionDataOptionBase,
+} from './base.ts';
 import type { ApplicationCommandOptionType } from './shared.ts';
 
 export type APIApplicationCommandBooleanOption = APIApplicationCommandOptionBase<ApplicationCommandOptionType.Boolean>;
+
+export type APIApplicationCommandBooleanOptionResponse =
+	APIApplicationCommandOptionBaseResponse<ApplicationCommandOptionType.Boolean>;
 
 export type APIApplicationCommandInteractionDataBooleanOption = APIInteractionDataOptionBase<
 	ApplicationCommandOptionType.Boolean,

--- a/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/channel.ts
+++ b/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/channel.ts
@@ -1,9 +1,17 @@
 import type { Snowflake } from '../../../../../globals.ts';
 import type { ApplicationCommandOptionAllowedChannelType } from '../../../channel.ts';
-import type { APIApplicationCommandOptionBase, APIInteractionDataOptionBase } from './base.ts';
+import type {
+	APIApplicationCommandOptionBase,
+	APIApplicationCommandOptionBaseResponse,
+	APIInteractionDataOptionBase,
+} from './base.ts';
 import type { ApplicationCommandOptionType } from './shared.ts';
 
 export interface APIApplicationCommandChannelOption extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.Channel> {
+	channel_types?: ApplicationCommandOptionAllowedChannelType[];
+}
+
+export interface APIApplicationCommandChannelOptionResponse extends APIApplicationCommandOptionBaseResponse<ApplicationCommandOptionType.Channel> {
 	channel_types?: ApplicationCommandOptionAllowedChannelType[];
 }
 

--- a/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/integer.ts
+++ b/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/integer.ts
@@ -1,10 +1,15 @@
 import type { InteractionType } from '../../responses.ts';
 import type {
 	APIApplicationCommandOptionBase,
+	APIApplicationCommandOptionBaseResponse,
 	APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper,
 	APIInteractionDataOptionBase,
 } from './base.ts';
-import type { APIApplicationCommandOptionChoice, ApplicationCommandOptionType } from './shared.ts';
+import type {
+	APIApplicationCommandOptionChoice,
+	APIApplicationCommandOptionChoiceResponse,
+	ApplicationCommandOptionType,
+} from './shared.ts';
 
 export interface APIApplicationCommandIntegerOptionBase extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.Integer> {
 	/**
@@ -20,6 +25,22 @@ export interface APIApplicationCommandIntegerOptionBase extends APIApplicationCo
 export type APIApplicationCommandIntegerOption = APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper<
 	APIApplicationCommandIntegerOptionBase,
 	APIApplicationCommandOptionChoice<number>
+>;
+
+export interface APIApplicationCommandIntegerOptionResponseBase extends APIApplicationCommandOptionBaseResponse<ApplicationCommandOptionType.Integer> {
+	/**
+	 * If the option is an `INTEGER` or `NUMBER` type, the minimum value permitted.
+	 */
+	min_value?: number;
+	/**
+	 * If the option is an `INTEGER` or `NUMBER` type, the maximum value permitted.
+	 */
+	max_value?: number;
+}
+
+export type APIApplicationCommandIntegerOptionResponse = APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper<
+	APIApplicationCommandIntegerOptionResponseBase,
+	APIApplicationCommandOptionChoiceResponse<number>
 >;
 
 export interface APIApplicationCommandInteractionDataIntegerOption<

--- a/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/mentionable.ts
+++ b/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/mentionable.ts
@@ -1,9 +1,16 @@
 import type { Snowflake } from '../../../../../globals.ts';
-import type { APIApplicationCommandOptionBase, APIInteractionDataOptionBase } from './base.ts';
+import type {
+	APIApplicationCommandOptionBase,
+	APIApplicationCommandOptionBaseResponse,
+	APIInteractionDataOptionBase,
+} from './base.ts';
 import type { ApplicationCommandOptionType } from './shared.ts';
 
 export type APIApplicationCommandMentionableOption =
 	APIApplicationCommandOptionBase<ApplicationCommandOptionType.Mentionable>;
+
+export type APIApplicationCommandMentionableOptionResponse =
+	APIApplicationCommandOptionBaseResponse<ApplicationCommandOptionType.Mentionable>;
 
 export type APIApplicationCommandInteractionDataMentionableOption = APIInteractionDataOptionBase<
 	ApplicationCommandOptionType.Mentionable,

--- a/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/number.ts
+++ b/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/number.ts
@@ -1,10 +1,15 @@
 import type { InteractionType } from '../../responses.ts';
 import type {
 	APIApplicationCommandOptionBase,
+	APIApplicationCommandOptionBaseResponse,
 	APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper,
 	APIInteractionDataOptionBase,
 } from './base.ts';
-import type { APIApplicationCommandOptionChoice, ApplicationCommandOptionType } from './shared.ts';
+import type {
+	APIApplicationCommandOptionChoice,
+	APIApplicationCommandOptionChoiceResponse,
+	ApplicationCommandOptionType,
+} from './shared.ts';
 
 export interface APIApplicationCommandNumberOptionBase extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.Number> {
 	/**
@@ -20,6 +25,22 @@ export interface APIApplicationCommandNumberOptionBase extends APIApplicationCom
 export type APIApplicationCommandNumberOption = APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper<
 	APIApplicationCommandNumberOptionBase,
 	APIApplicationCommandOptionChoice<number>
+>;
+
+export interface APIApplicationCommandNumberOptionResponseBase extends APIApplicationCommandOptionBaseResponse<ApplicationCommandOptionType.Number> {
+	/**
+	 * If the option is an `INTEGER` or `NUMBER` type, the minimum value permitted.
+	 */
+	min_value?: number;
+	/**
+	 * If the option is an `INTEGER` or `NUMBER` type, the maximum value permitted.
+	 */
+	max_value?: number;
+}
+
+export type APIApplicationCommandNumberOptionResponse = APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper<
+	APIApplicationCommandNumberOptionResponseBase,
+	APIApplicationCommandOptionChoiceResponse<number>
 >;
 
 export interface APIApplicationCommandInteractionDataNumberOption<

--- a/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/role.ts
+++ b/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/role.ts
@@ -1,8 +1,15 @@
 import type { Snowflake } from '../../../../../globals.ts';
-import type { APIApplicationCommandOptionBase, APIInteractionDataOptionBase } from './base.ts';
+import type {
+	APIApplicationCommandOptionBase,
+	APIApplicationCommandOptionBaseResponse,
+	APIInteractionDataOptionBase,
+} from './base.ts';
 import type { ApplicationCommandOptionType } from './shared.ts';
 
 export type APIApplicationCommandRoleOption = APIApplicationCommandOptionBase<ApplicationCommandOptionType.Role>;
+
+export type APIApplicationCommandRoleOptionResponse =
+	APIApplicationCommandOptionBaseResponse<ApplicationCommandOptionType.Role>;
 
 export type APIApplicationCommandInteractionDataRoleOption = APIInteractionDataOptionBase<
 	ApplicationCommandOptionType.Role,

--- a/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/shared.ts
+++ b/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/shared.ts
@@ -25,3 +25,12 @@ export interface APIApplicationCommandOptionChoice<ValueType = number | string> 
 	name_localizations?: LocalizationMap | null;
 	value: ValueType;
 }
+
+/**
+ * @see {@link https://docs.discord.com/developers/interactions/application-commands#application-command-object-application-command-option-choice-structure}
+ */
+export interface APIApplicationCommandOptionChoiceResponse<
+	ValueType = number | string,
+> extends APIApplicationCommandOptionChoice<ValueType> {
+	name_localized?: string;
+}

--- a/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/string.ts
+++ b/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/string.ts
@@ -1,9 +1,14 @@
 import type {
 	APIApplicationCommandOptionBase,
+	APIApplicationCommandOptionBaseResponse,
 	APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper,
 	APIInteractionDataOptionBase,
 } from './base.ts';
-import type { APIApplicationCommandOptionChoice, ApplicationCommandOptionType } from './shared.ts';
+import type {
+	APIApplicationCommandOptionChoice,
+	APIApplicationCommandOptionChoiceResponse,
+	ApplicationCommandOptionType,
+} from './shared.ts';
 
 export interface APIApplicationCommandStringOptionBase extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.String> {
 	/**
@@ -19,6 +24,22 @@ export interface APIApplicationCommandStringOptionBase extends APIApplicationCom
 export type APIApplicationCommandStringOption = APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper<
 	APIApplicationCommandStringOptionBase,
 	APIApplicationCommandOptionChoice<string>
+>;
+
+export interface APIApplicationCommandStringOptionResponseBase extends APIApplicationCommandOptionBaseResponse<ApplicationCommandOptionType.String> {
+	/**
+	 * For option type `STRING`, the minimum allowed length (minimum of `0`, maximum of `6000`).
+	 */
+	min_length?: number;
+	/**
+	 * For option type `STRING`, the maximum allowed length (minimum of `1`, maximum of `6000`).
+	 */
+	max_length?: number;
+}
+
+export type APIApplicationCommandStringOptionResponse = APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper<
+	APIApplicationCommandStringOptionResponseBase,
+	APIApplicationCommandOptionChoiceResponse<string>
 >;
 
 export interface APIApplicationCommandInteractionDataStringOption extends APIInteractionDataOptionBase<

--- a/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/subcommand.ts
+++ b/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/subcommand.ts
@@ -1,10 +1,18 @@
 import type { InteractionType } from '../../responses.ts';
-import type { APIApplicationCommandBasicOption, APIApplicationCommandInteractionDataBasicOption } from '../chatInput.ts';
-import type { APIApplicationCommandOptionBase } from './base.ts';
+import type {
+	APIApplicationCommandBasicOption,
+	APIApplicationCommandBasicOptionResponse,
+	APIApplicationCommandInteractionDataBasicOption,
+} from '../chatInput.ts';
+import type { APIApplicationCommandOptionBase, APIApplicationCommandOptionBaseResponse } from './base.ts';
 import type { ApplicationCommandOptionType } from './shared.ts';
 
 export interface APIApplicationCommandSubcommandOption extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.Subcommand> {
 	options?: APIApplicationCommandBasicOption[];
+}
+
+export interface APIApplicationCommandSubcommandOptionResponse extends APIApplicationCommandOptionBaseResponse<ApplicationCommandOptionType.Subcommand> {
+	options?: APIApplicationCommandBasicOptionResponse[];
 }
 
 export interface APIApplicationCommandInteractionDataSubcommandOption<Type extends InteractionType = InteractionType> {

--- a/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/subcommandGroup.ts
+++ b/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/subcommandGroup.ts
@@ -1,13 +1,18 @@
 import type { InteractionType } from '../../responses.ts';
-import type { APIApplicationCommandOptionBase } from './base.ts';
+import type { APIApplicationCommandOptionBase, APIApplicationCommandOptionBaseResponse } from './base.ts';
 import type { ApplicationCommandOptionType } from './shared.ts';
 import type {
 	APIApplicationCommandInteractionDataSubcommandOption,
 	APIApplicationCommandSubcommandOption,
+	APIApplicationCommandSubcommandOptionResponse,
 } from './subcommand.ts';
 
 export interface APIApplicationCommandSubcommandGroupOption extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.SubcommandGroup> {
 	options?: APIApplicationCommandSubcommandOption[];
+}
+
+export interface APIApplicationCommandSubcommandGroupOptionResponse extends APIApplicationCommandOptionBaseResponse<ApplicationCommandOptionType.SubcommandGroup> {
+	options?: APIApplicationCommandSubcommandOptionResponse[];
 }
 
 export interface APIApplicationCommandInteractionDataSubcommandGroupOption<

--- a/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/user.ts
+++ b/deno/payloads/v10/_interactions/_applicationCommands/_chatInput/user.ts
@@ -1,8 +1,15 @@
 import type { Snowflake } from '../../../../../globals.ts';
-import type { APIApplicationCommandOptionBase, APIInteractionDataOptionBase } from './base.ts';
+import type {
+	APIApplicationCommandOptionBase,
+	APIApplicationCommandOptionBaseResponse,
+	APIInteractionDataOptionBase,
+} from './base.ts';
 import type { ApplicationCommandOptionType } from './shared.ts';
 
 export type APIApplicationCommandUserOption = APIApplicationCommandOptionBase<ApplicationCommandOptionType.User>;
+
+export type APIApplicationCommandUserOptionResponse =
+	APIApplicationCommandOptionBaseResponse<ApplicationCommandOptionType.User>;
 
 export type APIApplicationCommandInteractionDataUserOption = APIInteractionDataOptionBase<
 	ApplicationCommandOptionType.User,

--- a/deno/payloads/v10/_interactions/_applicationCommands/chatInput.ts
+++ b/deno/payloads/v10/_interactions/_applicationCommands/chatInput.ts
@@ -3,47 +3,58 @@ import type { APIApplicationCommandInteractionWrapper, ApplicationCommandType } 
 import type { APIDMInteractionWrapper, APIGuildInteractionWrapper } from '../base.ts';
 import type {
 	APIApplicationCommandAttachmentOption,
+	APIApplicationCommandAttachmentOptionResponse,
 	APIApplicationCommandInteractionDataAttachmentOption,
 } from './_chatInput/attachment.ts';
 import type {
 	APIApplicationCommandBooleanOption,
+	APIApplicationCommandBooleanOptionResponse,
 	APIApplicationCommandInteractionDataBooleanOption,
 } from './_chatInput/boolean.ts';
 import type {
 	APIApplicationCommandChannelOption,
+	APIApplicationCommandChannelOptionResponse,
 	APIApplicationCommandInteractionDataChannelOption,
 } from './_chatInput/channel.ts';
 import type {
 	APIApplicationCommandIntegerOption,
+	APIApplicationCommandIntegerOptionResponse,
 	APIApplicationCommandInteractionDataIntegerOption,
 } from './_chatInput/integer.ts';
 import type {
 	APIApplicationCommandInteractionDataMentionableOption,
 	APIApplicationCommandMentionableOption,
+	APIApplicationCommandMentionableOptionResponse,
 } from './_chatInput/mentionable.ts';
 import type {
 	APIApplicationCommandInteractionDataNumberOption,
 	APIApplicationCommandNumberOption,
+	APIApplicationCommandNumberOptionResponse,
 } from './_chatInput/number.ts';
 import type {
 	APIApplicationCommandInteractionDataRoleOption,
 	APIApplicationCommandRoleOption,
+	APIApplicationCommandRoleOptionResponse,
 } from './_chatInput/role.ts';
 import type {
 	APIApplicationCommandInteractionDataStringOption,
 	APIApplicationCommandStringOption,
+	APIApplicationCommandStringOptionResponse,
 } from './_chatInput/string.ts';
 import type {
 	APIApplicationCommandInteractionDataSubcommandOption,
 	APIApplicationCommandSubcommandOption,
+	APIApplicationCommandSubcommandOptionResponse,
 } from './_chatInput/subcommand.ts';
 import type {
 	APIApplicationCommandInteractionDataSubcommandGroupOption,
 	APIApplicationCommandSubcommandGroupOption,
+	APIApplicationCommandSubcommandGroupOptionResponse,
 } from './_chatInput/subcommandGroup.ts';
 import type {
 	APIApplicationCommandInteractionDataUserOption,
 	APIApplicationCommandUserOption,
+	APIApplicationCommandUserOptionResponse,
 } from './_chatInput/user.ts';
 import type { APIBaseApplicationCommandInteractionData } from './internals.ts';
 
@@ -76,12 +87,34 @@ export type APIApplicationCommandBasicOption =
 	| APIApplicationCommandUserOption;
 
 /**
+ * @see {@link https://docs.discord.com/developers/interactions/application-commands#application-command-object-application-command-option-structure}
+ */
+export type APIApplicationCommandBasicOptionResponse =
+	| APIApplicationCommandAttachmentOptionResponse
+	| APIApplicationCommandBooleanOptionResponse
+	| APIApplicationCommandChannelOptionResponse
+	| APIApplicationCommandIntegerOptionResponse
+	| APIApplicationCommandMentionableOptionResponse
+	| APIApplicationCommandNumberOptionResponse
+	| APIApplicationCommandRoleOptionResponse
+	| APIApplicationCommandStringOptionResponse
+	| APIApplicationCommandUserOptionResponse;
+
+/**
  * @see {@link https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure}
  */
 export type APIApplicationCommandOption =
 	| APIApplicationCommandBasicOption
 	| APIApplicationCommandSubcommandGroupOption
 	| APIApplicationCommandSubcommandOption;
+
+/**
+ * @see {@link https://docs.discord.com/developers/interactions/application-commands#application-command-object-application-command-option-structure}
+ */
+export type APIApplicationCommandOptionResponse =
+	| APIApplicationCommandBasicOptionResponse
+	| APIApplicationCommandSubcommandGroupOptionResponse
+	| APIApplicationCommandSubcommandOptionResponse;
 
 /**
  * @see {@link https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-interaction-data-option-structure}

--- a/deno/payloads/v10/_interactions/applicationCommands.ts
+++ b/deno/payloads/v10/_interactions/applicationCommands.ts
@@ -1,7 +1,7 @@
 import type { Permissions, Snowflake } from '../../../globals.ts';
 import type { LocalizationMap } from '../../../v10.ts';
 import type {
-	APIApplicationCommandOption,
+	APIApplicationCommandOptionResponse,
 	APIChatInputApplicationCommandDMInteraction,
 	APIChatInputApplicationCommandGuildInteraction,
 	APIChatInputApplicationCommandInteraction,
@@ -75,7 +75,7 @@ export interface APIApplicationCommand {
 	/**
 	 * The parameters for the `CHAT_INPUT` command, max 25
 	 */
-	options?: APIApplicationCommandOption[];
+	options?: APIApplicationCommandOptionResponse[];
 	/**
 	 * Set of permissions represented as a bitset
 	 */

--- a/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/attachment.ts
+++ b/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/attachment.ts
@@ -1,10 +1,18 @@
 import type { Snowflake } from '../../../../../globals.ts';
-import type { APIApplicationCommandOptionBase, APIInteractionDataOptionBase } from './base.ts';
+import type {
+	APIApplicationCommandOptionBase,
+	APIApplicationCommandOptionBaseResponse,
+	APIInteractionDataOptionBase,
+} from './base.ts';
 import type { ApplicationCommandOptionType } from './shared.ts';
 
 export type FileUploadType = 'audio' | 'image' | 'video' | `.${string}`;
 
 export interface APIApplicationCommandAttachmentOption extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.Attachment> {
+	file_types?: FileUploadType[];
+}
+
+export interface APIApplicationCommandAttachmentOptionResponse extends APIApplicationCommandOptionBaseResponse<ApplicationCommandOptionType.Attachment> {
 	file_types?: FileUploadType[];
 }
 

--- a/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/base.ts
+++ b/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/base.ts
@@ -10,6 +10,13 @@ export interface APIApplicationCommandOptionBase<Type extends ApplicationCommand
 	required?: boolean;
 }
 
+export interface APIApplicationCommandOptionBaseResponse<
+	Type extends ApplicationCommandOptionType,
+> extends APIApplicationCommandOptionBase<Type> {
+	name_localized?: string;
+	description_localized?: string;
+}
+
 export interface APIInteractionDataOptionBase<T extends ApplicationCommandOptionType, D> {
 	name: string;
 	type: T;

--- a/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/boolean.ts
+++ b/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/boolean.ts
@@ -1,7 +1,14 @@
-import type { APIApplicationCommandOptionBase, APIInteractionDataOptionBase } from './base.ts';
+import type {
+	APIApplicationCommandOptionBase,
+	APIApplicationCommandOptionBaseResponse,
+	APIInteractionDataOptionBase,
+} from './base.ts';
 import type { ApplicationCommandOptionType } from './shared.ts';
 
 export type APIApplicationCommandBooleanOption = APIApplicationCommandOptionBase<ApplicationCommandOptionType.Boolean>;
+
+export type APIApplicationCommandBooleanOptionResponse =
+	APIApplicationCommandOptionBaseResponse<ApplicationCommandOptionType.Boolean>;
 
 export type APIApplicationCommandInteractionDataBooleanOption = APIInteractionDataOptionBase<
 	ApplicationCommandOptionType.Boolean,

--- a/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/channel.ts
+++ b/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/channel.ts
@@ -1,9 +1,17 @@
 import type { Snowflake } from '../../../../../globals.ts';
 import type { ChannelType } from '../../../channel.ts';
-import type { APIApplicationCommandOptionBase, APIInteractionDataOptionBase } from './base.ts';
+import type {
+	APIApplicationCommandOptionBase,
+	APIApplicationCommandOptionBaseResponse,
+	APIInteractionDataOptionBase,
+} from './base.ts';
 import type { ApplicationCommandOptionType } from './shared.ts';
 
 export interface APIApplicationCommandChannelOption extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.Channel> {
+	channel_types?: Exclude<ChannelType, ChannelType.GuildDirectory>[];
+}
+
+export interface APIApplicationCommandChannelOptionResponse extends APIApplicationCommandOptionBaseResponse<ApplicationCommandOptionType.Channel> {
 	channel_types?: Exclude<ChannelType, ChannelType.GuildDirectory>[];
 }
 

--- a/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/integer.ts
+++ b/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/integer.ts
@@ -1,10 +1,15 @@
 import type { InteractionType } from '../../responses.ts';
 import type {
 	APIApplicationCommandOptionBase,
+	APIApplicationCommandOptionBaseResponse,
 	APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper,
 	APIInteractionDataOptionBase,
 } from './base.ts';
-import type { APIApplicationCommandOptionChoice, ApplicationCommandOptionType } from './shared.ts';
+import type {
+	APIApplicationCommandOptionChoice,
+	APIApplicationCommandOptionChoiceResponse,
+	ApplicationCommandOptionType,
+} from './shared.ts';
 
 export interface APIApplicationCommandIntegerOptionBase extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.Integer> {
 	/**
@@ -20,6 +25,22 @@ export interface APIApplicationCommandIntegerOptionBase extends APIApplicationCo
 export type APIApplicationCommandIntegerOption = APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper<
 	APIApplicationCommandIntegerOptionBase,
 	APIApplicationCommandOptionChoice<number>
+>;
+
+export interface APIApplicationCommandIntegerOptionResponseBase extends APIApplicationCommandOptionBaseResponse<ApplicationCommandOptionType.Integer> {
+	/**
+	 * If the option is an `INTEGER` or `NUMBER` type, the minimum value permitted.
+	 */
+	min_value?: number;
+	/**
+	 * If the option is an `INTEGER` or `NUMBER` type, the maximum value permitted.
+	 */
+	max_value?: number;
+}
+
+export type APIApplicationCommandIntegerOptionResponse = APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper<
+	APIApplicationCommandIntegerOptionResponseBase,
+	APIApplicationCommandOptionChoiceResponse<number>
 >;
 
 export interface APIApplicationCommandInteractionDataIntegerOption<

--- a/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/mentionable.ts
+++ b/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/mentionable.ts
@@ -1,9 +1,16 @@
 import type { Snowflake } from '../../../../../globals.ts';
-import type { APIApplicationCommandOptionBase, APIInteractionDataOptionBase } from './base.ts';
+import type {
+	APIApplicationCommandOptionBase,
+	APIApplicationCommandOptionBaseResponse,
+	APIInteractionDataOptionBase,
+} from './base.ts';
 import type { ApplicationCommandOptionType } from './shared.ts';
 
 export type APIApplicationCommandMentionableOption =
 	APIApplicationCommandOptionBase<ApplicationCommandOptionType.Mentionable>;
+
+export type APIApplicationCommandMentionableOptionResponse =
+	APIApplicationCommandOptionBaseResponse<ApplicationCommandOptionType.Mentionable>;
 
 export type APIApplicationCommandInteractionDataMentionableOption = APIInteractionDataOptionBase<
 	ApplicationCommandOptionType.Mentionable,

--- a/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/number.ts
+++ b/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/number.ts
@@ -1,10 +1,15 @@
 import type { InteractionType } from '../../responses.ts';
 import type {
 	APIApplicationCommandOptionBase,
+	APIApplicationCommandOptionBaseResponse,
 	APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper,
 	APIInteractionDataOptionBase,
 } from './base.ts';
-import type { APIApplicationCommandOptionChoice, ApplicationCommandOptionType } from './shared.ts';
+import type {
+	APIApplicationCommandOptionChoice,
+	APIApplicationCommandOptionChoiceResponse,
+	ApplicationCommandOptionType,
+} from './shared.ts';
 
 export interface APIApplicationCommandNumberOptionBase extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.Number> {
 	/**
@@ -20,6 +25,22 @@ export interface APIApplicationCommandNumberOptionBase extends APIApplicationCom
 export type APIApplicationCommandNumberOption = APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper<
 	APIApplicationCommandNumberOptionBase,
 	APIApplicationCommandOptionChoice<number>
+>;
+
+export interface APIApplicationCommandNumberOptionResponseBase extends APIApplicationCommandOptionBaseResponse<ApplicationCommandOptionType.Number> {
+	/**
+	 * If the option is an `INTEGER` or `NUMBER` type, the minimum value permitted.
+	 */
+	min_value?: number;
+	/**
+	 * If the option is an `INTEGER` or `NUMBER` type, the maximum value permitted.
+	 */
+	max_value?: number;
+}
+
+export type APIApplicationCommandNumberOptionResponse = APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper<
+	APIApplicationCommandNumberOptionResponseBase,
+	APIApplicationCommandOptionChoiceResponse<number>
 >;
 
 export interface APIApplicationCommandInteractionDataNumberOption<

--- a/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/role.ts
+++ b/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/role.ts
@@ -1,8 +1,15 @@
 import type { Snowflake } from '../../../../../globals.ts';
-import type { APIApplicationCommandOptionBase, APIInteractionDataOptionBase } from './base.ts';
+import type {
+	APIApplicationCommandOptionBase,
+	APIApplicationCommandOptionBaseResponse,
+	APIInteractionDataOptionBase,
+} from './base.ts';
 import type { ApplicationCommandOptionType } from './shared.ts';
 
 export type APIApplicationCommandRoleOption = APIApplicationCommandOptionBase<ApplicationCommandOptionType.Role>;
+
+export type APIApplicationCommandRoleOptionResponse =
+	APIApplicationCommandOptionBaseResponse<ApplicationCommandOptionType.Role>;
 
 export type APIApplicationCommandInteractionDataRoleOption = APIInteractionDataOptionBase<
 	ApplicationCommandOptionType.Role,

--- a/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/shared.ts
+++ b/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/shared.ts
@@ -25,3 +25,12 @@ export interface APIApplicationCommandOptionChoice<ValueType = number | string> 
 	name_localizations?: LocalizationMap | null;
 	value: ValueType;
 }
+
+/**
+ * @see {@link https://docs.discord.com/developers/interactions/application-commands#application-command-object-application-command-option-choice-structure}
+ */
+export interface APIApplicationCommandOptionChoiceResponse<
+	ValueType = number | string,
+> extends APIApplicationCommandOptionChoice<ValueType> {
+	name_localized?: string;
+}

--- a/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/string.ts
+++ b/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/string.ts
@@ -1,9 +1,14 @@
 import type {
 	APIApplicationCommandOptionBase,
+	APIApplicationCommandOptionBaseResponse,
 	APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper,
 	APIInteractionDataOptionBase,
 } from './base.ts';
-import type { APIApplicationCommandOptionChoice, ApplicationCommandOptionType } from './shared.ts';
+import type {
+	APIApplicationCommandOptionChoice,
+	APIApplicationCommandOptionChoiceResponse,
+	ApplicationCommandOptionType,
+} from './shared.ts';
 
 export interface APIApplicationCommandStringOptionBase extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.String> {
 	/**
@@ -19,6 +24,22 @@ export interface APIApplicationCommandStringOptionBase extends APIApplicationCom
 export type APIApplicationCommandStringOption = APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper<
 	APIApplicationCommandStringOptionBase,
 	APIApplicationCommandOptionChoice<string>
+>;
+
+export interface APIApplicationCommandStringOptionResponseBase extends APIApplicationCommandOptionBaseResponse<ApplicationCommandOptionType.String> {
+	/**
+	 * For option type `STRING`, the minimum allowed length (minimum of `0`, maximum of `6000`).
+	 */
+	min_length?: number;
+	/**
+	 * For option type `STRING`, the maximum allowed length (minimum of `1`, maximum of `6000`).
+	 */
+	max_length?: number;
+}
+
+export type APIApplicationCommandStringOptionResponse = APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper<
+	APIApplicationCommandStringOptionResponseBase,
+	APIApplicationCommandOptionChoiceResponse<string>
 >;
 
 export interface APIApplicationCommandInteractionDataStringOption extends APIInteractionDataOptionBase<

--- a/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/subcommand.ts
+++ b/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/subcommand.ts
@@ -1,10 +1,18 @@
 import type { InteractionType } from '../../responses.ts';
-import type { APIApplicationCommandBasicOption, APIApplicationCommandInteractionDataBasicOption } from '../chatInput.ts';
-import type { APIApplicationCommandOptionBase } from './base.ts';
+import type {
+	APIApplicationCommandBasicOption,
+	APIApplicationCommandBasicOptionResponse,
+	APIApplicationCommandInteractionDataBasicOption,
+} from '../chatInput.ts';
+import type { APIApplicationCommandOptionBase, APIApplicationCommandOptionBaseResponse } from './base.ts';
 import type { ApplicationCommandOptionType } from './shared.ts';
 
 export interface APIApplicationCommandSubcommandOption extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.Subcommand> {
 	options?: APIApplicationCommandBasicOption[];
+}
+
+export interface APIApplicationCommandSubcommandOptionResponse extends APIApplicationCommandOptionBaseResponse<ApplicationCommandOptionType.Subcommand> {
+	options?: APIApplicationCommandBasicOptionResponse[];
 }
 
 export interface APIApplicationCommandInteractionDataSubcommandOption<Type extends InteractionType = InteractionType> {

--- a/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/subcommandGroup.ts
+++ b/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/subcommandGroup.ts
@@ -1,13 +1,18 @@
 import type { InteractionType } from '../../responses.ts';
-import type { APIApplicationCommandOptionBase } from './base.ts';
+import type { APIApplicationCommandOptionBase, APIApplicationCommandOptionBaseResponse } from './base.ts';
 import type { ApplicationCommandOptionType } from './shared.ts';
 import type {
 	APIApplicationCommandInteractionDataSubcommandOption,
 	APIApplicationCommandSubcommandOption,
+	APIApplicationCommandSubcommandOptionResponse,
 } from './subcommand.ts';
 
 export interface APIApplicationCommandSubcommandGroupOption extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.SubcommandGroup> {
 	options?: APIApplicationCommandSubcommandOption[];
+}
+
+export interface APIApplicationCommandSubcommandGroupOptionResponse extends APIApplicationCommandOptionBaseResponse<ApplicationCommandOptionType.SubcommandGroup> {
+	options?: APIApplicationCommandSubcommandOptionResponse[];
 }
 
 export interface APIApplicationCommandInteractionDataSubcommandGroupOption<

--- a/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/user.ts
+++ b/deno/payloads/v9/_interactions/_applicationCommands/_chatInput/user.ts
@@ -1,8 +1,15 @@
 import type { Snowflake } from '../../../../../globals.ts';
-import type { APIApplicationCommandOptionBase, APIInteractionDataOptionBase } from './base.ts';
+import type {
+	APIApplicationCommandOptionBase,
+	APIApplicationCommandOptionBaseResponse,
+	APIInteractionDataOptionBase,
+} from './base.ts';
 import type { ApplicationCommandOptionType } from './shared.ts';
 
 export type APIApplicationCommandUserOption = APIApplicationCommandOptionBase<ApplicationCommandOptionType.User>;
+
+export type APIApplicationCommandUserOptionResponse =
+	APIApplicationCommandOptionBaseResponse<ApplicationCommandOptionType.User>;
 
 export type APIApplicationCommandInteractionDataUserOption = APIInteractionDataOptionBase<
 	ApplicationCommandOptionType.User,

--- a/deno/payloads/v9/_interactions/_applicationCommands/chatInput.ts
+++ b/deno/payloads/v9/_interactions/_applicationCommands/chatInput.ts
@@ -3,47 +3,58 @@ import type { APIApplicationCommandInteractionWrapper, ApplicationCommandType } 
 import type { APIDMInteractionWrapper, APIGuildInteractionWrapper } from '../base.ts';
 import type {
 	APIApplicationCommandAttachmentOption,
+	APIApplicationCommandAttachmentOptionResponse,
 	APIApplicationCommandInteractionDataAttachmentOption,
 } from './_chatInput/attachment.ts';
 import type {
 	APIApplicationCommandBooleanOption,
+	APIApplicationCommandBooleanOptionResponse,
 	APIApplicationCommandInteractionDataBooleanOption,
 } from './_chatInput/boolean.ts';
 import type {
 	APIApplicationCommandChannelOption,
+	APIApplicationCommandChannelOptionResponse,
 	APIApplicationCommandInteractionDataChannelOption,
 } from './_chatInput/channel.ts';
 import type {
 	APIApplicationCommandIntegerOption,
+	APIApplicationCommandIntegerOptionResponse,
 	APIApplicationCommandInteractionDataIntegerOption,
 } from './_chatInput/integer.ts';
 import type {
 	APIApplicationCommandInteractionDataMentionableOption,
 	APIApplicationCommandMentionableOption,
+	APIApplicationCommandMentionableOptionResponse,
 } from './_chatInput/mentionable.ts';
 import type {
 	APIApplicationCommandInteractionDataNumberOption,
 	APIApplicationCommandNumberOption,
+	APIApplicationCommandNumberOptionResponse,
 } from './_chatInput/number.ts';
 import type {
 	APIApplicationCommandInteractionDataRoleOption,
 	APIApplicationCommandRoleOption,
+	APIApplicationCommandRoleOptionResponse,
 } from './_chatInput/role.ts';
 import type {
 	APIApplicationCommandInteractionDataStringOption,
 	APIApplicationCommandStringOption,
+	APIApplicationCommandStringOptionResponse,
 } from './_chatInput/string.ts';
 import type {
 	APIApplicationCommandInteractionDataSubcommandOption,
 	APIApplicationCommandSubcommandOption,
+	APIApplicationCommandSubcommandOptionResponse,
 } from './_chatInput/subcommand.ts';
 import type {
 	APIApplicationCommandInteractionDataSubcommandGroupOption,
 	APIApplicationCommandSubcommandGroupOption,
+	APIApplicationCommandSubcommandGroupOptionResponse,
 } from './_chatInput/subcommandGroup.ts';
 import type {
 	APIApplicationCommandInteractionDataUserOption,
 	APIApplicationCommandUserOption,
+	APIApplicationCommandUserOptionResponse,
 } from './_chatInput/user.ts';
 import type { APIBaseApplicationCommandInteractionData } from './internals.ts';
 
@@ -76,12 +87,34 @@ export type APIApplicationCommandBasicOption =
 	| APIApplicationCommandUserOption;
 
 /**
+ * @see {@link https://docs.discord.com/developers/interactions/application-commands#application-command-object-application-command-option-structure}
+ */
+export type APIApplicationCommandBasicOptionResponse =
+	| APIApplicationCommandAttachmentOptionResponse
+	| APIApplicationCommandBooleanOptionResponse
+	| APIApplicationCommandChannelOptionResponse
+	| APIApplicationCommandIntegerOptionResponse
+	| APIApplicationCommandMentionableOptionResponse
+	| APIApplicationCommandNumberOptionResponse
+	| APIApplicationCommandRoleOptionResponse
+	| APIApplicationCommandStringOptionResponse
+	| APIApplicationCommandUserOptionResponse;
+
+/**
  * @see {@link https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure}
  */
 export type APIApplicationCommandOption =
 	| APIApplicationCommandBasicOption
 	| APIApplicationCommandSubcommandGroupOption
 	| APIApplicationCommandSubcommandOption;
+
+/**
+ * @see {@link https://docs.discord.com/developers/interactions/application-commands#application-command-object-application-command-option-structure}
+ */
+export type APIApplicationCommandOptionResponse =
+	| APIApplicationCommandBasicOptionResponse
+	| APIApplicationCommandSubcommandGroupOptionResponse
+	| APIApplicationCommandSubcommandOptionResponse;
 
 /**
  * @see {@link https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-interaction-data-option-structure}

--- a/deno/payloads/v9/_interactions/applicationCommands.ts
+++ b/deno/payloads/v9/_interactions/applicationCommands.ts
@@ -1,7 +1,7 @@
 import type { Permissions, Snowflake } from '../../../globals.ts';
 import type { LocalizationMap } from '../../../v9.ts';
 import type {
-	APIApplicationCommandOption,
+	APIApplicationCommandOptionResponse,
 	APIChatInputApplicationCommandDMInteraction,
 	APIChatInputApplicationCommandGuildInteraction,
 	APIChatInputApplicationCommandInteraction,
@@ -75,7 +75,7 @@ export interface APIApplicationCommand {
 	/**
 	 * The parameters for the `CHAT_INPUT` command, max 25
 	 */
-	options?: APIApplicationCommandOption[];
+	options?: APIApplicationCommandOptionResponse[];
 	/**
 	 * Set of permissions represented as a bitset
 	 */

--- a/payloads/v10/_interactions/_applicationCommands/_chatInput/attachment.ts
+++ b/payloads/v10/_interactions/_applicationCommands/_chatInput/attachment.ts
@@ -1,10 +1,18 @@
 import type { Snowflake } from '../../../../../globals';
-import type { APIApplicationCommandOptionBase, APIInteractionDataOptionBase } from './base';
+import type {
+	APIApplicationCommandOptionBase,
+	APIApplicationCommandOptionBaseResponse,
+	APIInteractionDataOptionBase,
+} from './base';
 import type { ApplicationCommandOptionType } from './shared';
 
 export type FileUploadType = 'audio' | 'image' | 'video' | `.${string}`;
 
 export interface APIApplicationCommandAttachmentOption extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.Attachment> {
+	file_types?: FileUploadType[];
+}
+
+export interface APIApplicationCommandAttachmentOptionResponse extends APIApplicationCommandOptionBaseResponse<ApplicationCommandOptionType.Attachment> {
 	file_types?: FileUploadType[];
 }
 

--- a/payloads/v10/_interactions/_applicationCommands/_chatInput/base.ts
+++ b/payloads/v10/_interactions/_applicationCommands/_chatInput/base.ts
@@ -10,6 +10,13 @@ export interface APIApplicationCommandOptionBase<Type extends ApplicationCommand
 	required?: boolean;
 }
 
+export interface APIApplicationCommandOptionBaseResponse<
+	Type extends ApplicationCommandOptionType,
+> extends APIApplicationCommandOptionBase<Type> {
+	name_localized?: string;
+	description_localized?: string;
+}
+
 export interface APIInteractionDataOptionBase<T extends ApplicationCommandOptionType, D> {
 	name: string;
 	type: T;

--- a/payloads/v10/_interactions/_applicationCommands/_chatInput/boolean.ts
+++ b/payloads/v10/_interactions/_applicationCommands/_chatInput/boolean.ts
@@ -1,7 +1,14 @@
-import type { APIApplicationCommandOptionBase, APIInteractionDataOptionBase } from './base';
+import type {
+	APIApplicationCommandOptionBase,
+	APIApplicationCommandOptionBaseResponse,
+	APIInteractionDataOptionBase,
+} from './base';
 import type { ApplicationCommandOptionType } from './shared';
 
 export type APIApplicationCommandBooleanOption = APIApplicationCommandOptionBase<ApplicationCommandOptionType.Boolean>;
+
+export type APIApplicationCommandBooleanOptionResponse =
+	APIApplicationCommandOptionBaseResponse<ApplicationCommandOptionType.Boolean>;
 
 export type APIApplicationCommandInteractionDataBooleanOption = APIInteractionDataOptionBase<
 	ApplicationCommandOptionType.Boolean,

--- a/payloads/v10/_interactions/_applicationCommands/_chatInput/channel.ts
+++ b/payloads/v10/_interactions/_applicationCommands/_chatInput/channel.ts
@@ -1,9 +1,17 @@
 import type { Snowflake } from '../../../../../globals';
 import type { ApplicationCommandOptionAllowedChannelType } from '../../../channel';
-import type { APIApplicationCommandOptionBase, APIInteractionDataOptionBase } from './base';
+import type {
+	APIApplicationCommandOptionBase,
+	APIApplicationCommandOptionBaseResponse,
+	APIInteractionDataOptionBase,
+} from './base';
 import type { ApplicationCommandOptionType } from './shared';
 
 export interface APIApplicationCommandChannelOption extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.Channel> {
+	channel_types?: ApplicationCommandOptionAllowedChannelType[];
+}
+
+export interface APIApplicationCommandChannelOptionResponse extends APIApplicationCommandOptionBaseResponse<ApplicationCommandOptionType.Channel> {
 	channel_types?: ApplicationCommandOptionAllowedChannelType[];
 }
 

--- a/payloads/v10/_interactions/_applicationCommands/_chatInput/integer.ts
+++ b/payloads/v10/_interactions/_applicationCommands/_chatInput/integer.ts
@@ -1,10 +1,15 @@
 import type { InteractionType } from '../../responses';
 import type {
 	APIApplicationCommandOptionBase,
+	APIApplicationCommandOptionBaseResponse,
 	APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper,
 	APIInteractionDataOptionBase,
 } from './base';
-import type { APIApplicationCommandOptionChoice, ApplicationCommandOptionType } from './shared';
+import type {
+	APIApplicationCommandOptionChoice,
+	APIApplicationCommandOptionChoiceResponse,
+	ApplicationCommandOptionType,
+} from './shared';
 
 export interface APIApplicationCommandIntegerOptionBase extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.Integer> {
 	/**
@@ -20,6 +25,22 @@ export interface APIApplicationCommandIntegerOptionBase extends APIApplicationCo
 export type APIApplicationCommandIntegerOption = APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper<
 	APIApplicationCommandIntegerOptionBase,
 	APIApplicationCommandOptionChoice<number>
+>;
+
+export interface APIApplicationCommandIntegerOptionResponseBase extends APIApplicationCommandOptionBaseResponse<ApplicationCommandOptionType.Integer> {
+	/**
+	 * If the option is an `INTEGER` or `NUMBER` type, the minimum value permitted.
+	 */
+	min_value?: number;
+	/**
+	 * If the option is an `INTEGER` or `NUMBER` type, the maximum value permitted.
+	 */
+	max_value?: number;
+}
+
+export type APIApplicationCommandIntegerOptionResponse = APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper<
+	APIApplicationCommandIntegerOptionResponseBase,
+	APIApplicationCommandOptionChoiceResponse<number>
 >;
 
 export interface APIApplicationCommandInteractionDataIntegerOption<

--- a/payloads/v10/_interactions/_applicationCommands/_chatInput/mentionable.ts
+++ b/payloads/v10/_interactions/_applicationCommands/_chatInput/mentionable.ts
@@ -1,9 +1,16 @@
 import type { Snowflake } from '../../../../../globals';
-import type { APIApplicationCommandOptionBase, APIInteractionDataOptionBase } from './base';
+import type {
+	APIApplicationCommandOptionBase,
+	APIApplicationCommandOptionBaseResponse,
+	APIInteractionDataOptionBase,
+} from './base';
 import type { ApplicationCommandOptionType } from './shared';
 
 export type APIApplicationCommandMentionableOption =
 	APIApplicationCommandOptionBase<ApplicationCommandOptionType.Mentionable>;
+
+export type APIApplicationCommandMentionableOptionResponse =
+	APIApplicationCommandOptionBaseResponse<ApplicationCommandOptionType.Mentionable>;
 
 export type APIApplicationCommandInteractionDataMentionableOption = APIInteractionDataOptionBase<
 	ApplicationCommandOptionType.Mentionable,

--- a/payloads/v10/_interactions/_applicationCommands/_chatInput/number.ts
+++ b/payloads/v10/_interactions/_applicationCommands/_chatInput/number.ts
@@ -1,10 +1,15 @@
 import type { InteractionType } from '../../responses';
 import type {
 	APIApplicationCommandOptionBase,
+	APIApplicationCommandOptionBaseResponse,
 	APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper,
 	APIInteractionDataOptionBase,
 } from './base';
-import type { APIApplicationCommandOptionChoice, ApplicationCommandOptionType } from './shared';
+import type {
+	APIApplicationCommandOptionChoice,
+	APIApplicationCommandOptionChoiceResponse,
+	ApplicationCommandOptionType,
+} from './shared';
 
 export interface APIApplicationCommandNumberOptionBase extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.Number> {
 	/**
@@ -20,6 +25,22 @@ export interface APIApplicationCommandNumberOptionBase extends APIApplicationCom
 export type APIApplicationCommandNumberOption = APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper<
 	APIApplicationCommandNumberOptionBase,
 	APIApplicationCommandOptionChoice<number>
+>;
+
+export interface APIApplicationCommandNumberOptionResponseBase extends APIApplicationCommandOptionBaseResponse<ApplicationCommandOptionType.Number> {
+	/**
+	 * If the option is an `INTEGER` or `NUMBER` type, the minimum value permitted.
+	 */
+	min_value?: number;
+	/**
+	 * If the option is an `INTEGER` or `NUMBER` type, the maximum value permitted.
+	 */
+	max_value?: number;
+}
+
+export type APIApplicationCommandNumberOptionResponse = APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper<
+	APIApplicationCommandNumberOptionResponseBase,
+	APIApplicationCommandOptionChoiceResponse<number>
 >;
 
 export interface APIApplicationCommandInteractionDataNumberOption<

--- a/payloads/v10/_interactions/_applicationCommands/_chatInput/role.ts
+++ b/payloads/v10/_interactions/_applicationCommands/_chatInput/role.ts
@@ -1,8 +1,15 @@
 import type { Snowflake } from '../../../../../globals';
-import type { APIApplicationCommandOptionBase, APIInteractionDataOptionBase } from './base';
+import type {
+	APIApplicationCommandOptionBase,
+	APIApplicationCommandOptionBaseResponse,
+	APIInteractionDataOptionBase,
+} from './base';
 import type { ApplicationCommandOptionType } from './shared';
 
 export type APIApplicationCommandRoleOption = APIApplicationCommandOptionBase<ApplicationCommandOptionType.Role>;
+
+export type APIApplicationCommandRoleOptionResponse =
+	APIApplicationCommandOptionBaseResponse<ApplicationCommandOptionType.Role>;
 
 export type APIApplicationCommandInteractionDataRoleOption = APIInteractionDataOptionBase<
 	ApplicationCommandOptionType.Role,

--- a/payloads/v10/_interactions/_applicationCommands/_chatInput/shared.ts
+++ b/payloads/v10/_interactions/_applicationCommands/_chatInput/shared.ts
@@ -25,3 +25,12 @@ export interface APIApplicationCommandOptionChoice<ValueType = number | string> 
 	name_localizations?: LocalizationMap | null;
 	value: ValueType;
 }
+
+/**
+ * @see {@link https://docs.discord.com/developers/interactions/application-commands#application-command-object-application-command-option-choice-structure}
+ */
+export interface APIApplicationCommandOptionChoiceResponse<
+	ValueType = number | string,
+> extends APIApplicationCommandOptionChoice<ValueType> {
+	name_localized?: string;
+}

--- a/payloads/v10/_interactions/_applicationCommands/_chatInput/string.ts
+++ b/payloads/v10/_interactions/_applicationCommands/_chatInput/string.ts
@@ -1,9 +1,14 @@
 import type {
 	APIApplicationCommandOptionBase,
+	APIApplicationCommandOptionBaseResponse,
 	APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper,
 	APIInteractionDataOptionBase,
 } from './base';
-import type { APIApplicationCommandOptionChoice, ApplicationCommandOptionType } from './shared';
+import type {
+	APIApplicationCommandOptionChoice,
+	APIApplicationCommandOptionChoiceResponse,
+	ApplicationCommandOptionType,
+} from './shared';
 
 export interface APIApplicationCommandStringOptionBase extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.String> {
 	/**
@@ -19,6 +24,22 @@ export interface APIApplicationCommandStringOptionBase extends APIApplicationCom
 export type APIApplicationCommandStringOption = APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper<
 	APIApplicationCommandStringOptionBase,
 	APIApplicationCommandOptionChoice<string>
+>;
+
+export interface APIApplicationCommandStringOptionResponseBase extends APIApplicationCommandOptionBaseResponse<ApplicationCommandOptionType.String> {
+	/**
+	 * For option type `STRING`, the minimum allowed length (minimum of `0`, maximum of `6000`).
+	 */
+	min_length?: number;
+	/**
+	 * For option type `STRING`, the maximum allowed length (minimum of `1`, maximum of `6000`).
+	 */
+	max_length?: number;
+}
+
+export type APIApplicationCommandStringOptionResponse = APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper<
+	APIApplicationCommandStringOptionResponseBase,
+	APIApplicationCommandOptionChoiceResponse<string>
 >;
 
 export interface APIApplicationCommandInteractionDataStringOption extends APIInteractionDataOptionBase<

--- a/payloads/v10/_interactions/_applicationCommands/_chatInput/subcommand.ts
+++ b/payloads/v10/_interactions/_applicationCommands/_chatInput/subcommand.ts
@@ -1,10 +1,18 @@
 import type { InteractionType } from '../../responses';
-import type { APIApplicationCommandBasicOption, APIApplicationCommandInteractionDataBasicOption } from '../chatInput';
-import type { APIApplicationCommandOptionBase } from './base';
+import type {
+	APIApplicationCommandBasicOption,
+	APIApplicationCommandBasicOptionResponse,
+	APIApplicationCommandInteractionDataBasicOption,
+} from '../chatInput';
+import type { APIApplicationCommandOptionBase, APIApplicationCommandOptionBaseResponse } from './base';
 import type { ApplicationCommandOptionType } from './shared';
 
 export interface APIApplicationCommandSubcommandOption extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.Subcommand> {
 	options?: APIApplicationCommandBasicOption[];
+}
+
+export interface APIApplicationCommandSubcommandOptionResponse extends APIApplicationCommandOptionBaseResponse<ApplicationCommandOptionType.Subcommand> {
+	options?: APIApplicationCommandBasicOptionResponse[];
 }
 
 export interface APIApplicationCommandInteractionDataSubcommandOption<Type extends InteractionType = InteractionType> {

--- a/payloads/v10/_interactions/_applicationCommands/_chatInput/subcommandGroup.ts
+++ b/payloads/v10/_interactions/_applicationCommands/_chatInput/subcommandGroup.ts
@@ -1,13 +1,18 @@
 import type { InteractionType } from '../../responses';
-import type { APIApplicationCommandOptionBase } from './base';
+import type { APIApplicationCommandOptionBase, APIApplicationCommandOptionBaseResponse } from './base';
 import type { ApplicationCommandOptionType } from './shared';
 import type {
 	APIApplicationCommandInteractionDataSubcommandOption,
 	APIApplicationCommandSubcommandOption,
+	APIApplicationCommandSubcommandOptionResponse,
 } from './subcommand';
 
 export interface APIApplicationCommandSubcommandGroupOption extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.SubcommandGroup> {
 	options?: APIApplicationCommandSubcommandOption[];
+}
+
+export interface APIApplicationCommandSubcommandGroupOptionResponse extends APIApplicationCommandOptionBaseResponse<ApplicationCommandOptionType.SubcommandGroup> {
+	options?: APIApplicationCommandSubcommandOptionResponse[];
 }
 
 export interface APIApplicationCommandInteractionDataSubcommandGroupOption<

--- a/payloads/v10/_interactions/_applicationCommands/_chatInput/user.ts
+++ b/payloads/v10/_interactions/_applicationCommands/_chatInput/user.ts
@@ -1,8 +1,15 @@
 import type { Snowflake } from '../../../../../globals';
-import type { APIApplicationCommandOptionBase, APIInteractionDataOptionBase } from './base';
+import type {
+	APIApplicationCommandOptionBase,
+	APIApplicationCommandOptionBaseResponse,
+	APIInteractionDataOptionBase,
+} from './base';
 import type { ApplicationCommandOptionType } from './shared';
 
 export type APIApplicationCommandUserOption = APIApplicationCommandOptionBase<ApplicationCommandOptionType.User>;
+
+export type APIApplicationCommandUserOptionResponse =
+	APIApplicationCommandOptionBaseResponse<ApplicationCommandOptionType.User>;
 
 export type APIApplicationCommandInteractionDataUserOption = APIInteractionDataOptionBase<
 	ApplicationCommandOptionType.User,

--- a/payloads/v10/_interactions/_applicationCommands/chatInput.ts
+++ b/payloads/v10/_interactions/_applicationCommands/chatInput.ts
@@ -3,47 +3,58 @@ import type { APIApplicationCommandInteractionWrapper, ApplicationCommandType } 
 import type { APIDMInteractionWrapper, APIGuildInteractionWrapper } from '../base';
 import type {
 	APIApplicationCommandAttachmentOption,
+	APIApplicationCommandAttachmentOptionResponse,
 	APIApplicationCommandInteractionDataAttachmentOption,
 } from './_chatInput/attachment';
 import type {
 	APIApplicationCommandBooleanOption,
+	APIApplicationCommandBooleanOptionResponse,
 	APIApplicationCommandInteractionDataBooleanOption,
 } from './_chatInput/boolean';
 import type {
 	APIApplicationCommandChannelOption,
+	APIApplicationCommandChannelOptionResponse,
 	APIApplicationCommandInteractionDataChannelOption,
 } from './_chatInput/channel';
 import type {
 	APIApplicationCommandIntegerOption,
+	APIApplicationCommandIntegerOptionResponse,
 	APIApplicationCommandInteractionDataIntegerOption,
 } from './_chatInput/integer';
 import type {
 	APIApplicationCommandInteractionDataMentionableOption,
 	APIApplicationCommandMentionableOption,
+	APIApplicationCommandMentionableOptionResponse,
 } from './_chatInput/mentionable';
 import type {
 	APIApplicationCommandInteractionDataNumberOption,
 	APIApplicationCommandNumberOption,
+	APIApplicationCommandNumberOptionResponse,
 } from './_chatInput/number';
 import type {
 	APIApplicationCommandInteractionDataRoleOption,
 	APIApplicationCommandRoleOption,
+	APIApplicationCommandRoleOptionResponse,
 } from './_chatInput/role';
 import type {
 	APIApplicationCommandInteractionDataStringOption,
 	APIApplicationCommandStringOption,
+	APIApplicationCommandStringOptionResponse,
 } from './_chatInput/string';
 import type {
 	APIApplicationCommandInteractionDataSubcommandOption,
 	APIApplicationCommandSubcommandOption,
+	APIApplicationCommandSubcommandOptionResponse,
 } from './_chatInput/subcommand';
 import type {
 	APIApplicationCommandInteractionDataSubcommandGroupOption,
 	APIApplicationCommandSubcommandGroupOption,
+	APIApplicationCommandSubcommandGroupOptionResponse,
 } from './_chatInput/subcommandGroup';
 import type {
 	APIApplicationCommandInteractionDataUserOption,
 	APIApplicationCommandUserOption,
+	APIApplicationCommandUserOptionResponse,
 } from './_chatInput/user';
 import type { APIBaseApplicationCommandInteractionData } from './internals';
 
@@ -76,12 +87,34 @@ export type APIApplicationCommandBasicOption =
 	| APIApplicationCommandUserOption;
 
 /**
+ * @see {@link https://docs.discord.com/developers/interactions/application-commands#application-command-object-application-command-option-structure}
+ */
+export type APIApplicationCommandBasicOptionResponse =
+	| APIApplicationCommandAttachmentOptionResponse
+	| APIApplicationCommandBooleanOptionResponse
+	| APIApplicationCommandChannelOptionResponse
+	| APIApplicationCommandIntegerOptionResponse
+	| APIApplicationCommandMentionableOptionResponse
+	| APIApplicationCommandNumberOptionResponse
+	| APIApplicationCommandRoleOptionResponse
+	| APIApplicationCommandStringOptionResponse
+	| APIApplicationCommandUserOptionResponse;
+
+/**
  * @see {@link https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure}
  */
 export type APIApplicationCommandOption =
 	| APIApplicationCommandBasicOption
 	| APIApplicationCommandSubcommandGroupOption
 	| APIApplicationCommandSubcommandOption;
+
+/**
+ * @see {@link https://docs.discord.com/developers/interactions/application-commands#application-command-object-application-command-option-structure}
+ */
+export type APIApplicationCommandOptionResponse =
+	| APIApplicationCommandBasicOptionResponse
+	| APIApplicationCommandSubcommandGroupOptionResponse
+	| APIApplicationCommandSubcommandOptionResponse;
 
 /**
  * @see {@link https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-interaction-data-option-structure}

--- a/payloads/v10/_interactions/applicationCommands.ts
+++ b/payloads/v10/_interactions/applicationCommands.ts
@@ -1,7 +1,7 @@
 import type { Permissions, Snowflake } from '../../../globals';
 import type { LocalizationMap } from '../../../v10';
 import type {
-	APIApplicationCommandOption,
+	APIApplicationCommandOptionResponse,
 	APIChatInputApplicationCommandDMInteraction,
 	APIChatInputApplicationCommandGuildInteraction,
 	APIChatInputApplicationCommandInteraction,
@@ -75,7 +75,7 @@ export interface APIApplicationCommand {
 	/**
 	 * The parameters for the `CHAT_INPUT` command, max 25
 	 */
-	options?: APIApplicationCommandOption[];
+	options?: APIApplicationCommandOptionResponse[];
 	/**
 	 * Set of permissions represented as a bitset
 	 */

--- a/payloads/v9/_interactions/_applicationCommands/_chatInput/attachment.ts
+++ b/payloads/v9/_interactions/_applicationCommands/_chatInput/attachment.ts
@@ -1,10 +1,18 @@
 import type { Snowflake } from '../../../../../globals';
-import type { APIApplicationCommandOptionBase, APIInteractionDataOptionBase } from './base';
+import type {
+	APIApplicationCommandOptionBase,
+	APIApplicationCommandOptionBaseResponse,
+	APIInteractionDataOptionBase,
+} from './base';
 import type { ApplicationCommandOptionType } from './shared';
 
 export type FileUploadType = 'audio' | 'image' | 'video' | `.${string}`;
 
 export interface APIApplicationCommandAttachmentOption extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.Attachment> {
+	file_types?: FileUploadType[];
+}
+
+export interface APIApplicationCommandAttachmentOptionResponse extends APIApplicationCommandOptionBaseResponse<ApplicationCommandOptionType.Attachment> {
 	file_types?: FileUploadType[];
 }
 

--- a/payloads/v9/_interactions/_applicationCommands/_chatInput/base.ts
+++ b/payloads/v9/_interactions/_applicationCommands/_chatInput/base.ts
@@ -10,6 +10,13 @@ export interface APIApplicationCommandOptionBase<Type extends ApplicationCommand
 	required?: boolean;
 }
 
+export interface APIApplicationCommandOptionBaseResponse<
+	Type extends ApplicationCommandOptionType,
+> extends APIApplicationCommandOptionBase<Type> {
+	name_localized?: string;
+	description_localized?: string;
+}
+
 export interface APIInteractionDataOptionBase<T extends ApplicationCommandOptionType, D> {
 	name: string;
 	type: T;

--- a/payloads/v9/_interactions/_applicationCommands/_chatInput/boolean.ts
+++ b/payloads/v9/_interactions/_applicationCommands/_chatInput/boolean.ts
@@ -1,7 +1,14 @@
-import type { APIApplicationCommandOptionBase, APIInteractionDataOptionBase } from './base';
+import type {
+	APIApplicationCommandOptionBase,
+	APIApplicationCommandOptionBaseResponse,
+	APIInteractionDataOptionBase,
+} from './base';
 import type { ApplicationCommandOptionType } from './shared';
 
 export type APIApplicationCommandBooleanOption = APIApplicationCommandOptionBase<ApplicationCommandOptionType.Boolean>;
+
+export type APIApplicationCommandBooleanOptionResponse =
+	APIApplicationCommandOptionBaseResponse<ApplicationCommandOptionType.Boolean>;
 
 export type APIApplicationCommandInteractionDataBooleanOption = APIInteractionDataOptionBase<
 	ApplicationCommandOptionType.Boolean,

--- a/payloads/v9/_interactions/_applicationCommands/_chatInput/channel.ts
+++ b/payloads/v9/_interactions/_applicationCommands/_chatInput/channel.ts
@@ -1,9 +1,17 @@
 import type { Snowflake } from '../../../../../globals';
 import type { ChannelType } from '../../../channel';
-import type { APIApplicationCommandOptionBase, APIInteractionDataOptionBase } from './base';
+import type {
+	APIApplicationCommandOptionBase,
+	APIApplicationCommandOptionBaseResponse,
+	APIInteractionDataOptionBase,
+} from './base';
 import type { ApplicationCommandOptionType } from './shared';
 
 export interface APIApplicationCommandChannelOption extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.Channel> {
+	channel_types?: Exclude<ChannelType, ChannelType.GuildDirectory>[];
+}
+
+export interface APIApplicationCommandChannelOptionResponse extends APIApplicationCommandOptionBaseResponse<ApplicationCommandOptionType.Channel> {
 	channel_types?: Exclude<ChannelType, ChannelType.GuildDirectory>[];
 }
 

--- a/payloads/v9/_interactions/_applicationCommands/_chatInput/integer.ts
+++ b/payloads/v9/_interactions/_applicationCommands/_chatInput/integer.ts
@@ -1,10 +1,15 @@
 import type { InteractionType } from '../../responses';
 import type {
 	APIApplicationCommandOptionBase,
+	APIApplicationCommandOptionBaseResponse,
 	APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper,
 	APIInteractionDataOptionBase,
 } from './base';
-import type { APIApplicationCommandOptionChoice, ApplicationCommandOptionType } from './shared';
+import type {
+	APIApplicationCommandOptionChoice,
+	APIApplicationCommandOptionChoiceResponse,
+	ApplicationCommandOptionType,
+} from './shared';
 
 export interface APIApplicationCommandIntegerOptionBase extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.Integer> {
 	/**
@@ -20,6 +25,22 @@ export interface APIApplicationCommandIntegerOptionBase extends APIApplicationCo
 export type APIApplicationCommandIntegerOption = APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper<
 	APIApplicationCommandIntegerOptionBase,
 	APIApplicationCommandOptionChoice<number>
+>;
+
+export interface APIApplicationCommandIntegerOptionResponseBase extends APIApplicationCommandOptionBaseResponse<ApplicationCommandOptionType.Integer> {
+	/**
+	 * If the option is an `INTEGER` or `NUMBER` type, the minimum value permitted.
+	 */
+	min_value?: number;
+	/**
+	 * If the option is an `INTEGER` or `NUMBER` type, the maximum value permitted.
+	 */
+	max_value?: number;
+}
+
+export type APIApplicationCommandIntegerOptionResponse = APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper<
+	APIApplicationCommandIntegerOptionResponseBase,
+	APIApplicationCommandOptionChoiceResponse<number>
 >;
 
 export interface APIApplicationCommandInteractionDataIntegerOption<

--- a/payloads/v9/_interactions/_applicationCommands/_chatInput/mentionable.ts
+++ b/payloads/v9/_interactions/_applicationCommands/_chatInput/mentionable.ts
@@ -1,9 +1,16 @@
 import type { Snowflake } from '../../../../../globals';
-import type { APIApplicationCommandOptionBase, APIInteractionDataOptionBase } from './base';
+import type {
+	APIApplicationCommandOptionBase,
+	APIApplicationCommandOptionBaseResponse,
+	APIInteractionDataOptionBase,
+} from './base';
 import type { ApplicationCommandOptionType } from './shared';
 
 export type APIApplicationCommandMentionableOption =
 	APIApplicationCommandOptionBase<ApplicationCommandOptionType.Mentionable>;
+
+export type APIApplicationCommandMentionableOptionResponse =
+	APIApplicationCommandOptionBaseResponse<ApplicationCommandOptionType.Mentionable>;
 
 export type APIApplicationCommandInteractionDataMentionableOption = APIInteractionDataOptionBase<
 	ApplicationCommandOptionType.Mentionable,

--- a/payloads/v9/_interactions/_applicationCommands/_chatInput/number.ts
+++ b/payloads/v9/_interactions/_applicationCommands/_chatInput/number.ts
@@ -1,10 +1,15 @@
 import type { InteractionType } from '../../responses';
 import type {
 	APIApplicationCommandOptionBase,
+	APIApplicationCommandOptionBaseResponse,
 	APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper,
 	APIInteractionDataOptionBase,
 } from './base';
-import type { APIApplicationCommandOptionChoice, ApplicationCommandOptionType } from './shared';
+import type {
+	APIApplicationCommandOptionChoice,
+	APIApplicationCommandOptionChoiceResponse,
+	ApplicationCommandOptionType,
+} from './shared';
 
 export interface APIApplicationCommandNumberOptionBase extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.Number> {
 	/**
@@ -20,6 +25,22 @@ export interface APIApplicationCommandNumberOptionBase extends APIApplicationCom
 export type APIApplicationCommandNumberOption = APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper<
 	APIApplicationCommandNumberOptionBase,
 	APIApplicationCommandOptionChoice<number>
+>;
+
+export interface APIApplicationCommandNumberOptionResponseBase extends APIApplicationCommandOptionBaseResponse<ApplicationCommandOptionType.Number> {
+	/**
+	 * If the option is an `INTEGER` or `NUMBER` type, the minimum value permitted.
+	 */
+	min_value?: number;
+	/**
+	 * If the option is an `INTEGER` or `NUMBER` type, the maximum value permitted.
+	 */
+	max_value?: number;
+}
+
+export type APIApplicationCommandNumberOptionResponse = APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper<
+	APIApplicationCommandNumberOptionResponseBase,
+	APIApplicationCommandOptionChoiceResponse<number>
 >;
 
 export interface APIApplicationCommandInteractionDataNumberOption<

--- a/payloads/v9/_interactions/_applicationCommands/_chatInput/role.ts
+++ b/payloads/v9/_interactions/_applicationCommands/_chatInput/role.ts
@@ -1,8 +1,15 @@
 import type { Snowflake } from '../../../../../globals';
-import type { APIApplicationCommandOptionBase, APIInteractionDataOptionBase } from './base';
+import type {
+	APIApplicationCommandOptionBase,
+	APIApplicationCommandOptionBaseResponse,
+	APIInteractionDataOptionBase,
+} from './base';
 import type { ApplicationCommandOptionType } from './shared';
 
 export type APIApplicationCommandRoleOption = APIApplicationCommandOptionBase<ApplicationCommandOptionType.Role>;
+
+export type APIApplicationCommandRoleOptionResponse =
+	APIApplicationCommandOptionBaseResponse<ApplicationCommandOptionType.Role>;
 
 export type APIApplicationCommandInteractionDataRoleOption = APIInteractionDataOptionBase<
 	ApplicationCommandOptionType.Role,

--- a/payloads/v9/_interactions/_applicationCommands/_chatInput/shared.ts
+++ b/payloads/v9/_interactions/_applicationCommands/_chatInput/shared.ts
@@ -25,3 +25,12 @@ export interface APIApplicationCommandOptionChoice<ValueType = number | string> 
 	name_localizations?: LocalizationMap | null;
 	value: ValueType;
 }
+
+/**
+ * @see {@link https://docs.discord.com/developers/interactions/application-commands#application-command-object-application-command-option-choice-structure}
+ */
+export interface APIApplicationCommandOptionChoiceResponse<
+	ValueType = number | string,
+> extends APIApplicationCommandOptionChoice<ValueType> {
+	name_localized?: string;
+}

--- a/payloads/v9/_interactions/_applicationCommands/_chatInput/string.ts
+++ b/payloads/v9/_interactions/_applicationCommands/_chatInput/string.ts
@@ -1,9 +1,14 @@
 import type {
 	APIApplicationCommandOptionBase,
+	APIApplicationCommandOptionBaseResponse,
 	APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper,
 	APIInteractionDataOptionBase,
 } from './base';
-import type { APIApplicationCommandOptionChoice, ApplicationCommandOptionType } from './shared';
+import type {
+	APIApplicationCommandOptionChoice,
+	APIApplicationCommandOptionChoiceResponse,
+	ApplicationCommandOptionType,
+} from './shared';
 
 export interface APIApplicationCommandStringOptionBase extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.String> {
 	/**
@@ -19,6 +24,22 @@ export interface APIApplicationCommandStringOptionBase extends APIApplicationCom
 export type APIApplicationCommandStringOption = APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper<
 	APIApplicationCommandStringOptionBase,
 	APIApplicationCommandOptionChoice<string>
+>;
+
+export interface APIApplicationCommandStringOptionResponseBase extends APIApplicationCommandOptionBaseResponse<ApplicationCommandOptionType.String> {
+	/**
+	 * For option type `STRING`, the minimum allowed length (minimum of `0`, maximum of `6000`).
+	 */
+	min_length?: number;
+	/**
+	 * For option type `STRING`, the maximum allowed length (minimum of `1`, maximum of `6000`).
+	 */
+	max_length?: number;
+}
+
+export type APIApplicationCommandStringOptionResponse = APIApplicationCommandOptionWithAutocompleteOrChoicesWrapper<
+	APIApplicationCommandStringOptionResponseBase,
+	APIApplicationCommandOptionChoiceResponse<string>
 >;
 
 export interface APIApplicationCommandInteractionDataStringOption extends APIInteractionDataOptionBase<

--- a/payloads/v9/_interactions/_applicationCommands/_chatInput/subcommand.ts
+++ b/payloads/v9/_interactions/_applicationCommands/_chatInput/subcommand.ts
@@ -1,10 +1,18 @@
 import type { InteractionType } from '../../responses';
-import type { APIApplicationCommandBasicOption, APIApplicationCommandInteractionDataBasicOption } from '../chatInput';
-import type { APIApplicationCommandOptionBase } from './base';
+import type {
+	APIApplicationCommandBasicOption,
+	APIApplicationCommandBasicOptionResponse,
+	APIApplicationCommandInteractionDataBasicOption,
+} from '../chatInput';
+import type { APIApplicationCommandOptionBase, APIApplicationCommandOptionBaseResponse } from './base';
 import type { ApplicationCommandOptionType } from './shared';
 
 export interface APIApplicationCommandSubcommandOption extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.Subcommand> {
 	options?: APIApplicationCommandBasicOption[];
+}
+
+export interface APIApplicationCommandSubcommandOptionResponse extends APIApplicationCommandOptionBaseResponse<ApplicationCommandOptionType.Subcommand> {
+	options?: APIApplicationCommandBasicOptionResponse[];
 }
 
 export interface APIApplicationCommandInteractionDataSubcommandOption<Type extends InteractionType = InteractionType> {

--- a/payloads/v9/_interactions/_applicationCommands/_chatInput/subcommandGroup.ts
+++ b/payloads/v9/_interactions/_applicationCommands/_chatInput/subcommandGroup.ts
@@ -1,13 +1,18 @@
 import type { InteractionType } from '../../responses';
-import type { APIApplicationCommandOptionBase } from './base';
+import type { APIApplicationCommandOptionBase, APIApplicationCommandOptionBaseResponse } from './base';
 import type { ApplicationCommandOptionType } from './shared';
 import type {
 	APIApplicationCommandInteractionDataSubcommandOption,
 	APIApplicationCommandSubcommandOption,
+	APIApplicationCommandSubcommandOptionResponse,
 } from './subcommand';
 
 export interface APIApplicationCommandSubcommandGroupOption extends APIApplicationCommandOptionBase<ApplicationCommandOptionType.SubcommandGroup> {
 	options?: APIApplicationCommandSubcommandOption[];
+}
+
+export interface APIApplicationCommandSubcommandGroupOptionResponse extends APIApplicationCommandOptionBaseResponse<ApplicationCommandOptionType.SubcommandGroup> {
+	options?: APIApplicationCommandSubcommandOptionResponse[];
 }
 
 export interface APIApplicationCommandInteractionDataSubcommandGroupOption<

--- a/payloads/v9/_interactions/_applicationCommands/_chatInput/user.ts
+++ b/payloads/v9/_interactions/_applicationCommands/_chatInput/user.ts
@@ -1,8 +1,15 @@
 import type { Snowflake } from '../../../../../globals';
-import type { APIApplicationCommandOptionBase, APIInteractionDataOptionBase } from './base';
+import type {
+	APIApplicationCommandOptionBase,
+	APIApplicationCommandOptionBaseResponse,
+	APIInteractionDataOptionBase,
+} from './base';
 import type { ApplicationCommandOptionType } from './shared';
 
 export type APIApplicationCommandUserOption = APIApplicationCommandOptionBase<ApplicationCommandOptionType.User>;
+
+export type APIApplicationCommandUserOptionResponse =
+	APIApplicationCommandOptionBaseResponse<ApplicationCommandOptionType.User>;
 
 export type APIApplicationCommandInteractionDataUserOption = APIInteractionDataOptionBase<
 	ApplicationCommandOptionType.User,

--- a/payloads/v9/_interactions/_applicationCommands/chatInput.ts
+++ b/payloads/v9/_interactions/_applicationCommands/chatInput.ts
@@ -3,47 +3,58 @@ import type { APIApplicationCommandInteractionWrapper, ApplicationCommandType } 
 import type { APIDMInteractionWrapper, APIGuildInteractionWrapper } from '../base';
 import type {
 	APIApplicationCommandAttachmentOption,
+	APIApplicationCommandAttachmentOptionResponse,
 	APIApplicationCommandInteractionDataAttachmentOption,
 } from './_chatInput/attachment';
 import type {
 	APIApplicationCommandBooleanOption,
+	APIApplicationCommandBooleanOptionResponse,
 	APIApplicationCommandInteractionDataBooleanOption,
 } from './_chatInput/boolean';
 import type {
 	APIApplicationCommandChannelOption,
+	APIApplicationCommandChannelOptionResponse,
 	APIApplicationCommandInteractionDataChannelOption,
 } from './_chatInput/channel';
 import type {
 	APIApplicationCommandIntegerOption,
+	APIApplicationCommandIntegerOptionResponse,
 	APIApplicationCommandInteractionDataIntegerOption,
 } from './_chatInput/integer';
 import type {
 	APIApplicationCommandInteractionDataMentionableOption,
 	APIApplicationCommandMentionableOption,
+	APIApplicationCommandMentionableOptionResponse,
 } from './_chatInput/mentionable';
 import type {
 	APIApplicationCommandInteractionDataNumberOption,
 	APIApplicationCommandNumberOption,
+	APIApplicationCommandNumberOptionResponse,
 } from './_chatInput/number';
 import type {
 	APIApplicationCommandInteractionDataRoleOption,
 	APIApplicationCommandRoleOption,
+	APIApplicationCommandRoleOptionResponse,
 } from './_chatInput/role';
 import type {
 	APIApplicationCommandInteractionDataStringOption,
 	APIApplicationCommandStringOption,
+	APIApplicationCommandStringOptionResponse,
 } from './_chatInput/string';
 import type {
 	APIApplicationCommandInteractionDataSubcommandOption,
 	APIApplicationCommandSubcommandOption,
+	APIApplicationCommandSubcommandOptionResponse,
 } from './_chatInput/subcommand';
 import type {
 	APIApplicationCommandInteractionDataSubcommandGroupOption,
 	APIApplicationCommandSubcommandGroupOption,
+	APIApplicationCommandSubcommandGroupOptionResponse,
 } from './_chatInput/subcommandGroup';
 import type {
 	APIApplicationCommandInteractionDataUserOption,
 	APIApplicationCommandUserOption,
+	APIApplicationCommandUserOptionResponse,
 } from './_chatInput/user';
 import type { APIBaseApplicationCommandInteractionData } from './internals';
 
@@ -76,12 +87,34 @@ export type APIApplicationCommandBasicOption =
 	| APIApplicationCommandUserOption;
 
 /**
+ * @see {@link https://docs.discord.com/developers/interactions/application-commands#application-command-object-application-command-option-structure}
+ */
+export type APIApplicationCommandBasicOptionResponse =
+	| APIApplicationCommandAttachmentOptionResponse
+	| APIApplicationCommandBooleanOptionResponse
+	| APIApplicationCommandChannelOptionResponse
+	| APIApplicationCommandIntegerOptionResponse
+	| APIApplicationCommandMentionableOptionResponse
+	| APIApplicationCommandNumberOptionResponse
+	| APIApplicationCommandRoleOptionResponse
+	| APIApplicationCommandStringOptionResponse
+	| APIApplicationCommandUserOptionResponse;
+
+/**
  * @see {@link https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure}
  */
 export type APIApplicationCommandOption =
 	| APIApplicationCommandBasicOption
 	| APIApplicationCommandSubcommandGroupOption
 	| APIApplicationCommandSubcommandOption;
+
+/**
+ * @see {@link https://docs.discord.com/developers/interactions/application-commands#application-command-object-application-command-option-structure}
+ */
+export type APIApplicationCommandOptionResponse =
+	| APIApplicationCommandBasicOptionResponse
+	| APIApplicationCommandSubcommandGroupOptionResponse
+	| APIApplicationCommandSubcommandOptionResponse;
 
 /**
  * @see {@link https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-interaction-data-option-structure}

--- a/payloads/v9/_interactions/applicationCommands.ts
+++ b/payloads/v9/_interactions/applicationCommands.ts
@@ -1,7 +1,7 @@
 import type { Permissions, Snowflake } from '../../../globals';
 import type { LocalizationMap } from '../../../v9';
 import type {
-	APIApplicationCommandOption,
+	APIApplicationCommandOptionResponse,
 	APIChatInputApplicationCommandDMInteraction,
 	APIChatInputApplicationCommandGuildInteraction,
 	APIChatInputApplicationCommandInteraction,
@@ -75,7 +75,7 @@ export interface APIApplicationCommand {
 	/**
 	 * The parameters for the `CHAT_INPUT` command, max 25
 	 */
-	options?: APIApplicationCommandOption[];
+	options?: APIApplicationCommandOptionResponse[];
 	/**
 	 * Set of permissions represented as a bitset
 	 */


### PR DESCRIPTION
Through the `X-Discord-Locale` header, a singular localisation property will be returned.[^1]

This was fine for `APIApplicationCommand`'s top-level properties. However, `options` did not have this same treatment. From the API, they also possessed the singular properties.

This pull request extracts the payloads into a base which the API response and the API request uses so going into `options`, the correct properties will be returned.

[^1]: https://docs.discord.com/developers/interactions/application-commands#retrieving-localized-commands